### PR TITLE
WebGLMultipleRenderTargets: Add new class.

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -176,6 +176,7 @@ export * from './objects/Group';
 /**
  * Renderers
  */
+export * from './renderers/WebGLMultipleRenderTargets';
 export * from './renderers/WebGLMultisampleRenderTarget';
 export * from './renderers/WebGLCubeRenderTarget';
 export * from './renderers/WebGLRenderTarget';

--- a/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
+++ b/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
@@ -1,0 +1,10 @@
+import { WebGLRenderTarget } from './WebGLRenderTarget';
+import { Texture } from '../textures/Texture';
+
+export class WebGLMultipleRenderTargets extends WebGLRenderTarget {
+    constructor(width: number, height: number, count: number);
+
+    readonly isWebGLMultipleRenderTargets: true;
+
+    texture: Texture[];
+}


### PR DESCRIPTION
### Why

A new type of render target was added with https://github.com/mrdoob/three.js/pull/16390.

### What

Adds type declaration file for `WebGLMultipleRenderTargets`.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged