### PR TITLE
chore: added forceContextRestore method to WebGLRenderer

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -221,6 +221,7 @@ export class WebGLRenderer implements Renderer {
     getContext(): WebGLRenderingContext;
     getContextAttributes(): any;
     forceContextLoss(): void;
+    forceContextRestore(): void;
 
     /**
      * @deprecated Use {@link WebGLCapabilities#getMaxAnisotropy .capabilities.getMaxAnisotropy()} instead.


### PR DESCRIPTION

### Why/What
added forceContextRestore method to WebGLRenderer as per https://github.com/mrdoob/three.js/blob/dev/src/renderers/WebGLRenderer.js


### Checklist

-   [x] Added myself to contributors table
-   [] Ready to be merged

