### PR TITLE
fix: missing `.morphTargets` in MeshDepthMaterial

### DIFF
--- a/types/three/src/materials/MeshDepthMaterial.d.ts
+++ b/types/three/src/materials/MeshDepthMaterial.d.ts
@@ -11,6 +11,7 @@ export interface MeshDepthMaterialParameters extends MaterialParameters {
     displacementBias?: number;
     wireframe?: boolean;
     wireframeLinewidth?: number;
+    morphTargets?: boolean;
 }
 
 export class MeshDepthMaterial extends Material {
@@ -65,6 +66,11 @@ export class MeshDepthMaterial extends Material {
      * @default false
      */
     fog: boolean;
+
+    /**
+     * @default false
+     */
+    morphTargets: boolean;
 
     setValues(parameters: MeshDepthMaterialParameters): void;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

There's a prop `.morphTargets` ( in MeshDepthMaterial.js https://github.com/mrdoob/three.js/blob/master/src/materials/MeshDepthMaterial.js#L32 ) which is missing in MeshDepthMaterial.d.ts 

### What

<!-- what have you done, if its a bug, whats your solution? -->
Add `.morphTargets` declaration.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
Thanks.
