### PR TITLE
BufferGeometry: Add applyQuaternion().

### DIFF
--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -2,6 +2,7 @@ import { BufferAttribute } from './BufferAttribute';
 import { Box3 } from './../math/Box3';
 import { Sphere } from './../math/Sphere';
 import { Matrix4 } from './../math/Matrix4';
+import { Quaternion } from './../math/Quaternion';
 import { Vector2 } from './../math/Vector2';
 import { Vector3 } from './../math/Vector3';
 import { EventDispatcher } from './EventDispatcher';
@@ -109,6 +110,7 @@ export class BufferGeometry extends EventDispatcher {
      * Bakes matrix transform directly into vertex coordinates.
      */
     applyMatrix4(matrix: Matrix4): BufferGeometry;
+    applyQuaternion(q: Quaternion): BufferGeometry;
 
     rotateX(angle: number): BufferGeometry;
     rotateY(angle: number): BufferGeometry;


### PR DESCRIPTION
### Why

`BufferGeometry.applyQuaternion()` was added with https://github.com/mrdoob/three.js/pull/21835.

### What

The new method is added to the respective type declaration file.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
