### PR TITLE
Add setPath method to XRHandModelFactory.

### DIFF
--- a/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -9,8 +9,8 @@ export class XRHandModel extends Object3D {
 export class XRHandModelFactory {
     constructor();
     path: string;
-    
-    setPath( path: string ): XRHandModelFactory;
+
+    setPath(path: string): XRHandModelFactory;
 
     createHandModel(
         controller: Group,

--- a/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -9,6 +9,8 @@ export class XRHandModel extends Object3D {
 export class XRHandModelFactory {
     constructor();
     path: string;
+    
+    setPath( path: string ): XRHandModelFactory;
 
     createHandModel(
         controller: Group,


### PR DESCRIPTION
### Why

This pull request is a follow-up to an earlier PR on the three.js repository. XRHandModelFactory is still missing its `setPath` method in its type definitions. This makes TypeScript unhappy and we can't have that 🙃.

### What

Added a missing `setPath` method to XRHandModelFactory.