### PR TITLE
Update RectAreaLightHelper.d.ts

### DIFF
--- a/types/three/examples/jsm/helpers/RectAreaLightHelper.d.ts
+++ b/types/three/examples/jsm/helpers/RectAreaLightHelper.d.ts
@@ -6,6 +6,5 @@ export class RectAreaLightHelper extends Line {
     light: RectAreaLight;
     color: Color | string | number | undefined;
 
-    update(): void;
     dispose(): void;
 }


### PR DESCRIPTION
### Why

`RectAreaLightHelper.update()` has been removed with https://github.com/mrdoob/three.js/pull/21016.

### What

This PR removes `update()` from `RectAreaLightHelper.d.ts`.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
