### PR TITLE
Improve node material typings

### DIFF
--- a/types/three/examples/jsm/nodes/inputs/TextureNode.d.ts
+++ b/types/three/examples/jsm/nodes/inputs/TextureNode.d.ts
@@ -4,12 +4,13 @@ import { InputNode } from '../core/InputNode';
 import { NodeBuilder } from '../core/NodeBuilder';
 import { Node } from '../core/Node';
 import { UVNode } from '../accessors/UVNode';
+import { UVTransformNode } from '../utils/UVTransformNode';
 
 export class TextureNode extends InputNode {
-    constructor(value: Texture, uv?: UVNode, bias?: Node, project?: boolean);
+    constructor(value: Texture, uv?: UVNode | UVTransformNode, bias?: Node, project?: boolean);
 
     value: Texture;
-    uv: UVNode;
+    uv: UVNode | UVTransformNode;
     bias: Node;
     project: boolean;
     nodeType: string;

--- a/types/three/examples/jsm/nodes/utils/JoinNode.d.ts
+++ b/types/three/examples/jsm/nodes/utils/JoinNode.d.ts
@@ -1,4 +1,5 @@
 import { TempNode } from '../core/TempNode';
+import { Node } from '../core/Node';
 
 export class JoinNode extends TempNode {
     constructor(x: Node, y: Node, z?: Node, w?: Node);


### PR DESCRIPTION
- Fix `Node` import in `JoinNode`
- Allow the use of `UVTransformNode` as `uv`for `TextureNode`. It is not obvious from sources that this is possible, but [this three.js example](https://github.com/mrdoob/three.js/blob/master/examples/webgl_materials_nodes.html) showcases it and I tested it myself.