### PR TITLE
DataTextureLoader.load() should return DataTexture

### DIFF
--- a/types/three/src/loaders/DataTextureLoader.d.ts
+++ b/types/three/src/loaders/DataTextureLoader.d.ts
@@ -10,7 +10,7 @@ export class DataTextureLoader extends Loader {
         onLoad: (dataTexture: DataTexture) => void,
         onProgress?: (event: ProgressEvent) => void,
         onError?: (event: ErrorEvent) => void,
-    ): void;
+    ): DataTexture;
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<DataTexture>;
 }


### PR DESCRIPTION
### Why

Looking [at the source code](https://github.com/mrdoob/three.js/blob/350f0a021943d6fa1d039a7c14c303653daa463f/src/loaders/DataTextureLoader.js#L22-L103), and also [the documentation](https://threejs.org/docs/index.html#api/en/loaders/DataTextureLoader.load), `DataTextureLoader.load()` should return a `DataTexture` instead of `void`.

### What

I simply replaced `:void` with `:DataTexture` in the return type for the `.load()` method.

### Checklist
-   [x] Ready to be merged
