### PR TITLE
Update Water.d.ts

### DIFF
--- a/types/three/examples/jsm/objects/Water.d.ts
+++ b/types/three/examples/jsm/objects/Water.d.ts
@@ -1,4 +1,4 @@
-import { BufferGeometry, ColorRepresentation, Mesh, Side, Texture, Vector3 } from '../../../src/Three';
+import { BufferGeometry, ColorRepresentation, Mesh, ShaderMaterial, Side, Texture, Vector3 } from '../../../src/Three';
 
 export interface WaterOptions {
     textureWidth?: number;
@@ -17,5 +17,6 @@ export interface WaterOptions {
 }
 
 export class Water extends Mesh {
+    material: ShaderMaterial;
     constructor(geometry: BufferGeometry, options: WaterOptions);
 }

--- a/types/three/examples/jsm/objects/Water2.d.ts
+++ b/types/three/examples/jsm/objects/Water2.d.ts
@@ -1,4 +1,4 @@
-import { BufferGeometry, ColorRepresentation, Mesh, Texture, TextureEncoding, Vector2 } from '../../../src/Three';
+import { BufferGeometry, ColorRepresentation, Mesh, ShaderMaterial, Texture, TextureEncoding, Vector2 } from '../../../src/Three';
 
 export interface Water2Options {
     color?: ColorRepresentation;
@@ -17,5 +17,6 @@ export interface Water2Options {
 }
 
 export class Water extends Mesh {
+    material: ShaderMaterial;
     constructor(geometry: BufferGeometry, options: Water2Options);
 }

--- a/types/three/examples/jsm/objects/Water2.d.ts
+++ b/types/three/examples/jsm/objects/Water2.d.ts
@@ -1,4 +1,12 @@
-import { BufferGeometry, ColorRepresentation, Mesh, ShaderMaterial, Texture, TextureEncoding, Vector2 } from '../../../src/Three';
+import {
+    BufferGeometry,
+    ColorRepresentation,
+    Mesh,
+    ShaderMaterial,
+    Texture,
+    TextureEncoding,
+    Vector2,
+} from '../../../src/Three';
 
 export interface Water2Options {
     color?: ColorRepresentation;


### PR DESCRIPTION


### Why

https://github.com/mrdoob/three.js/blob/dev/examples/webgl_shaders_ocean.html

line 111:

```
water.material.uniforms[ 'sunDirection' ].value.copy( sun ).normalize();
```

<br>

line 188:

```
water.material.uniforms[ 'time' ].value += 1.0 / 60.0;
```



<br>

If using typescript...

```
Property 'uniforms' does not exist on type 'Material | Material[]'.
  Property 'uniforms' does not exist on type 'Material'.
```



<br>

<br>

https://github.com/mrdoob/three.js/blob/dev/examples/jsm/objects/Water.js

line 223:

```
const material = new ShaderMaterial( { ...

scope.material = material;
```



<br>

https://github.com/mrdoob/three.js/blob/dev/examples/jsm/objects/Water2.js

line 92:

```
this.material = new ShaderMaterial( { ...
```

