### PR TITLE
Orbitcontrols add types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -286,6 +286,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "LauferAlex",
+      "name": "Alejandro Laufer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/86115165?v=4",
+      "profile": "https://github.com/LauferAlex",
+      "contributions": [
+        "bug",
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://xk.io/"><img src="https://avatars.githubusercontent.com/u/1046448?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Max Kaye</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=XertroV" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/LauferAlex"><img src="https://avatars.githubusercontent.com/u/86115165?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alejandro Laufer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/issues?q=author%3ALauferAlex" title="Bug reports">🐛</a> <a href="https://github.com/three-types/three-ts-types/commits?author=LauferAlex" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -47,6 +47,10 @@ export class OrbitControls {
     mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
     touches: { ONE: TOUCH; TWO: TOUCH };
 
+    target0: Vector3;
+    position0: Vector3;
+    zoomO: number;
+
     update(): boolean;
 
     listenToKeyEvents(domElement: HTMLElement): void;


### PR DESCRIPTION
### Why
Adding missign types to the OrbitControls example. Problem arrises when the .saveState and reset methods are used and access to the `target0`, `position0` and `zoom0` properties is sought but they are not publicly accesible.
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
Definition added for:

```
target0: Vector3; 
position0: Vector3; 
zoom0: number;
```
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
