### PR TITLE
[Feature] re-add mesh generics

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -64,7 +64,6 @@ examples/jsm/loaders/ColladaLoader.d.ts
 examples/jsm/loaders/EXRLoader.d.ts
 examples/jsm/loaders/FBXLoader.d.ts
 examples/jsm/loaders/GCodeLoader.d.ts
-examples/jsm/loaders/HDRCubeTextureLoader.d.ts
 examples/jsm/loaders/KMZLoader.d.ts
 examples/jsm/loaders/KTXLoader.d.ts
 examples/jsm/loaders/LDrawLoader.d.ts
@@ -81,7 +80,6 @@ examples/jsm/loaders/PDBLoader.d.ts
 examples/jsm/loaders/PLYLoader.d.ts
 examples/jsm/loaders/PRWMLoader.d.ts
 examples/jsm/loaders/PVRLoader.d.ts
-examples/jsm/loaders/RGBMLoader.d.ts
 examples/jsm/loaders/STLLoader.d.ts
 examples/jsm/loaders/SVGLoader.d.ts
 examples/jsm/loaders/TDSLoader.d.ts

--- a/types/three/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
+++ b/types/three/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
@@ -12,7 +12,7 @@ export class HDRCubeTextureLoader extends Loader {
         onLoad: (texture: CubeTexture) => void,
         onProgress?: (event: ProgressEvent) => void,
         onError?: (event: ErrorEvent) => void,
-    ): void;
+    ): CubeTexture;
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<CubeTexture>;
     setDataType(type: TextureDataType): this;
 }

--- a/types/three/src/objects/InstancedMesh.d.ts
+++ b/types/three/src/objects/InstancedMesh.d.ts
@@ -5,8 +5,11 @@ import { Mesh } from './Mesh';
 import { Matrix4 } from './../math/Matrix4';
 import { Color } from './../math/Color';
 
