### PR TITLE
Update MeshPhysicalMaterial.d.ts

### DIFF
--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -81,9 +81,9 @@ export class MeshPhysicalMaterial extends MeshStandardMaterial {
     ior: number;
 
     /**
-     * @default null
+     * @default Color( 0, 0, 0 )
      */
-    sheenTint: Color | null;
+    sheenTint: Color;
 
     /**
      * @default 0
@@ -113,7 +113,7 @@ export class MeshPhysicalMaterial extends MeshStandardMaterial {
     /**
      * @default Color( 1, 1, 1 )
      */
-    attenuationColor: Color;
+    attenuationTint: Color;
 
     /**
      * @default 1.0


### PR DESCRIPTION
Marks `sheenTint` as non-nullable, renames `attenuationColor` -> `attenuationTint`.

https://github.com/mrdoob/three.js/blob/e62b253081438c030d6af1ee3c3346a89124f277/src/materials/MeshPhysicalMaterial.js#L71-L79