### PR TITLE
fix: 2nd parameter on WebGLRenderLists.get should be a number

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -223,6 +223,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "schwyzl",
+      "name": "schwyzl",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1556979?v=4",
+      "profile": "https://github.com/schwyzl",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/woo-cie"><img src="https://avatars.githubusercontent.com/u/24642989?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Makoto Yamada</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=woo-cie" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/schwyzl"><img src="https://avatars.githubusercontent.com/u/1556979?v=4?s=100" width="100px;" alt=""/><br /><sub><b>schwyzl</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=schwyzl" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -60,5 +60,5 @@ export class WebGLRenderLists {
     constructor(properties: WebGLProperties);
 
     dispose(): void;
-    get(scene: Scene, camera: Camera): WebGLRenderList;
+    get(scene: Scene, renderCallDepth: number): WebGLRenderList;
 }


### PR DESCRIPTION
The second parameter of WebGLRenderLists.get() should be a number indicating the render call depth.

Three.js source line here:
https://github.com/mrdoob/three.js/blob/68b5f4f0cc279b6b7c61205aeda72b995a3642f5/src/renderers/webgl/WebGLRenderLists.js#L205


### Why

Fixing a blocking bug relating to WebGLRenderLists. The param was updated in three here: https://github.com/mrdoob/three.js/pull/21254

### What

Modified a parameter name and type con the WebGLRenderLists.get() function. It was set as a Camera but it needs to be a number for the current version of three.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
