### PR TITLE
Make Raycaster::Intersection, intersectObject generic

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -225,7 +225,7 @@
       ]
     },
     {
-          "login": "woo-cie",
+      "login": "woo-cie",
       "name": "Makoto Yamada",
       "avatar_url": "https://avatars.githubusercontent.com/u/24642989?v=4",
       "profile": "https://github.com/woo-cie",
@@ -238,6 +238,15 @@
       "name": "schwyzl",
       "avatar_url": "https://avatars.githubusercontent.com/u/1556979?v=4",
       "profile": "https://github.com/schwyzl",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "Degubi",
+      "name": "Degubi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13366932?v=4",
+      "profile": "https://github.com/Degubi",
       "contributions": [
         "code"
       ]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://benpigchu.com/"><img src="https://avatars.githubusercontent.com/u/9023067?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ben "Pig" Chu</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=benpigchu" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/woo-cie"><img src="https://avatars.githubusercontent.com/u/24642989?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Makoto Yamada</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=woo-cie" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/schwyzl"><img src="https://avatars.githubusercontent.com/u/1556979?v=4?s=100" width="100px;" alt=""/><br /><sub><b>schwyzl</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=schwyzl" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/Degubi"><img src="https://avatars.githubusercontent.com/u/13366932?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Degubi</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Degubi" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
+++ b/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
@@ -53,9 +53,9 @@ export class OculusHandPointerModel extends Object3D {
 
     public isAttached(): boolean;
 
-    public intersectObject(object: Object3D): Intersection[] | void;
+    public intersectObject(object: Object3D): Array<Intersection<Object3D>> | void;
 
-    public intersectObjects(objects: Object3D[]): Intersection[] | void;
+    public intersectObjects(objects: Object3D[]): Array<Intersection<Object3D>> | void;
 
     public checkIntersections(objects: Object3D[]): void;
 

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -343,7 +343,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
     getWorldScale(target: Vector3): Vector3;
     getWorldDirection(target: Vector3): Vector3;
 
-    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
+    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
 
     traverse(callback: (object: Object3D) => any): void;
 

--- a/types/three/src/core/Raycaster.d.ts
+++ b/types/three/src/core/Raycaster.d.ts
@@ -13,14 +13,14 @@ export interface Face {
     materialIndex: number;
 }
 
-export interface Intersection {
+export interface Intersection<TIntersected extends Object3D> {
     distance: number;
     distanceToRay?: number | undefined;
     point: Vector3;
     index?: number | undefined;
     face?: Face | null | undefined;
     faceIndex?: number | undefined;
-    object: Object3D;
+    object: TIntersected;
     uv?: Vector2 | undefined;
     instanceId?: number | undefined;
 }
@@ -97,7 +97,11 @@ export class Raycaster {
      * @param recursive If true, it also checks all descendants. Otherwise it only checks intersecton with the object. Default is false.
      * @param optionalTarget (optional) target to set the result. Otherwise a new Array is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
      */
-    intersectObject(object: Object3D, recursive?: boolean, optionalTarget?: Intersection[]): Intersection[];
+    intersectObject<TIntersected extends Object3D>(
+        object: Object3D,
+        recursive?: boolean,
+        optionalTarget?: Array<Intersection<TIntersected>>,
+    ): Array<Intersection<TIntersected>>;
 
     /**
      * Checks all intersection between the ray and the objects with or without the descendants.
@@ -107,5 +111,9 @@ export class Raycaster {
      * @param recursive If true, it also checks all descendants of the objects. Otherwise it only checks intersecton with the objects. Default is false.
      * @param optionalTarget (optional) target to set the result. Otherwise a new Array is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
      */
-    intersectObjects(objects: Object3D[], recursive?: boolean, optionalTarget?: Intersection[]): Intersection[];
+    intersectObjects<TIntersected extends Object3D>(
+        objects: Object3D[],
+        recursive?: boolean,
+        optionalTarget?: Array<Intersection<TIntersected>>,
+    ): Array<Intersection<TIntersected>>;
 }

--- a/types/three/src/objects/LOD.d.ts
+++ b/types/three/src/objects/LOD.d.ts
@@ -15,7 +15,7 @@ export class LOD extends Object3D {
     addLevel(object: Object3D, distance?: number): this;
     getCurrentLevel(): number;
     getObjectForDistance(distance: number): Object3D | null;
-    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
+    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
     update(camera: Camera): void;
     toJSON(meta: any): any;
 

--- a/types/three/src/objects/Line.d.ts
+++ b/types/three/src/objects/Line.d.ts
@@ -20,6 +20,6 @@ export class Line<
     morphTargetDictionary?: { [key: string]: number } | undefined;
 
     computeLineDistances(): this;
-    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
+    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
     updateMorphTargets(): void;
 }

--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -18,5 +18,5 @@ export class Mesh<
     type: string;
 
     updateMorphTargets(): void;
-    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
+    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
 }

--- a/types/three/src/objects/Points.d.ts
+++ b/types/three/src/objects/Points.d.ts
@@ -32,6 +32,6 @@ export class Points<
      */
     material: TMaterial;
 
-    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
+    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
     updateMorphTargets(): void;
 }

--- a/types/three/src/objects/Sprite.d.ts
+++ b/types/three/src/objects/Sprite.d.ts
@@ -15,6 +15,6 @@ export class Sprite extends Object3D {
     material: SpriteMaterial;
     center: Vector2;
 
-    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
+    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
     copy(source: this): this;
 }


### PR DESCRIPTION
### Why

In our codebase we use jsdocs everywhere and anywhere we use the intersectObject(s) methods we have to do type casts or ts-ignores.
Example method from our code:

```javascript
/**
 * @param { Mesh<BufferGeometry, MeshStandardMaterial | MeshPhongMaterial>[] } meshesToRaytrace
 * @returns { T | null }
 */
getMeshAtCursor(meshesToRaytrace) {
	const intersects = raycaster.intersectObjects(meshesToRaytrace);

	// @ts-ignore We know this is a Mesh because we pass in meshes for checking in the first place
	return intersects.length > 0 ? intersects[0].object : null;
}
```

Here we pass in Mesh objects, but still get an Object3d back after the intersectObjects call, which is correct, but the type could be more concrete so that we don't need to do a ts-ignore.

### What

- Made Raycaster::Intersection generic
- Made Raycaster::intersectObject and Raycaster::intersectObjects generic
- Update files using Raycaster::Intersection as a return type

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged