### PR TITLE
Fix type of color parameter of Reflector

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -182,7 +182,6 @@ examples/jsm/objects/Lensflare.d.ts
 examples/jsm/objects/LightningStorm.d.ts
 examples/jsm/objects/LightningStorm.d.ts
 examples/jsm/objects/MarchingCubes.d.ts
-examples/jsm/objects/Reflector.d.ts
 examples/jsm/objects/ReflectorRTT.d.ts
 examples/jsm/objects/Refractor.d.ts
 examples/jsm/objects/ShadowMesh.d.ts

--- a/types/three/examples/jsm/objects/Reflector.d.ts
+++ b/types/three/examples/jsm/objects/Reflector.d.ts
@@ -1,7 +1,7 @@
-import { Mesh, BufferGeometry, Color, TextureEncoding, WebGLRenderTarget } from '../../../src/Three';
+import { Mesh, BufferGeometry, ColorRepresentation, TextureEncoding, WebGLRenderTarget } from '../../../src/Three';
 
 export interface ReflectorOptions {
-    color?: Color;
+    color?: ColorRepresentation;
     textureWidth?: number;
     textureHeight?: number;
     clipBias?: number;

--- a/types/three/examples/jsm/objects/Refractor.d.ts
+++ b/types/three/examples/jsm/objects/Refractor.d.ts
@@ -1,7 +1,7 @@
-import { Mesh, BufferGeometry, Color, TextureEncoding, WebGLRenderTarget } from '../../../src/Three';
+import { Mesh, BufferGeometry, ColorRepresentation, TextureEncoding, WebGLRenderTarget } from '../../../src/Three';
 
 export interface RefractorOptions {
-    color?: Color;
+    color?: ColorRepresentation;
     textureWidth?: number;
     textureHeight?: number;
     clipBias?: number;

--- a/types/three/test/objects/objects-reflector.ts
+++ b/types/three/test/objects/objects-reflector.ts
@@ -1,0 +1,42 @@
+import { Reflector } from 'three/examples/jsm/objects/Reflector';
+import {
+    DirectionalLight,
+    Mesh,
+    MeshStandardMaterial,
+    PerspectiveCamera,
+    PlaneBufferGeometry,
+    Scene,
+    SphereBufferGeometry,
+    sRGBEncoding,
+    WebGLRenderer,
+} from 'three';
+
+const renderer = new WebGLRenderer();
+renderer.outputEncoding = sRGBEncoding;
+
+const camera = new PerspectiveCamera();
+camera.position.set(0.0, 0.0, 5.0);
+
+const scene = new Scene();
+
+const geometry = new PlaneBufferGeometry(10.0, 10.0);
+const mirror = new Reflector(geometry, {
+    color: 0x4f4f4f,
+});
+mirror.position.y = -1.0;
+mirror.rotation.x = -0.5 * Math.PI;
+scene.add(mirror);
+
+const light = new DirectionalLight(0xffffff);
+light.position.set(5.0, 5.0, 5.0);
+scene.add(light);
+
+const sphere = new Mesh(new SphereBufferGeometry(1.0), new MeshStandardMaterial({ color: 0x77ff55 }));
+scene.add(sphere);
+
+function update() {
+    renderer.render(scene, camera);
+
+    requestAnimationFrame(update);
+}
+requestAnimationFrame(update);

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -39,6 +39,7 @@
         "test/loaders/loaders-voxloader.ts",
         "test/loaders/loaders-obj-mtl.ts",
         "test/objects/instanced-mesh.ts",
+        "test/objects/objects-reflector.ts",
         "test/materials/materials-envmaps-hdr.ts",
         "test/materials/materials-texture3d-partialupdate.ts",
         "test/materials/materials-variations-basic.ts",


### PR DESCRIPTION
### Why

Because I could not put `0x7f7f7f` into `color` parameter of `Reflector`

### What

- Change the type of `color` parameter of `Reflector` and `Refractor`
    - `Color` -> `ColorRepresentation`
    - Ref: https://github.com/mrdoob/three.js/blob/master/examples/js/objects/Reflector.js#L10
    - Ref: https://github.com/three-types/three-ts-types/blob/master/types/three/src/math/Color.d.ts#L19
- Also add a test, `objects-reflector.ts`

### Checklist

-   [x] Added myself to contributors table
    - It's already there
-   [x] Ready to be merged
