### PR TITLE
fix: Adding CustomToneMapping constant to ToneMapping enum.

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -105,6 +105,7 @@ export const LinearToneMapping: ToneMapping;
 export const ReinhardToneMapping: ToneMapping;
 export const CineonToneMapping: ToneMapping;
 export const ACESFilmicToneMapping: ToneMapping;
+export const CustomToneMapping: ToneMapping;
 
 // Mapping modes
 export enum Mapping {}


### PR DESCRIPTION
### What

The CustomToneMapping mapping constant isn't present in the ToneMapping enum definition, making the value of the constant inaccessible. This pull request adds the value to the enum.

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged