### PR TITLE
feature (GLTFLoader): Add beforeRoot and afterRoot to GLTFLoaderPlugin

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -78,6 +78,8 @@ export class GLTFParser {
 }
 
 export interface GLTFLoaderPlugin {
+    beforeRoot?: () => Promise<void> | null;
+    afterRoot?: (result: GLTF) => Promise<void> | null;
     loadMesh?: (meshIndex: number) => Promise<Group | Mesh | SkinnedMesh> | null;
     loadBufferView?: (bufferViewIndex: number) => Promise<ArrayBuffer> | null;
     loadMaterial?: (materialIndex: number) => Promise<Material> | null;

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -1,10 +1,14 @@
 import {
     AnimationClip,
+    BufferAttribute,
+    BufferGeometry,
     Camera,
     Group,
+    InterleavedBufferAttribute,
     Loader,
     LoadingManager,
     Mesh,
+    MeshStandardMaterial,
     Object3D,
     Material,
     SkinnedMesh,
@@ -74,7 +78,50 @@ export class GLTFParser {
 
     getDependency: (type: string, index: number) => Promise<any>;
     getDependencies: (type: string) => Promise<any[]>;
+    loadBuffer: (bufferIndex: number) => Promise<ArrayBuffer>;
+    loadBufferView: (bufferViewIndex: number) => Promise<ArrayBuffer>;
+    loadAccessor: (accessorIndex: number) => Promise<BufferAttribute | InterleavedBufferAttribute>;
+    loadTexture: (textureIndex: number) => Promise<Texture>;
+    loadTextureImage: (
+        textureIndex: number,
+        /**
+         * GLTF.Image
+         * See: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/image.schema.json
+         */
+        source: { [key: string]: any },
+        loader: Loader,
+    ) => Promise<Texture>;
+    assignTexture: (
+        materialParams: { [key: string]: any },
+        mapName: string,
+        mapDef: {
+            index: number;
+            texCoord?: number;
+            extensions?: any;
+        },
+    ) => Promise<void>;
     assignFinalMaterial: (object: Mesh) => void;
+    getMaterialType: () => typeof MeshStandardMaterial;
+    loadMaterial: (materialIndex: number) => Promise<Material>;
+    createUniqueName: (originalName: string) => string;
+    loadGeometries: (
+        /**
+         * GLTF.Primitive[]
+         * See: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/mesh.primitive.schema.json
+         */
+        primitives: Array<{ [key: string]: any }>,
+    ) => Promise<BufferGeometry[]>;
+    loadMesh: (meshIndex: number) => Promise<Group | Mesh | SkinnedMesh>;
+    loadCamera: (cameraIndex: number) => Promise<Camera>;
+    loadSkin: (
+        skinIndex: number,
+    ) => Promise<{
+        joints: number[];
+        inverseBindMatrices?: BufferAttribute | InterleavedBufferAttribute;
+    }>;
+    loadAnimation: (animationIndex: number) => Promise<AnimationClip>;
+    loadNode: (nodeIndex: number) => Promise<Object3D>;
+    loadScene: () => Promise<Group>;
 }
 
 export interface GLTFLoaderPlugin {

--- a/types/three/test/examples/loaders/gltfloader-plugin.ts
+++ b/types/three/test/examples/loaders/gltfloader-plugin.ts
@@ -1,0 +1,95 @@
+// An example that uses plugin system in GLTFLoader.
+
+import * as THREE from 'three';
+import { GLTF, GLTFLoader, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader';
+
+// Assuming we are using duck.gltf
+// https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/Duck/glTF-Binary/Duck.glb
+const modelUrl = 'models/duck.gltf';
+
+const container = document.createElement('div');
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+const camera = new THREE.PerspectiveCamera(50, 2, 0.1, 10);
+const scene = new THREE.Scene();
+
+init().then(() => {
+    animate();
+});
+
+class ExamplePlugin implements GLTFLoaderPlugin {
+    parser: GLTFParser;
+
+    constructor(parser: GLTFParser) {
+        this.parser = parser;
+    }
+
+    async beforeRoot(): Promise<void> {
+        console.info('beforeRoot');
+    }
+
+    async afterRoot(result: GLTF): Promise<void> {
+        console.info('afterRoot', result);
+    }
+
+    async loadMesh(meshIndex: number): Promise<THREE.Group | THREE.Mesh | THREE.SkinnedMesh> {
+        console.info('loadMesh', meshIndex);
+        return this.parser.loadMesh(meshIndex);
+    }
+
+    async loadBufferView(bufferViewIndex: number): Promise<ArrayBuffer> {
+        console.info('loadBufferView', bufferViewIndex);
+        return this.parser.loadBufferView(bufferViewIndex);
+    }
+
+    async loadMaterial(materialIndex: number): Promise<THREE.Material> {
+        console.info('loadMaterial', materialIndex);
+        return this.parser.loadMaterial(materialIndex);
+    }
+
+    async loadTexture(textureIndex: number): Promise<THREE.Texture> {
+        console.info('loadTexture', textureIndex);
+        return this.parser.loadTexture(textureIndex);
+    }
+
+    getMaterialType(materialIndex: number): typeof THREE.Material {
+        console.info('getMaterialType', materialIndex);
+        return THREE.MeshStandardMaterial;
+    }
+
+    async extendMaterialParams(materialIndex: number, materialParams: { [key: string]: any }): Promise<void> {
+        console.info('extendMaterialParams', materialIndex, materialParams);
+    }
+
+    async createNodeAttachment(nodeIndex: number): Promise<THREE.Object3D> {
+        console.info('createNodeAttachment', nodeIndex);
+        return new THREE.Object3D();
+    }
+}
+
+async function init(): Promise<void> {
+    document.body.appendChild(container);
+
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(300, 150);
+    renderer.outputEncoding = THREE.sRGBEncoding;
+    container.appendChild(renderer.domElement);
+
+    camera.position.set(0, 0, 5);
+    scene.add(camera);
+
+    const loader = new GLTFLoader();
+    loader.register(parser => new ExamplePlugin(parser));
+    const gltf = await loader.loadAsync(modelUrl);
+    scene.add(gltf.scene);
+
+    const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+    directionalLight.position.set(1, 1, 1).normalize();
+    scene.add(directionalLight);
+}
+
+function animate(): void {
+    requestAnimationFrame(animate);
+
+    renderer.render(scene, camera);
+}

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -18,6 +18,7 @@
         "test/cameras/camera.ts",
         "test/cameras/camera-array.ts",
         "test/cameras/camera-cinematic.ts",
+        "test/examples/loaders/gltfloader-plugin.ts",
         "test/geometries/geometry-cube.ts",
         "test/geometries/geometry-shapes.ts",
         "test/lights/lights-hemisphere.ts",


### PR DESCRIPTION
Related issue: #2 

It's directed to `dev` since it's a change that will be applied in the next release (r126).

### Why

To follow the recent change to the GLTFLoader.

See: https://github.com/mrdoob/three.js/pull/21207

### What

- Add `beforeRoot` and `afterRoot` to the interface `GLTFLoaderPlugin` .
- Add a test `gltfloader-plugin.ts`, an example that uses a user-defined plugin in GLTFLoader.
    - Because of the test, I had to add missing methods of `GLTFParser`.

### Checklist

-   [x] Added myself to contributors table
    - I'm already on there
-   [x] Add a test 
-   [x] Ready to be merged

### Points need review

- I'm not sure I should add those `GLTFParser` methods.
    - Most of them are probably not intended to be used by end developers.
        - I might want to ask about this to contributors of GLTFLoader 🤔 
    - I had to add them because of the test, as I mentioned above.
        - I can do `(parser as any).loadMesh` instead though.
- Are those `{ [key: string]: any }` good enough?
    - They are using the schema of GLTF, I would rather add type definitions of GLTF schema if I have to type them.
- The model of the example is missing.
    - It's working for type checking purpose so I think it's okay to leave it as is
    - The working one written in JS, just in case: https://glitch.com/edit/#!/eight-outstanding-approach
