### PR TITLE
MeshPhysicalMaterial: Optional constructor parameters

### DIFF
--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -21,7 +21,7 @@ export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialPara
 }
 
 export class MeshPhysicalMaterial extends MeshStandardMaterial {
-    constructor(parameters: MeshPhysicalMaterialParameters);
+    constructor(parameters?: MeshPhysicalMaterialParameters);
 
     /**
      * @default 'MeshPhysicalMaterial'


### PR DESCRIPTION
Material constructor parameters argument is optional; changing in MeshPhysicalMaterial for consistency with others, eg.:

https://github.com/three-types/three-ts-types/blob/master/types/three/src/materials/MeshStandardMaterial.d.ts#L42