### PR TITLE
Fix ColorNode imports

### DIFF
--- a/types/three/examples/jsm/nodes/inputs/ColorNode.d.ts
+++ b/types/three/examples/jsm/nodes/inputs/ColorNode.d.ts
@@ -1,4 +1,4 @@
-import { Color } from '../../../../src/Three';
+import { Color, ColorRepresentation } from '../../../../src/Three';
 
 import { InputNode } from '../core/InputNode';
 import { NodeBuilder } from '../core/NodeBuilder';


### PR DESCRIPTION
PR #107 introduced a new `ColorRepresentation` type. It is now used for `ColorNode`. It seams like nobody tested this though, because the import is missing in ColorNode.d.ts and thus compilation fails.