-export class InstancedMesh extends Mesh {
-    constructor(geometry: BufferGeometry, material: Material | Material[], count: number);
+export class InstancedMesh<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Mesh {
+    constructor(geometry: Geom, material: Mat, count: number);
 
     count: number;
     instanceColor: null | BufferAttribute;

--- a/types/three/src/objects/InstancedMesh.d.ts
+++ b/types/three/src/objects/InstancedMesh.d.ts
@@ -6,10 +6,10 @@ import { Matrix4 } from './../math/Matrix4';
 import { Color } from './../math/Color';
 
 export class InstancedMesh<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
-> extends Mesh {
-    constructor(geometry: Geom, material: Mat, count: number);
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
+> extends Mesh<TGeometry, TMaterial> {
+    constructor(geometry: TGeometry, material: TMaterial, count: number);
 
     count: number;
     instanceColor: null | BufferAttribute;

--- a/types/three/src/objects/Line.d.ts
+++ b/types/three/src/objects/Line.d.ts
@@ -4,11 +4,14 @@ import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Line extends Object3D {
-    constructor(geometry?: BufferGeometry, material?: Material | Material[]);
+export class Line<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Object3D {
+    constructor(geometry?: Geom, material?: Mat);
 
-    geometry: BufferGeometry;
-    material: Material | Material[];
+    geometry: Geom;
+    material: Mat;
 
     type: 'Line' | 'LineLoop' | 'LineSegments' | string;
     readonly isLine: true;

--- a/types/three/src/objects/Line.d.ts
+++ b/types/three/src/objects/Line.d.ts
@@ -5,13 +5,13 @@ import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
 export class Line<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
 > extends Object3D {
-    constructor(geometry?: Geom, material?: Mat);
+    constructor(geometry?: TGeometry, material?: TMaterial);
 
-    geometry: Geom;
-    material: Mat;
+    geometry: TGeometry;
+    material: TMaterial;
 
     type: 'Line' | 'LineLoop' | 'LineSegments' | string;
     readonly isLine: true;

--- a/types/three/src/objects/LineLoop.d.ts
+++ b/types/three/src/objects/LineLoop.d.ts
@@ -3,10 +3,10 @@ import { Material } from './../materials/Material';
 import { BufferGeometry } from '../core/BufferGeometry';
 
 export class LineLoop<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
-> extends Line {
-    constructor(geometry?: Geom, material?: Mat);
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
+> extends Line<TGeometry, TMaterial> {
+    constructor(geometry?: TGeometry, material?: TMaterial);
 
     type: 'LineLoop';
     readonly isLineLoop: true;

--- a/types/three/src/objects/LineLoop.d.ts
+++ b/types/three/src/objects/LineLoop.d.ts
@@ -2,8 +2,11 @@ import { Line } from './Line';
 import { Material } from './../materials/Material';
 import { BufferGeometry } from '../core/BufferGeometry';
 
-export class LineLoop extends Line {
-    constructor(geometry?: BufferGeometry, material?: Material | Material[]);
+export class LineLoop<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Line {
+    constructor(geometry?: Geom, material?: Mat);
 
     type: 'LineLoop';
     readonly isLineLoop: true;

--- a/types/three/src/objects/LineSegments.d.ts
+++ b/types/three/src/objects/LineSegments.d.ts
@@ -12,10 +12,10 @@ export const LineStrip: number;
 export const LinePieces: number;
 
 export class LineSegments<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
-> extends Line {
-    constructor(geometry?: Geom, material?: Mat);
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
+> extends Line<TGeometry, TMaterial> {
+    constructor(geometry?: TGeometry, material?: TMaterial);
 
     /**
      * @default 'LineSegments'

--- a/types/three/src/objects/LineSegments.d.ts
+++ b/types/three/src/objects/LineSegments.d.ts
@@ -11,8 +11,11 @@ export const LineStrip: number;
  */
 export const LinePieces: number;
 
-export class LineSegments extends Line {
-    constructor(geometry?: BufferGeometry, material?: Material | Material[]);
+export class LineSegments<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Line {
+    constructor(geometry?: Geom, material?: Mat);
 
     /**
      * @default 'LineSegments'

--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -5,13 +5,13 @@ import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
 export class Mesh<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
 > extends Object3D {
-    constructor(geometry?: Geom, material?: Mat);
+    constructor(geometry?: TGeometry, material?: TMaterial);
 
-    geometry: Geom;
-    material: Mat;
+    geometry: TGeometry;
+    material: TMaterial;
     morphTargetInfluences?: number[];
     morphTargetDictionary?: { [key: string]: number };
     readonly isMesh: true;

--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -4,11 +4,14 @@ import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Intersection } from '../core/Raycaster';
 
-export class Mesh extends Object3D {
-    constructor(geometry?: BufferGeometry, material?: Material | Material[]);
+export class Mesh<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Object3D {
+    constructor(geometry?: Geom, material?: Mat);
 
-    geometry: BufferGeometry;
-    material: Material | Material[];
+    geometry: Geom;
+    material: Mat;
     morphTargetInfluences?: number[];
     morphTargetDictionary?: { [key: string]: number };
     readonly isMesh: true;

--- a/types/three/src/objects/Points.d.ts
+++ b/types/three/src/objects/Points.d.ts
@@ -8,14 +8,14 @@ import { Intersection } from '../core/Raycaster';
  * A class for displaying points. The points are rendered by the WebGLRenderer using gl.POINTS.
  */
 export class Points<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
 > extends Object3D {
     /**
      * @param geometry An instance of BufferGeometry.
      * @param material An instance of Material (optional).
      */
-    constructor(geometry?: Geom, material?: Mat);
+    constructor(geometry?: TGeometry, material?: TMaterial);
 
     type: 'Points';
     morphTargetInfluences?: number[];
@@ -25,12 +25,12 @@ export class Points<
     /**
      * An instance of BufferGeometry, where each vertex designates the position of a particle in the system.
      */
-    geometry: Geom;
+    geometry: TGeometry;
 
     /**
      * An instance of Material, defining the object's appearance. Default is a PointsMaterial with randomised colour.
      */
-    material: Mat;
+    material: TMaterial;
 
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     updateMorphTargets(): void;

--- a/types/three/src/objects/Points.d.ts
+++ b/types/three/src/objects/Points.d.ts
@@ -7,12 +7,15 @@ import { Intersection } from '../core/Raycaster';
 /**
  * A class for displaying points. The points are rendered by the WebGLRenderer using gl.POINTS.
  */
-export class Points extends Object3D {
+export class Points<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Object3D {
     /**
      * @param geometry An instance of BufferGeometry.
      * @param material An instance of Material (optional).
      */
-    constructor(geometry?: BufferGeometry, material?: Material | Material[]);
+    constructor(geometry?: Geom, material?: Mat);
 
     type: 'Points';
     morphTargetInfluences?: number[];
@@ -22,12 +25,12 @@ export class Points extends Object3D {
     /**
      * An instance of BufferGeometry, where each vertex designates the position of a particle in the system.
      */
-    geometry: BufferGeometry;
+    geometry: Geom;
 
     /**
      * An instance of Material, defining the object's appearance. Default is a PointsMaterial with randomised colour.
      */
-    material: Material | Material[];
+    material: Mat;
 
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     updateMorphTargets(): void;

--- a/types/three/src/objects/SkinnedMesh.d.ts
+++ b/types/three/src/objects/SkinnedMesh.d.ts
@@ -4,8 +4,11 @@ import { Skeleton } from './Skeleton';
 import { Mesh } from './Mesh';
 import { BufferGeometry } from '../core/BufferGeometry';
 
-export class SkinnedMesh extends Mesh {
-    constructor(geometry?: BufferGeometry, material?: Material | Material[], useVertexTexture?: boolean);
+export class SkinnedMesh<
+    Geom extends BufferGeometry = BufferGeometry,
+    Mat extends Material | Material[] = Material
+> extends Mesh {
+    constructor(geometry?: Geom, material?: Mat, useVertexTexture?: boolean);
 
     bindMode: string;
     bindMatrix: Matrix4;

--- a/types/three/src/objects/SkinnedMesh.d.ts
+++ b/types/three/src/objects/SkinnedMesh.d.ts
@@ -5,10 +5,10 @@ import { Mesh } from './Mesh';
 import { BufferGeometry } from '../core/BufferGeometry';
 
 export class SkinnedMesh<
-    Geom extends BufferGeometry = BufferGeometry,
-    Mat extends Material | Material[] = Material
-> extends Mesh {
-    constructor(geometry?: Geom, material?: Mat, useVertexTexture?: boolean);
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[]
+> extends Mesh<TGeometry, TMaterial> {
+    constructor(geometry?: TGeometry, material?: TMaterial, useVertexTexture?: boolean);
 
     bindMode: string;
     bindMatrix: Matrix4;

--- a/types/three/test/lights/lights-spotlight.ts
+++ b/types/three/test/lights/lights-spotlight.ts
@@ -55,7 +55,7 @@ function init() {
 
     const geometry = new THREE.PlaneGeometry(2000, 2000);
 
-    let mesh = new THREE.Mesh(geometry, material);
+    const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(0, -1, 0);
     mesh.rotation.x = -Math.PI * 0.5;
     mesh.receiveShadow = true;
@@ -67,10 +67,10 @@ function init() {
 
     const clyGeometry = new THREE.CylinderGeometry(5, 5, 2, 32, 1, false);
 
-    mesh = new THREE.Mesh(clyGeometry, material);
-    mesh.position.set(0, 5, 0);
-    mesh.castShadow = true;
-    scene.add(mesh);
+    const clyMesh = new THREE.Mesh(clyGeometry, material);
+    clyMesh.position.set(0, 5, 0);
+    clyMesh.castShadow = true;
+    scene.add(clyMesh);
 
     render();
 

--- a/types/three/test/materials/materials-envmaps-hdr.ts
+++ b/types/three/test/materials/materials-envmaps-hdr.ts
@@ -100,7 +100,7 @@ function init() {
     planeMesh.rotation.x = -Math.PI * 0.5;
     scene.add(planeMesh);
 
-    THREE.DefaultLoadingManager.onLoad = function () {
+    THREE.DefaultLoadingManager.onLoad = () => {
         pmremGenerator.dispose();
     };
 
@@ -108,7 +108,7 @@ function init() {
     hdrCubeMap = new HDRCubeTextureLoader()
         .setPath('./textures/cube/pisaHDR/')
         .setDataType(THREE.UnsignedByteType)
-        .load(hdrUrls, function () {
+        .load(hdrUrls, () => {
             hdrCubeRenderTarget = pmremGenerator.fromCubemap(hdrCubeMap);
 
             hdrCubeMap.magFilter = THREE.LinearFilter;
@@ -116,14 +116,14 @@ function init() {
         });
 
     const ldrUrls = ['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png'];
-    ldrCubeMap = new THREE.CubeTextureLoader().setPath('./textures/cube/pisa/').load(ldrUrls, function () {
+    ldrCubeMap = new THREE.CubeTextureLoader().setPath('./textures/cube/pisa/').load(ldrUrls, () => {
         ldrCubeMap.encoding = THREE.sRGBEncoding;
 
         ldrCubeRenderTarget = pmremGenerator.fromCubemap(ldrCubeMap);
     });
 
     const rgbmUrls = ['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png'];
-    rgbmCubeMap = new RGBMLoader().setPath('./textures/cube/pisaRGBM16/').loadCubemap(rgbmUrls, function () {
+    rgbmCubeMap = new RGBMLoader().setPath('./textures/cube/pisaRGBM16/').loadCubemap(rgbmUrls, () => {
         rgbmCubeMap.encoding = THREE.RGBM16Encoding;
 
         rgbmCubeRenderTarget = pmremGenerator.fromCubemap(rgbmCubeMap);
@@ -139,7 +139,6 @@ function init() {
     renderer.setSize(window.innerWidth, window.innerHeight);
     container.appendChild(renderer.domElement);
 
-    //renderer.toneMapping = ReinhardToneMapping;
     renderer.outputEncoding = THREE.sRGBEncoding;
 
     controls = new OrbitControls(camera, renderer.domElement);
@@ -169,7 +168,8 @@ function render() {
     torusMesh.material.roughness = params.roughness;
     torusMesh.material.metalness = params.metalness;
 
-    let renderTarget, cubeMap;
+    let renderTarget;
+    let cubeMap;
 
     switch (params.envMap) {
         case 'Generated':

--- a/types/three/test/materials/materials-envmaps-hdr.ts
+++ b/types/three/test/materials/materials-envmaps-hdr.ts
@@ -1,0 +1,210 @@
+import * as THREE from 'three';
+
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+import { HDRCubeTextureLoader } from 'three/examples/jsm/loaders/HDRCubeTextureLoader';
+import { RGBMLoader } from 'three/examples/jsm/loaders/RGBMLoader';
+
+const params = {
+    envMap: 'HDR',
+    roughness: 0.0,
+    metalness: 0.0,
+    exposure: 1.0,
+    debug: false,
+};
+
+const container = document.createElement('div');
+let camera: THREE.PerspectiveCamera;
+let scene: THREE.Scene;
+let renderer: THREE.WebGLRenderer;
+let controls: OrbitControls;
+let torusMesh: THREE.Mesh<THREE.TorusKnotGeometry, THREE.MeshStandardMaterial>;
+let planeMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+let generatedCubeRenderTarget: THREE.WebGLRenderTarget;
+let ldrCubeRenderTarget: THREE.WebGLRenderTarget;
+let hdrCubeRenderTarget: THREE.WebGLRenderTarget;
+let rgbmCubeRenderTarget: THREE.WebGLRenderTarget;
+let ldrCubeMap: THREE.CubeTexture;
+let hdrCubeMap: THREE.CubeTexture;
+let rgbmCubeMap: THREE.CubeTexture;
+
+init();
+animate();
+
+function getEnvScene() {
+    const envScene = new THREE.Scene();
+
+    const geometry = new THREE.BoxGeometry();
+    geometry.deleteAttribute('uv');
+    const roomMaterial = new THREE.MeshStandardMaterial({ metalness: 0, side: THREE.BackSide });
+    const room = new THREE.Mesh(geometry, roomMaterial);
+    room.scale.setScalar(10);
+    envScene.add(room);
+
+    const mainLight = new THREE.PointLight(0xffffff, 50, 0, 2);
+    envScene.add(mainLight);
+
+    const lightMaterial = new THREE.MeshLambertMaterial({ color: 0x000000, emissive: 0xffffff, emissiveIntensity: 10 });
+
+    const light1 = new THREE.Mesh(geometry, lightMaterial);
+    light1.material.color.setHex(0xff0000);
+    light1.position.set(-5, 2, 0);
+    light1.scale.set(0.1, 1, 1);
+    envScene.add(light1);
+
+    const light2 = new THREE.Mesh(geometry, lightMaterial.clone() as THREE.MeshLambertMaterial);
+    light2.material.color.setHex(0x00ff00);
+    light2.position.set(0, 5, 0);
+    light2.scale.set(1, 0.1, 1);
+    envScene.add(light2);
+
+    const light3 = new THREE.Mesh(geometry, lightMaterial.clone() as THREE.MeshLambertMaterial);
+    light3.material.color.setHex(0x0000ff);
+    light3.position.set(2, 1, 5);
+    light3.scale.set(1.5, 2, 0.1);
+    envScene.add(light3);
+
+    return envScene;
+}
+
+function init() {
+    document.body.appendChild(container);
+
+    camera = new THREE.PerspectiveCamera(40, window.innerWidth / window.innerHeight, 1, 1000);
+    camera.position.set(0, 0, 120);
+
+    scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x000000);
+
+    renderer = new THREE.WebGLRenderer();
+    renderer.physicallyCorrectLights = true;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+
+    //
+
+    let geometry: THREE.TorusKnotBufferGeometry | THREE.PlaneGeometry = new THREE.TorusKnotGeometry(18, 8, 150, 20);
+    // let geometry = new THREE.SphereGeometry( 26, 64, 32 );
+    let material: THREE.MeshStandardMaterial | THREE.MeshBasicMaterial = new THREE.MeshStandardMaterial({
+        color: 0xffffff,
+        metalness: params.metalness,
+        roughness: params.roughness,
+    });
+
+    torusMesh = new THREE.Mesh(geometry, material);
+    scene.add(torusMesh);
+
+    geometry = new THREE.PlaneGeometry(200, 200);
+    material = new THREE.MeshBasicMaterial();
+
+    planeMesh = new THREE.Mesh(geometry, material);
+    planeMesh.position.y = -50;
+    planeMesh.rotation.x = -Math.PI * 0.5;
+    scene.add(planeMesh);
+
+    THREE.DefaultLoadingManager.onLoad = function () {
+        pmremGenerator.dispose();
+    };
+
+    const hdrUrls = ['px.hdr', 'nx.hdr', 'py.hdr', 'ny.hdr', 'pz.hdr', 'nz.hdr'];
+    hdrCubeMap = new HDRCubeTextureLoader()
+        .setPath('./textures/cube/pisaHDR/')
+        .setDataType(THREE.UnsignedByteType)
+        .load(hdrUrls, function () {
+            hdrCubeRenderTarget = pmremGenerator.fromCubemap(hdrCubeMap);
+
+            hdrCubeMap.magFilter = THREE.LinearFilter;
+            hdrCubeMap.needsUpdate = true;
+        });
+
+    const ldrUrls = ['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png'];
+    ldrCubeMap = new THREE.CubeTextureLoader().setPath('./textures/cube/pisa/').load(ldrUrls, function () {
+        ldrCubeMap.encoding = THREE.sRGBEncoding;
+
+        ldrCubeRenderTarget = pmremGenerator.fromCubemap(ldrCubeMap);
+    });
+
+    const rgbmUrls = ['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png'];
+    rgbmCubeMap = new RGBMLoader().setPath('./textures/cube/pisaRGBM16/').loadCubemap(rgbmUrls, function () {
+        rgbmCubeMap.encoding = THREE.RGBM16Encoding;
+
+        rgbmCubeRenderTarget = pmremGenerator.fromCubemap(rgbmCubeMap);
+    });
+
+    const pmremGenerator = new THREE.PMREMGenerator(renderer);
+    pmremGenerator.compileCubemapShader();
+
+    const envScene = getEnvScene();
+    generatedCubeRenderTarget = pmremGenerator.fromScene(envScene, 0.04);
+
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    container.appendChild(renderer.domElement);
+
+    //renderer.toneMapping = ReinhardToneMapping;
+    renderer.outputEncoding = THREE.sRGBEncoding;
+
+    controls = new OrbitControls(camera, renderer.domElement);
+    controls.minDistance = 50;
+    controls.maxDistance = 300;
+
+    window.addEventListener('resize', onWindowResize);
+}
+
+function onWindowResize() {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+
+    renderer.setSize(width, height);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+
+    render();
+}
+
+function render() {
+    torusMesh.material.roughness = params.roughness;
+    torusMesh.material.metalness = params.metalness;
+
+    let renderTarget, cubeMap;
+
+    switch (params.envMap) {
+        case 'Generated':
+            renderTarget = generatedCubeRenderTarget;
+            cubeMap = generatedCubeRenderTarget.texture;
+            break;
+        case 'LDR':
+            renderTarget = ldrCubeRenderTarget;
+            cubeMap = ldrCubeMap;
+            break;
+        case 'HDR':
+            renderTarget = hdrCubeRenderTarget;
+            cubeMap = hdrCubeMap;
+            break;
+        case 'RGBM16':
+            renderTarget = rgbmCubeRenderTarget;
+            cubeMap = rgbmCubeMap;
+            break;
+    }
+
+    const newEnvMap = renderTarget ? renderTarget.texture : null;
+
+    if (newEnvMap && newEnvMap !== torusMesh.material.envMap) {
+        torusMesh.material.envMap = newEnvMap;
+        torusMesh.material.needsUpdate = true;
+
+        planeMesh.material.map = newEnvMap;
+        planeMesh.material.needsUpdate = true;
+    }
+
+    torusMesh.rotation.y += 0.005;
+    planeMesh.visible = params.debug;
+
+    scene.background = cubeMap as THREE.Texture;
+    renderer.toneMappingExposure = params.exposure;
+
+    renderer.render(scene, camera);
+}

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -26,6 +26,7 @@
         "test/lights/lights-pointlights2.ts",
         "test/lights/lights-rectarealight.ts",
         "test/lights/lights-spotlight.ts",
+        "test/materials/materials-envmaps-hdr.ts",
         "test/materials/materials-variations-basic.ts",
         "test/materials/materials-variations-lambert.ts",
         "test/materials/materials-variations-phong.ts",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

resolves #3

### What

<!-- what have you done, if its a bug, whats your solution? -->

Undone the work done in three's commit – https://github.com/mrdoob/three.js/commit/8c4ff573de466cd97d1074c73b7d8e675a0fe1f5 because you end up having to typecast everything when using `react-three-fiber` and the material type was wrong, it would always complain that it could be an array.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
