### PR TITLE
fix(DirectionalLight): member position is readonly

### DIFF
--- a/types/three/src/lights/DirectionalLight.d.ts
+++ b/types/three/src/lights/DirectionalLight.d.ts
@@ -24,7 +24,7 @@ export class DirectionalLight extends Light {
     /**
      * @default THREE.Object3D.DefaultUp
      */
-    position: Vector3;
+    readonly position: Vector3;
 
     /**
      * Target used for shadow camera orientation.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why


<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
resolves #134 

DirectionalLight derives from Object3d that has a readonly property 'position'.
So this is also the case for DirectionalLight

### What

<!-- what have you done, if its a bug, whats your solution? -->
I changed the property to `readonly`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
