### PR TITLE
fix: add null to Material.shadowSide's type

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -225,7 +225,7 @@
       ]
     },
     {
-          "login": "woo-cie",
+      "login": "woo-cie",
       "name": "Makoto Yamada",
       "avatar_url": "https://avatars.githubusercontent.com/u/24642989?v=4",
       "profile": "https://github.com/woo-cie",
@@ -238,6 +238,15 @@
       "name": "schwyzl",
       "avatar_url": "https://avatars.githubusercontent.com/u/1556979?v=4",
       "profile": "https://github.com/schwyzl",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "WCWedin",
+      "name": "Ibby Wedin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/110730?v=4",
+      "profile": "https://github.com/WCWedin",
       "contributions": [
         "code"
       ]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://benpigchu.com/"><img src="https://avatars.githubusercontent.com/u/9023067?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ben "Pig" Chu</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=benpigchu" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/woo-cie"><img src="https://avatars.githubusercontent.com/u/24642989?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Makoto Yamada</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=woo-cie" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/schwyzl"><img src="https://avatars.githubusercontent.com/u/1556979?v=4?s=100" width="100px;" alt=""/><br /><sub><b>schwyzl</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=schwyzl" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/WCWedin"><img src="https://avatars.githubusercontent.com/u/110730?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ibby Wedin</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=WCWedin" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -317,7 +317,7 @@ export class Material extends EventDispatcher {
      * If *null*, the value is opposite that of side, above.
      * @default null
      */
-    shadowSide: Side;
+    shadowSide: Side | null;
 
     /**
      * Defines whether this material is tone mapped according to the renderer's toneMapping setting.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

It is currently not possible to work with `Material.shadowSide`'s default value of null, as property's type does not include `null`.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

This commit changes the type of `Material.shadowSide` from `Side` to `Side | null`.

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
