### PR TITLE
change (Material): Add a new property .alphaWrite

### DIFF
--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -81,6 +81,11 @@ export class Material extends EventDispatcher {
     alphaToCoverage: boolean;
 
     /**
+     * @default false
+     */
+    alphaWrite: boolean;
+
+    /**
      * Blending destination. It's one of the blending mode constants defined in Three.js. Default is {@link OneMinusSrcAlphaFactor}.
      * @default THREE.OneMinusSrcAlphaFactor
      */


### PR DESCRIPTION
Contributing to #154 

### Why

To catch up with r137

### What

Add a new property `.alphaWrite` to `Material` .

See: https://github.com/mrdoob/three.js/pull/23166

### Points need review

- [ ] Since it's undocumented I could not fill the doc comment properly,,,

### Checklist

-   [x] Added myself to contributors table
-   [x] Ready to be merged
