### PR TITLE
Update Audio.d.ts

### DIFF
--- a/types/three/src/audio/Audio.d.ts
+++ b/types/three/src/audio/Audio.d.ts
@@ -72,7 +72,7 @@ export class Audio<NodeType extends AudioNode = GainNode> extends Object3D {
     /**
      * @default []
      */
-    filters: any[];
+    filters: AudioNode[];
 
     getOutput(): NodeType;
     setNodeSource(audioNode: AudioBufferSourceNode): this;
@@ -87,10 +87,10 @@ export class Audio<NodeType extends AudioNode = GainNode> extends Object3D {
     disconnect(): this;
     setDetune(value: number): this;
     getDetune(): number;
-    getFilters(): any[];
-    setFilters(value: any[]): this;
-    getFilter(): any;
-    setFilter(filter: any): this;
+    getFilters(): AudioNode[];
+    setFilters(value: AudioNode[]): this;
+    getFilter(): AudioNode;
+    setFilter(filter: AudioNode): this;
     setPlaybackRate(value: number): this;
     getPlaybackRate(): number;
     getLoop(): boolean;


### PR DESCRIPTION
### Why

The generic `AudioNode` is now used as the type of audio filters, see https://github.com/mrdoob/three.js/pull/21523.

### What

Use `AudioNode` instead of `any` as type for filters.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
