### PR TITLE
Material.d.ts: Add alphaToCoverage.

### DIFF
--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -15,6 +15,7 @@ import {
 
 export interface MaterialParameters {
     alphaTest?: number;
+    alphaToCoverage?: boolean;
     blendDst?: BlendingDstFactor;
     blendDstAlpha?: number;
     blendEquation?: BlendingEquation;
@@ -67,6 +68,12 @@ export class Material extends EventDispatcher {
      * @default 0
      */
     alphaTest: number;
+    
+    /**
+     * Enables alpha to coverage. Can only be used with MSAA-enabled rendering contexts.
+     * @default false
+     */
+    alphaToCoverage: boolean;
 
     /**
      * Blending destination. It's one of the blending mode constants defined in Three.js. Default is {@link OneMinusSrcAlphaFactor}.

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -68,7 +68,7 @@ export class Material extends EventDispatcher {
      * @default 0
      */
     alphaTest: number;
-    
+
     /**
      * Enables alpha to coverage. Can only be used with MSAA-enabled rendering contexts.
      * @default false


### PR DESCRIPTION
### Why

A new material property was added: https://github.com/mrdoob/three.js/pull/21383

### What

Adding `alphaToCoverage` to `Material`.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
