### PR TITLE
Add gltf loader types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -268,6 +268,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "robertlong",
+      "name": "Robert Long",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1753624?v=4",
+      "profile": "https://github.com/robertlong",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -13,6 +13,9 @@ import {
     Material,
     SkinnedMesh,
     Texture,
+    TextureLoader,
+    FileLoader,
+    ImageBitmapLoader,
 } from '../../../src/Three';
 
 import { DRACOLoader } from './DRACOLoader';
@@ -75,6 +78,19 @@ export interface GLTFReference {
 export class GLTFParser {
     json: any;
 
+    options: {
+        path: string;
+        manager: LoadingManager;
+        ktx2Loader: KTX2Loader;
+        meshoptDecoder: /* MeshoptDecoder */ any;
+        crossOrigin: string;
+        requestHeader: { [header: string]: string };
+    };
+
+    fileLoader: FileLoader;
+    textureLoader: TextureLoader | ImageBitmapLoader;
+    plugins: GLTFLoaderPlugin;
+    extensions: { [name: string]: any };
     associations: Map<Object3D | Material | Texture, GLTFReference>;
 
     getDependency: (type: string, index: number) => Promise<any>;
@@ -135,5 +151,6 @@ export interface GLTFLoaderPlugin {
     extendMaterialParams?:
         | ((materialIndex: number, materialParams: { [key: string]: any }) => Promise<any> | null)
         | undefined;
+    createNodeMesh?: ((nodeIndex: number) => Promise<Object3D> | null) | undefined;
     createNodeAttachment?: ((nodeIndex: number) => Promise<Object3D> | null) | undefined;
 }

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -151,6 +151,6 @@ export interface GLTFLoaderPlugin {
     extendMaterialParams?:
         | ((materialIndex: number, materialParams: { [key: string]: any }) => Promise<any> | null)
         | undefined;
-    createNodeMesh?: ((nodeIndex: number) => Promise<Object3D> | null) | undefined;
+    createNodeMesh?: ((nodeIndex: number) => Promise<Group | Mesh | SkinnedMesh> | null) | undefined;
     createNodeAttachment?: ((nodeIndex: number) => Promise<Object3D> | null) | undefined;
 }


### PR DESCRIPTION
### Why

This PR adds types to `GLTFParser` and `GLTFLoaderPlugin` which makes it easier to author new GLTFLoader plugins in typescript.

### What

This PR includes additional type definitions for the [GLTFLoader](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/loaders/GLTFLoader.js) file.

I added types for properties to the `GLTFParser` such as `options` which is useful for accessing the `options.path` variable to determine the base path to use in a plugin. Or the `textureLoader` which is useful when you want to reuse the existing texture loader.

I also added the `createNodeMesh` hook to the `GLTFLoaderPlugin` which is used to create different mesh objects.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
