### PR TITLE
fix: added missing transmissive member to WebGLRenderList

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -223,6 +223,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "schwyzl",
+      "name": "schwyzl",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1556979?v=4",
+      "profile": "https://github.com/schwyzl",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/woo-cie"><img src="https://avatars.githubusercontent.com/u/24642989?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Makoto Yamada</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=woo-cie" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/schwyzl"><img src="https://avatars.githubusercontent.com/u/1556979?v=4?s=100" width="100px;" alt=""/><br /><sub><b>schwyzl</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=schwyzl" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -60,5 +60,5 @@ export class WebGLRenderLists {
     constructor(properties: WebGLProperties);
 
     dispose(): void;
-    get(scene: Scene, camera: Camera): WebGLRenderList;
+    get(scene: Scene, renderCallDepth: number): WebGLRenderList;
 }

--- a/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -35,6 +35,11 @@ export class WebGLRenderList {
      */
     transparent: RenderItem[];
 
+    /**
+     * @default []
+     */
+    transmissive: RenderItem[];
+
     init(): void;
     push(
         object: Object3D,


### PR DESCRIPTION
### Why

This is a fix for a missing member declaration.
Three.js source here: https://github.com/mrdoob/three.js/blob/e62b253081438c030d6af1ee3c3346a89124f277/src/renderers/webgl/WebGLRenderLists.js#L60

### What

Fixed a bug in the WebGLRenderlist declaration. Missing member 'transmissive' is now declared similarly to 'opaque' and 'transparent'.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
