### PR TITLE
fix(WebXRManager): setAnimationLoop should accept null like WebGLRenderer

### DIFF
--- a/types/three/src/renderers/webxr/WebXRManager.d.ts
+++ b/types/three/src/renderers/webxr/WebXRManager.d.ts
@@ -25,7 +25,7 @@ export class WebXRManager extends EventDispatcher {
     getSession(): XRSession | null;
     setSession(value: XRSession): Promise<void>;
     getCamera(camera: Camera): Camera;
-    setAnimationLoop(callback: XRFrameRequestCallback): void;
+    setAnimationLoop(callback: XRFrameRequestCallback | null): void;
     getFoveation(): number | undefined;
     setFoveation(foveation: number): void;
     dispose(): void;


### PR DESCRIPTION
### Why

`WebXRManager#setAnimationLoop` is called internally by `WebGLRenderer#setAnimationLoop` to update camera and controller internals with the viewer's pose. Although they are passed the same callback, only WebGLRenderer's signature will accept null for a callback. There, a falsy value will stop the internal animation used to drive the animation loop. WebXRManager will only start/stop when sessions init/end but will respect WebGLRenderer's signature as it is called internally.

### What

I've updated WebXRManager's signature to match.

### Checklist

-   [ ] Added myself to contributors table
-   [x] Ready to be merged
