### PR TITLE
feat: Add auto-completion of built-in shader attribute names

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -106,6 +106,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "rinsuki",
+      "name": "rinsuki",
+      "avatar_url": "https://avatars.githubusercontent.com/u/6533808?v=4",
+      "profile": "https://github.com/rinsuki",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="http://sparklinlabs.com/"><img src="https://avatars.githubusercontent.com/u/446986?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Elisée Maurer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=elisee" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/soadzoor"><img src="https://avatars.githubusercontent.com/u/10392261?v=4?s=100" width="100px;" alt=""/><br /><sub><b>soadzoor</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=soadzoor" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/rinsuki"><img src="https://avatars.githubusercontent.com/u/6533808?v=4?s=100" width="100px;" alt=""/><br /><sub><b>rinsuki</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=rinsuki" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -369,3 +369,24 @@ export const StreamCopyUsage: Usage;
 export enum GLSLVersion {}
 export const GLSL1: GLSLVersion;
 export const GLSL3: GLSLVersion;
+
+export type BuiltinShaderAttributeName =
+    | 'position'
+    | 'normal'
+    | 'uv'
+    | 'color'
+    | 'skinIndex'
+    | 'skinWeight'
+    | 'instanceMatrix'
+    | 'morphTarget0'
+    | 'morphTarget1'
+    | 'morphTarget2'
+    | 'morphTarget3'
+    | 'morphTarget4'
+    | 'morphTarget5'
+    | 'morphTarget6'
+    | 'morphTarget7'
+    | 'morphNormal0'
+    | 'morphNormal1'
+    | 'morphNormal2'
+    | 'morphNormal3';

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -6,6 +6,7 @@ import { Vector2 } from './../math/Vector2';
 import { Vector3 } from './../math/Vector3';
 import { EventDispatcher } from './EventDispatcher';
 import { InterleavedBufferAttribute } from './InterleavedBufferAttribute';
+import { BuiltinShaderAttributeName } from '../constants';
 
 /**
  * This is a superefficent class for geometries because it saves all data in buffers.
@@ -91,7 +92,10 @@ export class BufferGeometry extends EventDispatcher {
     getIndex(): BufferAttribute | null;
     setIndex(index: BufferAttribute | number[] | null): BufferGeometry;
 
-    setAttribute(name: string, attribute: BufferAttribute | InterleavedBufferAttribute): BufferGeometry;
+    setAttribute(
+        name: BuiltinShaderAttributeName | (string & {}),
+        attribute: BufferAttribute | InterleavedBufferAttribute,
+    ): BufferGeometry;
     getAttribute(name: string): BufferAttribute | InterleavedBufferAttribute;
     deleteAttribute(name: string): BufferGeometry;
     hasAttribute(name: string): boolean;

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -96,9 +96,9 @@ export class BufferGeometry extends EventDispatcher {
         name: BuiltinShaderAttributeName | (string & {}),
         attribute: BufferAttribute | InterleavedBufferAttribute,
     ): BufferGeometry;
-    getAttribute(name: string): BufferAttribute | InterleavedBufferAttribute;
-    deleteAttribute(name: string): BufferGeometry;
-    hasAttribute(name: string): boolean;
+    getAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferAttribute | InterleavedBufferAttribute;
+    deleteAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferGeometry;
+    hasAttribute(name: BuiltinShaderAttributeName | (string & {})): boolean;
 
     addGroup(start: number, count: number, materialIndex?: number): void;
     clearGroups(): void;

--- a/types/three/test/geometries/buffer-geometry.ts
+++ b/types/three/test/geometries/buffer-geometry.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three';
+
+const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 1, 1000);
+const scene = new THREE.Scene();
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+let mesh: THREE.Mesh;
+
+init();
+animate();
+
+function init() {
+    camera.position.z = 5;
+
+    const geometry = new THREE.BufferGeometry();
+
+    const verticles = new Float32Array([
+        ...[-1.0, -1.0, 1.0], //
+        ...[1.0, -1.0, 1.0], //
+        ...[0.0, 1.0, 1.0], //
+    ]);
+    geometry.setAttribute('position', new THREE.BufferAttribute(verticles, 3));
+    geometry.getAttribute('position');
+    geometry.deleteAttribute('position');
+    geometry.setAttribute('position', new THREE.BufferAttribute(verticles, 3));
+
+    geometry.setAttribute('customAttribute', new THREE.BufferAttribute(new Float32Array([0]), 1));
+    geometry.getAttribute('customAttribute');
+    geometry.deleteAttribute('customAttribute');
+    const material = new THREE.MeshBasicMaterial({ color: 0xffffff, side: THREE.DoubleSide });
+
+    mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    //
+
+    window.addEventListener('resize', onWindowResize);
+}
+
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+
+    mesh.rotation.y += 0.01;
+
+    renderer.render(scene, camera);
+}

--- a/types/three/test/geometries/geometry-buffer.ts
+++ b/types/three/test/geometries/geometry-buffer.ts
@@ -19,13 +19,21 @@ function init() {
         ...[0.0, 1.0, 1.0], //
     ]);
     geometry.setAttribute('position', new THREE.BufferAttribute(verticles, 3));
-    geometry.getAttribute('position');
-    geometry.deleteAttribute('position');
+    const posAtt = geometry.getAttribute('position');
+
+    if (posAtt.name === 'position') {
+        geometry.deleteAttribute('position');
+    }
+
     geometry.setAttribute('position', new THREE.BufferAttribute(verticles, 3));
 
     geometry.setAttribute('customAttribute', new THREE.BufferAttribute(new Float32Array([0]), 1));
-    geometry.getAttribute('customAttribute');
-    geometry.deleteAttribute('customAttribute');
+    const customAtt = geometry.getAttribute('customAttribute');
+
+    if (customAtt.name === 'customAttribute') {
+        geometry.deleteAttribute('customAttribute');
+    }
+
     const material = new THREE.MeshBasicMaterial({ color: 0xffffff, side: THREE.DoubleSide });
 
     mesh = new THREE.Mesh(geometry, material);

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -19,6 +19,7 @@
         "test/cameras/camera-array.ts",
         "test/cameras/camera-cinematic.ts",
         "test/examples/loaders/gltfloader-plugin.ts",
+        "test/geometries/buffer-geometry.ts",
         "test/geometries/geometry-cube.ts",
         "test/geometries/geometry-shapes.ts",
         "test/lights/lights-hemisphere.ts",

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -19,7 +19,7 @@
         "test/cameras/camera-array.ts",
         "test/cameras/camera-cinematic.ts",
         "test/examples/loaders/gltfloader-plugin.ts",
-        "test/geometries/buffer-geometry.ts",
+        "test/geometries/geometry-buffer.ts",
         "test/geometries/geometry-cube.ts",
         "test/geometries/geometry-shapes.ts",
         "test/lights/lights-hemisphere.ts",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

I forgot the attribute name of the built-in shaders every time and wasting 3s~1m each time for remember it. 

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

I added auto-completion to `setAttribute` with String Union. this will save time for everyone (including me) who use this typing little a bit :)

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
