### PR TITLE
Fix clone this types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -115,6 +115,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "efokschaner",
+      "name": "efokschaner",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1409112?v=4",
+      "profile": "https://github.com/efokschaner",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ select the added contribution type.
 ## Committing and Pushing changes
 
 Please make sure to run the tests before you commit your changes. You can do so by running
-`npm test`.
+`npm test three`.
 
 ## Creating a PR
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="http://sparklinlabs.com/"><img src="https://avatars.githubusercontent.com/u/446986?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Elisée Maurer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=elisee" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/soadzoor"><img src="https://avatars.githubusercontent.com/u/10392261?v=4?s=100" width="100px;" alt=""/><br /><sub><b>soadzoor</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=soadzoor" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/rinsuki"><img src="https://avatars.githubusercontent.com/u/6533808?v=4?s=100" width="100px;" alt=""/><br /><sub><b>rinsuki</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=rinsuki" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/efokschaner"><img src="https://avatars.githubusercontent.com/u/1409112?v=4?s=100" width="100px;" alt=""/><br /><sub><b>efokschaner</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=efokschaner" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/deprecated/Geometry.d.ts
+++ b/types/three/examples/jsm/deprecated/Geometry.d.ts
@@ -337,6 +337,6 @@ export class Face3 {
      */
     materialIndex: number;
 
-    clone(): Face3;
+    clone(): this;
     copy(source: Face3): this;
 }

