### PR TITLE
SAOPass: params.saoBlur is a boolean.

### DIFF
--- a/types/three/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SAOPass.d.ts
@@ -28,7 +28,7 @@ export interface SAOPassParams {
     saoScale: number;
     saoKernelRadius: number;
     saoMinResolution: number;
-    saoBlur: number;
+    saoBlur: boolean;
     saoBlurRadius: number;
     saoBlurStdDev: number;
     saoBlurDepthCutoff: number;


### PR DESCRIPTION

### Why

`SAOPassParams.saoBlur` seems to be a boolean according to  https://github.com/mrdoob/three.js/blob/34519f5073c32eca2cf8b571ce03d44a5a80476a/examples/jsm/postprocessing/SAOPass.js#L57
so i suggest that `saoBlur: boolean` instead of `saoBlur: number`.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
Thanks.

