### PR TITLE
small 'f' for `getKeyframeOrder`

### DIFF
--- a/types/three/src/animation/AnimationUtils.d.ts
+++ b/types/three/src/animation/AnimationUtils.d.ts
@@ -4,7 +4,7 @@ export namespace AnimationUtils {
     function arraySlice(array: any, from: number, to: number): any;
     function convertArray(array: any, type: any, forceClone: boolean): any;
     function isTypedArray(object: any): boolean;
-    function getKeyFrameOrder(times: number[]): number[];
+    function getKeykrameOrder(times: number[]): number[];
     function sortedArray(values: any[], stride: number, order: number[]): any[];
     function flattenJSON(jsonKeys: string[], times: any[], values: any[], valuePropertyName: string): void;
 

--- a/types/three/src/animation/AnimationUtils.d.ts
+++ b/types/three/src/animation/AnimationUtils.d.ts
@@ -4,7 +4,7 @@ export namespace AnimationUtils {
     function arraySlice(array: any, from: number, to: number): any;
     function convertArray(array: any, type: any, forceClone: boolean): any;
     function isTypedArray(object: any): boolean;
-    function getKeykrameOrder(times: number[]): number[];
+    function getKeyframeOrder(times: number[]): number[];
     function sortedArray(values: any[], stride: number, order: number[]): any[];
     function flattenJSON(jsonKeys: string[], times: any[], values: any[], valuePropertyName: string): void;
 


### PR DESCRIPTION

In animation/AnimationUtils.d.ts 

`getKeyFrameOrder` should be `getKeyframeOrder`


-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
