### PR TITLE
r133 - include default Object3D in Intersection generic type

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -259,6 +259,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "dbuck",
+      "name": "dbuck",
+      "avatar_url": "https://avatars.githubusercontent.com/u/983807?v=4",
+      "profile": "https://github.com/dbuck",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/schwyzl"><img src="https://avatars.githubusercontent.com/u/1556979?v=4?s=100" width="100px;" alt=""/><br /><sub><b>schwyzl</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=schwyzl" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/Degubi"><img src="https://avatars.githubusercontent.com/u/13366932?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Degubi</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Degubi" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/WCWedin"><img src="https://avatars.githubusercontent.com/u/110730?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Ibby Wedin</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=WCWedin" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/dbuck"><img src="https://avatars.githubusercontent.com/u/983807?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Dave Buchhofer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=dbuck" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
+++ b/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
@@ -53,9 +53,9 @@ export class OculusHandPointerModel extends Object3D {
 
     public isAttached(): boolean;
 
-    public intersectObject(object: Object3D): Array<Intersection<Object3D>> | void;
+    public intersectObject(object: Object3D): Intersection[] | void;
 
-    public intersectObjects(objects: Object3D[]): Array<Intersection<Object3D>> | void;
+    public intersectObjects(objects: Object3D[]): Intersection[] | void;
 
     public checkIntersections(objects: Object3D[]): void;
 

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -343,7 +343,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
     getWorldScale(target: Vector3): Vector3;
     getWorldDirection(target: Vector3): Vector3;
 
-    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
+    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
 
     traverse(callback: (object: Object3D) => any): void;
 

--- a/types/three/src/core/Raycaster.d.ts
+++ b/types/three/src/core/Raycaster.d.ts
@@ -13,7 +13,7 @@ export interface Face {
     materialIndex: number;
 }
 
-export interface Intersection<TIntersected extends Object3D> {
+export interface Intersection<TIntersected extends Object3D = Object3D> {
     distance: number;
     distanceToRay?: number | undefined;
     point: Vector3;

--- a/types/three/src/objects/LOD.d.ts
+++ b/types/three/src/objects/LOD.d.ts
@@ -15,7 +15,7 @@ export class LOD extends Object3D {
     addLevel(object: Object3D, distance?: number): this;
     getCurrentLevel(): number;
     getObjectForDistance(distance: number): Object3D | null;
-    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
+    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     update(camera: Camera): void;
     toJSON(meta: any): any;
 

--- a/types/three/src/objects/Line.d.ts
+++ b/types/three/src/objects/Line.d.ts
@@ -20,6 +20,6 @@ export class Line<
     morphTargetDictionary?: { [key: string]: number } | undefined;
 
     computeLineDistances(): this;
-    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
+    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     updateMorphTargets(): void;
 }

--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -18,5 +18,5 @@ export class Mesh<
     type: string;
 
     updateMorphTargets(): void;
-    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
+    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
 }

--- a/types/three/src/objects/Points.d.ts
+++ b/types/three/src/objects/Points.d.ts
@@ -32,6 +32,6 @@ export class Points<
      */
     material: TMaterial;
 
-    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
+    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     updateMorphTargets(): void;
 }

--- a/types/three/src/objects/Sprite.d.ts
+++ b/types/three/src/objects/Sprite.d.ts
@@ -15,6 +15,6 @@ export class Sprite extends Object3D {
     material: SpriteMaterial;
     center: Vector2;
 
-    raycast(raycaster: Raycaster, intersects: Array<Intersection<Object3D>>): void;
+    raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     copy(source: this): this;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@
     "@types/node" "^14.14.35"
     fs-extra "^9.1.0"
 
-"@definitelytyped/dtslint-runner@^0.0.89":
+"@definitelytyped/dtslint-runner@*":
   version "0.0.89"
   resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint-runner/-/dtslint-runner-0.0.89.tgz#67e982ee7e330b7eead911342716e83c28b5d118"
   integrity sha512-EI7eDPZT5f4SwfR0OYUMQuFYnF+ZRAjqBTnuNHK5S5k3sgtrOeKci57/EoAGTYUGiJwYl3Zbg3VRXvU1gBLgVw==


### PR DESCRIPTION
### Why
Adding a default type of Object3D to the newly generic Intersection type, and simplifying the Array<Intersection<Object3D>> types back to Intersection[] again.

Reduces churn in client code which may already reference the Intersection type.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
