### PR TITLE
Update WebGLRenderer.d.ts

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -197,16 +197,6 @@ export class WebGLRenderer implements Renderer {
      */
     toneMappingExposure: number;
 
-    /**
-     * @default 8
-     */
-    maxMorphTargets: number;
-
-    /**
-     * @default 4
-     */
-    maxMorphNormals: number;
-
     info: WebGLInfo;
 
     shadowMap: WebGLShadowMap;


### PR DESCRIPTION
### Why

`maxMorphTargets` and  `maxMorphNormals` have been removed from the public interface of `WebGLRenderer`, see https://github.com/mrdoob/three.js/pull/21522.

### What

Removes `maxMorphTargets` and  `maxMorphNormals` from `WebGLRenderer.d.ts`.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged