### PR TITLE
Scene.d.ts: Remove unused import.

### DIFF
--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -5,7 +5,6 @@ import { Color } from '../math/Color';
 import { Texture } from '../textures/Texture';
 import { WebGLRenderer } from '../renderers/WebGLRenderer';
 import { Camera } from '../cameras/Camera';
-import { WebGLRenderTarget } from '../renderers/WebGLRenderTarget';
 
 // Scenes /////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
### Why

`WebGLRenderTarget` is actually not used.

### What

Removing the import of `WebGLRenderTarget`.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
