### PR TITLE
feat: add init function to MarchingCubes

### DIFF
--- a/types/three/examples/jsm/objects/MarchingCubes.d.ts
+++ b/types/three/examples/jsm/objects/MarchingCubes.d.ts
@@ -46,6 +46,8 @@ export class MarchingCubes extends ImmediateRenderObject {
     begin(): void;
     end(): void;
 
+    init(resolution: string): void;
+
     addBall(ballx: number, bally: number, ballz: number, strength: number, subtract: number, colors: any): void;
 
     addPlaneX(strength: number, subtract: number): void;


### PR DESCRIPTION
### Why

When working with the MarchingCubes I noticed the init function was missing.

### What

Added the function and ran the test.

### Checklist

-   [x] Ready to be merged
