### PR TITLE
feat: Add ShaderMaterial uniforms typing and autocompletion (+ ShaderPass)

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -286,6 +286,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "Lutymane",
+      "name": "Lutymane",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22231294?v=4",
+      "profile": "https://zeokku.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://xk.io/"><img src="https://avatars.githubusercontent.com/u/1046448?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Max Kaye</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=XertroV" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://zeokku.com/"><img src="https://avatars.githubusercontent.com/u/22231294?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Lutymane</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Lutymane" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
@@ -1,11 +1,16 @@
-import { ShaderMaterial } from '../../../src/Three';
+import { AvoidNullUniforms, ExtractUniforms, ShaderMaterial, TUniforms } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { FullScreenQuad, Pass } from './Pass';
 
-export class ShaderPass extends Pass {
-    constructor(shader: object, textureID?: string);
+export type TShader<Uniforms extends TUniforms> =
+    | ShaderMaterial<Uniforms>
+    | (Required<Pick<ShaderMaterial<Uniforms>, 'fragmentShader'>> &
+          Partial<Pick<ShaderMaterial<Uniforms>, 'vertexShader' | 'uniforms' | 'defines'>>);
+
+export class ShaderPass<T extends {} = TUniforms, Uniforms extends TUniforms = ExtractUniforms<T>> extends Pass {
+    constructor(shader: TShader<Uniforms>, textureID?: string);
     textureID: string;
-    uniforms: { [name: string]: { value: any } };
-    material: ShaderMaterial;
-    fsQuad: object;
+    uniforms: AvoidNullUniforms<Uniforms>;
+    material: ShaderMaterial<Uniforms>;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
@@ -1,14 +1,21 @@
-import { AvoidNullUniforms, ExtractUniforms, ShaderMaterial, TUniforms } from '../../../src/Three';
+import {
+    AvoidNullUniforms,
+    ExtractUniforms,
+    ShaderMaterial,
+    ShaderMaterialParameters,
+    TUniforms,
+} from '../../../src/Three';
 
 import { FullScreenQuad, Pass } from './Pass';
 
-export type TShader<Uniforms extends TUniforms> =
-    | ShaderMaterial<Uniforms>
-    | (Required<Pick<ShaderMaterial<Uniforms>, 'fragmentShader'>> &
-          Partial<Pick<ShaderMaterial<Uniforms>, 'vertexShader' | 'uniforms' | 'defines'>>);
+export type ShaderLike<Uniforms extends TUniforms> = {
+    fragmentShader: ShaderMaterial['fragmentShader'];
+    vertexShader?: ShaderMaterial['vertexShader'];
+    defines?: ShaderMaterial['defines'];
+} & (Exclude<keyof Uniforms, string> extends never ? { uniforms: Uniforms } : { uniforms?: Uniforms });
 
 export class ShaderPass<T extends {} = TUniforms, Uniforms extends TUniforms = ExtractUniforms<T>> extends Pass {
-    constructor(shader: TShader<Uniforms>, textureID?: string);
+    constructor(shader: ShaderLike<Uniforms>, textureID?: string);
     textureID: string;
     uniforms: AvoidNullUniforms<Uniforms>;
     material: ShaderMaterial<Uniforms>;

--- a/types/three/src/materials/RawShaderMaterial.d.ts
+++ b/types/three/src/materials/RawShaderMaterial.d.ts
@@ -1,5 +1,13 @@
-import { ShaderMaterialParameters, ShaderMaterial } from './ShaderMaterial';
+import { ShaderMaterialParameters, ShaderMaterial, TUniforms, ExtractUniforms } from './ShaderMaterial';
 
-export class RawShaderMaterial extends ShaderMaterial {
-    constructor(parameters?: ShaderMaterialParameters);
+export type RawShaderMaterialParameters<Uniforms extends TUniforms> = ShaderMaterialParameters<Uniforms> & {
+    vertexShader: string;
+    fragmentShader: string;
+};
+
+export class RawShaderMaterial<
+    T extends {} = TUniforms,
+    Uniforms extends TUniforms = ExtractUniforms<T>,
+> extends ShaderMaterial<T, Uniforms> {
+    constructor(parameters?: RawShaderMaterialParameters<Uniforms>);
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

To increase quality and speed of development. With autocompletion you won't misspell uniform names and mistype their values.
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Added uniforms typings for ShaderMaterial, RawShaderMaterial and ShaderPass and also overall type improvements. 

The uniform types are automatically inferred when creating an instance from parameters.

![image](https://user-images.githubusercontent.com/22231294/143920733-07837ceb-b61c-4905-895f-2d7d917e1153.png)

Or they can be supplied in generic (useful when just declaring variables) in multiple ways:
```ts
let shaderObject = {
  vertexShader: "",
  fragmentShader: "",
  uniforms: {
    u_one: { value: 1 },
    u_two: { value: null },
  },
};

let s0: ShaderMaterial<typeof shaderObject>;
```

```ts
let r1: RawShaderMaterial<{ u_time: number; u_amp: number }>;

let r2: RawShaderMaterial<{ u_one: { value: number }; u_two: { value: Vector2 } }>;
```

The uniform types will be asserted while creating an instance.

In `ShaderMaterial.d.ts` you can also find a more strict variant for uniforms (which is commented out) for the case when you don't supply types during declaration, meaning uniforms themselves can be undefined (as there's no assertion during instance creation) or when you cast Material to ShaderMaterial which produces a correct type error but due to the fact this practice is used everywhere in legacy code I decided not to keep it and leave it more loosely making it fully backwards compatible.

Also as `null` a separate type it's recommended to type uniforms the following way:
```ts
new ShaderMaterial({
  uniforms: {
    uTexture: { value: null as Texture | null },
  },
  vertexShader: "",
  fragmentShader: "",
});
```
Because if it's simply a `null` it will be replaced by `any` to allow value modification.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
