### PR TITLE
fix: adjust webgl example location and types

### DIFF
--- a/types/three/examples/jsm/WebGL.d.ts
+++ b/types/three/examples/jsm/WebGL.d.ts
@@ -1,7 +1,0 @@
-export namespace WEBGL {
-    function isWebGLAvailable(): boolean;
-    function isWebGL2Available(): boolean;
-    function getWebGLErrorMessage(): HTMLElement;
-    function getWebGL2ErrorMessage(): HTMLElement;
-    function getErrorMessage(version: number): HTMLElement;
-}

--- a/types/three/examples/jsm/capabilities/WebGL.d.ts
+++ b/types/three/examples/jsm/capabilities/WebGL.d.ts
@@ -1,0 +1,7 @@
+export default class WEBGL {
+    static isWebGLAvailable(): boolean;
+    static isWebGL2Available(): boolean;
+    static getWebGLErrorMessage(): HTMLElement;
+    static getWebGL2ErrorMessage(): HTMLElement;
+    static getErrorMessage(version: number): HTMLElement;
+}

--- a/types/three/examples/jsm/capabilities/WebGL.d.ts
+++ b/types/three/examples/jsm/capabilities/WebGL.d.ts
@@ -1,7 +1,9 @@
-export default class WEBGL {
-    static isWebGLAvailable(): boolean;
-    static isWebGL2Available(): boolean;
-    static getWebGLErrorMessage(): HTMLElement;
-    static getWebGL2ErrorMessage(): HTMLElement;
-    static getErrorMessage(version: number): HTMLElement;
+declare namespace WEBGL {
+    function isWebGLAvailable(): boolean;
+    function isWebGL2Available(): boolean;
+    function getWebGLErrorMessage(): HTMLElement;
+    function getWebGL2ErrorMessage(): HTMLElement;
+    function getErrorMessage(version: number): HTMLElement;
 }
+
+export default WEBGL;

--- a/types/three/test/loaders/loaders-voxloader.ts
+++ b/types/three/test/loaders/loaders-voxloader.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { VOXLoader, VOXDataTexture3D } from 'three/examples/jsm/loaders/VOXLoader';
 
-import { WEBGL } from 'three/examples/jsm/WebGL';
+import WEBGL from 'three/examples/jsm/capabilities/WebGL';
 
 if (!WEBGL.isWebGL2Available()) {
     document.body.appendChild(WEBGL.getWebGL2ErrorMessage());

--- a/types/three/test/materials/materials-texture3d-partialupdate.ts
+++ b/types/three/test/materials/materials-texture3d-partialupdate.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { ImprovedNoise } from 'three/examples/jsm/math/ImprovedNoise';
 
-import { WEBGL } from 'three/examples/jsm/WebGL';
+import WEBGL from 'three/examples/jsm/capabilities/WebGL';
 
 if (!WEBGL.isWebGL2Available()) {
     document.body.appendChild(WEBGL.getWebGL2ErrorMessage());

--- a/types/three/test/renderers/renderers-renderTarget-multiple.ts
+++ b/types/three/test/renderers/renderers-renderTarget-multiple.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 
-import { WEBGL } from 'three/examples/jsm/WebGL';
+import WEBGL from 'three/examples/jsm/capabilities/WebGL';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
 let camera: THREE.PerspectiveCamera;

--- a/types/three/test/renderers/renderers-renderTarget-texture2DArray.ts
+++ b/types/three/test/renderers/renderers-renderTarget-texture2DArray.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 
 import { unzipSync } from 'three/examples/jsm/libs/fflate.module.min';
-import { WEBGL } from 'three/examples/jsm/WebGL';
+import WEBGL from 'three/examples/jsm/capabilities/WebGL';
 
 const vertextPostProcessingShader = /* glsl */ `
 	out vec2 vUv;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
`WebGL` example has changed the placement in the r137. https://github.com/mrdoob/three.js/blob/master/examples/jsm/capabilities/WebGL.js

### What

<!-- what have you done, if its a bug, whats your solution? -->
Move the file to the proper path and fix the export according to the code.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
