### PR TITLE
Remove RGBFormat

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -154,7 +154,6 @@ export const UnsignedInt248Type: TextureDataType;
 // Pixel formats
 export enum PixelFormat {}
 export const AlphaFormat: PixelFormat;
-export const RGBFormat: PixelFormat;
 export const RGBAFormat: PixelFormat;
 export const LuminanceFormat: PixelFormat;
 export const LuminanceAlphaFormat: PixelFormat;

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -182,12 +182,6 @@ export class Material extends EventDispatcher {
     fog: boolean;
 
     /**
-     * When this property is set to THREE.RGBFormat, the material is considered to be opaque and alpha values are ignored.
-     * @default THREE.RGBAFormat
-     */
-    format: PixelFormat;
-
-    /**
      * Unique number of this material instance.
      */
     id: number;

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -9,7 +9,7 @@ export class CubeTexture extends Texture {
      * @param [wrapT=THREE.ClampToEdgeWrapping]
      * @param [magFilter=THREE.LinearFilter]
      * @param [minFilter=THREE.LinearMipmapLinearFilter]
-     * @param [format=THREE.RGBFormat]
+     * @param [format=THREE.RGBAFormat]
      * @param [type=THREE.UnsignedByteType]
      * @param [anisotropy=1]
      * @param [encoding=THREE.LinearEncoding]

--- a/types/three/src/textures/VideoTexture.d.ts
+++ b/types/three/src/textures/VideoTexture.d.ts
@@ -9,7 +9,7 @@ export class VideoTexture extends Texture {
      * @param [wrapT=THREE.ClampToEdgeWrapping]
      * @param [magFilter=THREE.LinearFilter]
      * @param [minFilter=THREE.LinearFilter]
-     * @param [format=THREE.RGBFormat]
+     * @param [format=THREE.RGBAFormat]
      * @param [type=THREE.UnsignedByteType]
      * @param [anisotropy=1]
      */

--- a/types/three/test/utils/utils-webgl-portal.ts
+++ b/types/three/test/utils/utils-webgl-portal.ts
@@ -78,7 +78,7 @@ function init() {
     leftPortalTexture = new THREE.WebGLRenderTarget(256, 256, {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
-        format: THREE.RGBFormat,
+        format: THREE.RGBAFormat,
     });
     leftPortal = new THREE.Mesh(planeGeo, new THREE.MeshBasicMaterial({ map: leftPortalTexture.texture }));
     leftPortal.position.x = -30;
@@ -89,7 +89,7 @@ function init() {
     rightPortalTexture = new THREE.WebGLRenderTarget(256, 256, {
         minFilter: THREE.LinearFilter,
         magFilter: THREE.LinearFilter,
-        format: THREE.RGBFormat,
+        format: THREE.RGBAFormat,
     });
     rightPortal = new THREE.Mesh(planeGeo, new THREE.MeshBasicMaterial({ map: rightPortalTexture.texture }));
     rightPortal.position.x = 30;


### PR DESCRIPTION
Contributing to #154 

### Why

To catch up with r137

### What

- Remove `RGBFormat` .

### Related PRs

- Main PR: https://github.com/mrdoob/three.js/pull/23223
- VideoTexture: https://github.com/mrdoob/three.js/pull/23223
- Deletion of `Material.format`: https://github.com/mrdoob/three.js/pull/23166 , https://github.com/mrdoob/three.js/pull/23219
    - It was replaced by `.alphaWrite` . I should also make a PR for this

### Points need review

- [ ] is there any leftover?
    - I searched "RGBFormat" through the project and fixed all of them I believe

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged

### Unrelated

I'm so sorry that you're taking a lot of burden about this project. Let me help you as much as I can
