### PR TITLE
WebGLRenderer: Refactor framebuffer state management.

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -378,14 +378,6 @@ export class WebGLRenderer implements Renderer {
     getActiveMipmapLevel(): number;
 
     /**
-     * Sets the given WebGLFramebuffer. This method can only be used if no render target is set via
-     * {@link WebGLRenderer#setRenderTarget .setRenderTarget}.
-     *
-     * @param value The WebGLFramebuffer.
-     */
-    setFramebuffer(value: WebGLFramebuffer): void;
-
-    /**
      * Returns the current render target. If no render target is set, null is returned.
      */
     getRenderTarget(): RenderTarget | null;

--- a/types/three/src/renderers/webgl/WebGLState.d.ts
+++ b/types/three/src/renderers/webgl/WebGLState.d.ts
@@ -66,6 +66,8 @@ export class WebGLState {
     ): void;
     enable(id: number): void;
     disable(id: number): void;
+    bindFramebuffer(target: number, framebuffer: WebGLFramebuffer | null): void;
+    bindXRFramebuffer(framebuffer: WebGLFramebuffer | null): void;
     useProgram(program: any): boolean;
     setBlending(
         blending: Blending,


### PR DESCRIPTION
### Why

The way framebuffers are managed has been changed, see https://github.com/mrdoob/three.js/pull/21447

### What

- `WebGLRenderer.setFramebuffer()` has been removed.
- `WebGLState.bindFramebuffer()` and `WebGLState.bindXRFramebuffer()` have been added.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged