### PR TITLE
Fix Missing Property in Raycaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   <tr>
     <td align="center"><a href="https://xk.io/"><img src="https://avatars.githubusercontent.com/u/1046448?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Max Kaye</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=XertroV" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/LauferAlex"><img src="https://avatars.githubusercontent.com/u/86115165?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alejandro Laufer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/issues?q=author%3ALauferAlex" title="Bug reports">🐛</a> <a href="https://github.com/three-types/three-ts-types/commits?author=LauferAlex" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.joemo.co.uk"><img src="https://avatars.githubusercontent.com/u/39060404?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Joe Tipping</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Gallahron" title="Code">💻</a></td>
+  </tr>
   </tr>
 </table>
 

--- a/types/three/src/core/Raycaster.d.ts
+++ b/types/three/src/core/Raycaster.d.ts
@@ -22,6 +22,7 @@ export interface Intersection<TIntersected extends Object3D = Object3D> {
     faceIndex?: number | undefined;
     object: TIntersected;
     uv?: Vector2 | undefined;
+    uv2?: Vector2 | undefined;
     instanceId?: number | undefined;
 }
 


### PR DESCRIPTION
Adds uv2 to Intersection interface to more accurately reflect the original documentation.

See: (https://threejs.org/docs/#api/en/core/Raycaster.intersectObject)[https://threejs.org/docs/#api/en/core/Raycaster.intersectObject]
This has been submitted in response to Josh's request in (this PR)[https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58462]

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Was having issues accessing the uv2 property of a raycast intersection.

### What

Added uv2 to core/raycast Intersection interface

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [ ] Added myself to contributors table
-   [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
