### PR TITLE
Remove RGBM7Encoding and RGBM16Encoding

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -302,8 +302,6 @@ export enum TextureEncoding {}
 export const LinearEncoding: TextureEncoding;
 export const sRGBEncoding: TextureEncoding;
 export const LogLuvEncoding: TextureEncoding;
-export const RGBM7Encoding: TextureEncoding;
-export const RGBM16Encoding: TextureEncoding;
 
 // Depth packing strategies
 export enum DepthPackingStrategies {}

--- a/types/three/test/materials/materials-envmaps-hdr.ts
+++ b/types/three/test/materials/materials-envmaps-hdr.ts
@@ -123,7 +123,8 @@ function init() {
     });
 
     const rgbmUrls = ['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png'];
-    rgbmCubeMap = new RGBMLoader().setMaxRange( 16 )
+    rgbmCubeMap = new RGBMLoader()
+        .setMaxRange(16)
         .setPath('./textures/cube/pisaRGBM16/')
         .loadCubemap(rgbmUrls, () => {
             rgbmCubeRenderTarget = pmremGenerator.fromCubemap(rgbmCubeMap);

--- a/types/three/test/materials/materials-envmaps-hdr.ts
+++ b/types/three/test/materials/materials-envmaps-hdr.ts
@@ -123,11 +123,11 @@ function init() {
     });
 
     const rgbmUrls = ['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png'];
-    rgbmCubeMap = new RGBMLoader().setPath('./textures/cube/pisaRGBM16/').loadCubemap(rgbmUrls, () => {
-        rgbmCubeMap.encoding = THREE.RGBM16Encoding;
-
-        rgbmCubeRenderTarget = pmremGenerator.fromCubemap(rgbmCubeMap);
-    });
+    rgbmCubeMap = new RGBMLoader().setMaxRange( 16 )
+        .setPath('./textures/cube/pisaRGBM16/')
+        .loadCubemap(rgbmUrls, () => {
+            rgbmCubeRenderTarget = pmremGenerator.fromCubemap(rgbmCubeMap);
+        });
 
     const pmremGenerator = new THREE.PMREMGenerator(renderer);
     pmremGenerator.compileCubemapShader();


### PR DESCRIPTION
### Why

To catch up with r136 changes

### What

- Remove `THREE.RGBM7Encoding` and `THREE.RGBM16Encoding` .
- Update a test `materials-envmaps-hdr.ts` .

See: https://github.com/mrdoob/three.js/pull/23046

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
    - It's a `r136` change so it should be directed to `master`
-   [x] Added myself to contributors table
-   [x] Ready to be merged