--- a/types/three/examples/jsm/geometries/DecalGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/DecalGeometry.d.ts
@@ -6,5 +6,5 @@ export class DecalGeometry extends BufferGeometry {
 
 export class DecalVertex {
     constructor(position: Vector3, normal: Vector3);
-    clone(): DecalVertex;
+    clone(): this;
 }

--- a/types/three/examples/jsm/geometries/LightningStrike.d.ts
+++ b/types/three/examples/jsm/geometries/LightningStrike.d.ts
@@ -104,5 +104,5 @@ export class LightningStrike {
     update(time: number): void;
 
     copy(source: LightningStrike): LightningStrike;
-    clone(): LightningStrike;
+    clone(): this;
 }

--- a/types/three/examples/jsm/math/OBB.d.ts
+++ b/types/three/examples/jsm/math/OBB.d.ts
@@ -8,7 +8,7 @@ export class OBB {
     constructor(center?: Vector3, halfSize?: Vector3, rotation?: Matrix3);
     set(center: Vector3, halfSize: Vector3, rotation: Matrix3): this;
     copy(obb: OBB): this;
-    clone(): OBB;
+    clone(): this;
     getSize(result: Vector3): Vector3;
     clampPoint(point: Vector3, result: Vector3): Vector3;
     containsPoint(point: Vector3): boolean;

--- a/types/three/examples/jsm/objects/LightningStorm.d.ts
+++ b/types/three/examples/jsm/objects/LightningStorm.d.ts
@@ -28,5 +28,5 @@ export class LightningStorm {
     constructor(stormParams?: StormParams);
     update(time: number): void;
     copy(source: LightningStorm): LightningStorm;
-    clone(): LightningStorm;
+    clone(): this;
 }

--- a/types/three/src/animation/AnimationClip.d.ts
+++ b/types/three/src/animation/AnimationClip.d.ts
@@ -30,7 +30,7 @@ export class AnimationClip {
     trim(): AnimationClip;
     validate(): boolean;
     optimize(): AnimationClip;
-    clone(): AnimationClip;
+    clone(): this;
     toJSON(clip: AnimationClip): any;
 
     static CreateFromMorphTargetSequence(

--- a/types/three/src/animation/KeyframeTrack.d.ts
+++ b/types/three/src/animation/KeyframeTrack.d.ts
@@ -39,7 +39,7 @@ export class KeyframeTrack {
     trim(startTime: number, endTime: number): KeyframeTrack;
     validate(): boolean;
     optimize(): KeyframeTrack;
-    clone(): KeyframeTrack;
+    clone(): this;
 
     static toJSON(track: KeyframeTrack): any;
 }

--- a/types/three/src/core/BufferAttribute.d.ts
+++ b/types/three/src/core/BufferAttribute.d.ts
@@ -47,7 +47,7 @@ export class BufferAttribute {
     onUploadCallback: () => void;
     onUpload(callback: () => void): this;
     setUsage(usage: Usage): this;
-    clone(): BufferAttribute;
+    clone(): this;
     copy(source: BufferAttribute): this;
     copyAt(index1: number, attribute: BufferAttribute, index2: number): this;
     copyArray(array: ArrayLike<number>): this;

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -360,7 +360,7 @@ export class Object3D extends EventDispatcher {
 
     toJSON(meta?: { geometries: any; materials: any; textures: any; images: any }): any;
 
-    clone(recursive?: boolean): Object3D;
+    clone(recursive?: boolean): this;
 
     /**
      *

--- a/types/three/src/extras/core/Curve.d.ts
+++ b/types/three/src/extras/core/Curve.d.ts
@@ -89,7 +89,7 @@ export class Curve<T extends Vector> {
         binormals: Vector3[];
     };
 
-    clone(): Curve<T>;
+    clone(): this;
     copy(source: Curve<T>): this;
     toJSON(): object;
     fromJSON(json: object): this;

--- a/types/three/src/lights/LightShadow.d.ts
+++ b/types/three/src/lights/LightShadow.d.ts
@@ -56,7 +56,7 @@ export class LightShadow {
     needsUpdate: boolean;
 
     copy(source: LightShadow): this;
-    clone(recursive?: boolean): LightShadow;
+    clone(recursive?: boolean): this;
     toJSON(): any;
     getFrustum(): number;
     updateMatrices(light: Light, viewportIndex?: number): void;

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -354,7 +354,7 @@ export class Material extends EventDispatcher {
     /**
      * Return a new material with the same parameters as this material.
      */
-    clone(): Material;
+    clone(): this;
 
     /**
      * Copy the parameters from the passed material into this material.

--- a/types/three/src/math/Box2.d.ts
+++ b/types/three/src/math/Box2.d.ts
@@ -18,7 +18,7 @@ export class Box2 {
     set(min: Vector2, max: Vector2): Box2;
     setFromPoints(points: Vector2[]): Box2;
     setFromCenterAndSize(center: Vector2, size: Vector2): Box2;
-    clone(): Box2;
+    clone(): this;
     copy(box: Box2): this;
     makeEmpty(): Box2;
     isEmpty(): boolean;

--- a/types/three/src/math/Box3.d.ts
+++ b/types/three/src/math/Box3.d.ts
@@ -26,7 +26,7 @@ export class Box3 {
     setFromPoints(points: Vector3[]): this;
     setFromCenterAndSize(center: Vector3, size: Vector3): this;
     setFromObject(object: Object3D): this;
-    clone(): Box3;
+    clone(): this;
     copy(box: Box3): this;
     makeEmpty(): this;
     isEmpty(): boolean;

--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -76,7 +76,7 @@ export class Color {
     /**
      * Clones this color.
      */
-    clone(): Color;
+    clone(): this;
 
     /**
      * Copies given color.

--- a/types/three/src/math/Cylindrical.d.ts
+++ b/types/three/src/math/Cylindrical.d.ts
@@ -18,7 +18,7 @@ export class Cylindrical {
      */
     y: number;
 
-    clone(): Cylindrical;
+    clone(): this;
     copy(other: Cylindrical): this;
     set(radius: number, theta: number, y: number): this;
     setFromVector3(vec3: Vector3): this;

--- a/types/three/src/math/Euler.d.ts
+++ b/types/three/src/math/Euler.d.ts
@@ -29,7 +29,7 @@ export class Euler {
     _onChangeCallback: () => void;
 
     set(x: number, y: number, z: number, order?: string): Euler;
-    clone(): Euler;
+    clone(): this;
     copy(euler: Euler): this;
     setFromRotationMatrix(m: Matrix4, order?: string, update?: boolean): Euler;
     setFromQuaternion(q: Quaternion, order?: string, update?: boolean): Euler;

--- a/types/three/src/math/Frustum.d.ts
+++ b/types/three/src/math/Frustum.d.ts
@@ -18,7 +18,7 @@ export class Frustum {
     planes: Plane[];
 
     set(p0: Plane, p1: Plane, p2: Plane, p3: Plane, p4: Plane, p5: Plane): Frustum;
-    clone(): Frustum;
+    clone(): this;
     copy(frustum: Frustum): this;
     setFromProjectionMatrix(m: Matrix4): this;
     intersectsObject(object: Object3D): boolean;

--- a/types/three/src/math/Line3.d.ts
+++ b/types/three/src/math/Line3.d.ts
@@ -15,7 +15,7 @@ export class Line3 {
     end: Vector3;
 
     set(start?: Vector3, end?: Vector3): Line3;
-    clone(): Line3;
+    clone(): this;
     copy(line: Line3): this;
     getCenter(target: Vector3): Vector3;
     delta(target: Vector3): Vector3;

--- a/types/three/src/math/Matrix3.d.ts
+++ b/types/three/src/math/Matrix3.d.ts
@@ -72,7 +72,7 @@ export class Matrix3 implements Matrix {
         n33: number,
     ): Matrix3;
     identity(): Matrix3;
-    clone(): Matrix3;
+    clone(): this;
     copy(m: Matrix3): this;
     extractBasis(xAxis: Vector3, yAxis: Vector3, zAxis: Vector3): Matrix3;
     setFromMatrix4(m: Matrix4): Matrix3;

--- a/types/three/src/math/Plane.d.ts
+++ b/types/three/src/math/Plane.d.ts
@@ -24,7 +24,7 @@ export class Plane {
     setComponents(x: number, y: number, z: number, w: number): Plane;
     setFromNormalAndCoplanarPoint(normal: Vector3, point: Vector3): Plane;
     setFromCoplanarPoints(a: Vector3, b: Vector3, c: Vector3): Plane;
-    clone(): Plane;
+    clone(): this;
     copy(plane: Plane): this;
     normalize(): Plane;
     negate(): Plane;

--- a/types/three/src/math/Quaternion.d.ts
+++ b/types/three/src/math/Quaternion.d.ts
@@ -49,7 +49,7 @@ export class Quaternion {
     /**
      * Clones this quaternion.
      */
-    clone(): Quaternion;
+    clone(): this;
 
     /**
      * Copies values of q to this quaternion.

--- a/types/three/src/math/Ray.d.ts
+++ b/types/three/src/math/Ray.d.ts
@@ -18,7 +18,7 @@ export class Ray {
     direction: Vector3;
 
     set(origin: Vector3, direction: Vector3): Ray;
-    clone(): Ray;
+    clone(): this;
     copy(ray: Ray): this;
     at(t: number, target: Vector3): Vector3;
     lookAt(v: Vector3): Ray;

--- a/types/three/src/math/Sphere.d.ts
+++ b/types/three/src/math/Sphere.d.ts
@@ -18,7 +18,7 @@ export class Sphere {
 
     set(center: Vector3, radius: number): Sphere;
     setFromPoints(points: Vector3[], optionalCenter?: Vector3): Sphere;
-    clone(): Sphere;
+    clone(): this;
     copy(sphere: Sphere): this;
     isEmpty(): boolean;
     makeEmpty(): this;

--- a/types/three/src/math/Spherical.d.ts
+++ b/types/three/src/math/Spherical.d.ts
@@ -19,7 +19,7 @@ export class Spherical {
     theta: number;
 
     set(radius: number, phi: number, theta: number): this;
-    clone(): Spherical;
+    clone(): this;
     copy(other: Spherical): this;
     makeSafe(): this;
     setFromVector3(v: Vector3): this;

--- a/types/three/src/math/SphericalHarmonics3.d.ts
+++ b/types/three/src/math/SphericalHarmonics3.d.ts
@@ -18,7 +18,7 @@ export class SphericalHarmonics3 {
     lerp(sh: SphericalHarmonics3, alpha: number): SphericalHarmonics3;
     equals(sh: SphericalHarmonics3): boolean;
     copy(sh: SphericalHarmonics3): SphericalHarmonics3;
-    clone(): SphericalHarmonics3;
+    clone(): this;
 
     /**
      * Sets the values of this spherical harmonics from the provided array or array-like.

--- a/types/three/src/math/Triangle.d.ts
+++ b/types/three/src/math/Triangle.d.ts
@@ -23,7 +23,7 @@ export class Triangle {
 
     set(a: Vector3, b: Vector3, c: Vector3): Triangle;
     setFromPointsAndIndices(points: Vector3[], i0: number, i1: number, i2: number): Triangle;
-    clone(): Triangle;
+    clone(): this;
     copy(triangle: Triangle): this;
     getArea(): number;
     getMidpoint(target: Vector3): Vector3;

--- a/types/three/src/math/Vector2.d.ts
+++ b/types/three/src/math/Vector2.d.ts
@@ -185,7 +185,7 @@ export class Vector2 implements Vector {
     /**
      * Returns a new Vector2 instance with the same `x` and `y` values.
      */
-    clone(): Vector2;
+    clone(): this;
 
     /**
      * Copies value of v to this vector.

--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -73,7 +73,7 @@ export class Vector3 implements Vector {
     /**
      * Clones this vector.
      */
-    clone(): Vector3;
+    clone(): this;
 
     /**
      * Copies value of v to this vector.

--- a/types/three/src/math/Vector4.d.ts
+++ b/types/three/src/math/Vector4.d.ts
@@ -74,7 +74,7 @@ export class Vector4 implements Vector {
     /**
      * Clones this vector.
      */
-    clone(): Vector4;
+    clone(): this;
 
     /**
      * Copies value of v to this vector.

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -93,7 +93,7 @@ export class WebGLRenderTarget extends EventDispatcher {
 
     setTexture(texture: Texture): void;
     setSize(width: number, height: number, depth?: number): void;
-    clone(): WebGLRenderTarget;
+    clone(): this;
     copy(source: WebGLRenderTarget): this;
     dispose(): void;
 }

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -164,7 +164,7 @@ export class Texture extends EventDispatcher {
     static DEFAULT_IMAGE: any;
     static DEFAULT_MAPPING: any;
 
-    clone(): Texture;
+    clone(): this;
     copy(source: Texture): this;
     toJSON(meta: any): any;
     dispose(): void;

--- a/types/three/test/materials/materials-envmaps-hdr.ts
+++ b/types/three/test/materials/materials-envmaps-hdr.ts
@@ -51,13 +51,13 @@ function getEnvScene() {
     light1.scale.set(0.1, 1, 1);
     envScene.add(light1);
 
-    const light2 = new THREE.Mesh(geometry, lightMaterial.clone() as THREE.MeshLambertMaterial);
+    const light2 = new THREE.Mesh(geometry, lightMaterial.clone());
     light2.material.color.setHex(0x00ff00);
     light2.position.set(0, 5, 0);
     light2.scale.set(1, 0.1, 1);
     envScene.add(light2);
 
-    const light3 = new THREE.Mesh(geometry, lightMaterial.clone() as THREE.MeshLambertMaterial);
+    const light3 = new THREE.Mesh(geometry, lightMaterial.clone());
     light3.material.color.setHex(0x0000ff);
     light3.position.set(2, 1, 5);
     light3.scale.set(1.5, 2, 0.1);


### PR DESCRIPTION
### Why

Some of three's objects clone themselves via `new this.constructor(...)`. This allows subclasses to be correctly cloned without slicing. By updating the return types to `this`, TypeScript is now aware of this and allows valid code to compile without type assertions.
You can see this in action in the test `types/three/test/materials/materials-envmaps-hdr.ts` where the type assertions are no longer necessary.

### What

Updated the return types to this where appropriate, after auditing the three implementations.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged

I also fixed the test command in contributing.md as the existing instructions did not work out of the box for me.

Thanks in advance!