### PR TITLE
feature (Texture): Add Source class

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -225,4 +225,5 @@ export * from './textures/CubeTexture';
 export * from './textures/CanvasTexture';
 export * from './textures/DepthTexture';
 export * from './textures/FramebufferTexture';
+export * from './textures/Source';
 export * from './textures/Texture';

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -38,7 +38,8 @@ export class CompressedTexture extends Texture {
         encoding?: TextureEncoding,
     );
 
-    image: { width: number; height: number };
+    get image(): { width: number; height: number };
+    set image(value: { width: number; height: number });
 
     mipmaps: ImageData[];
 

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -31,7 +31,8 @@ export class DataTexture extends Texture {
         encoding?: TextureEncoding,
     );
 
-    image: ImageData;
+    get image(): ImageData;
+    set image(value: ImageData);
 
     /**
      * @default false

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -25,7 +25,8 @@ export class DepthTexture extends Texture {
         anisotropy?: number,
     );
 
-    image: { width: number; height: number };
+    get image(): { width: number; height: number };
+    set image(value: { width: number; height: number });
 
     /**
      * @default false

--- a/types/three/src/textures/Source.d.ts
+++ b/types/three/src/textures/Source.d.ts
@@ -1,0 +1,43 @@
+import { DataTexture } from './DataTexture';
+
+export type SourceData = HTMLImageElement | HTMLCanvasElement | ImageBitmap | (HTMLImageElement | DataTexture)[];
+
+/**
+ * Represents the data source of a texture.
+ */
+export class Source {
+    /**
+     * @param [data] The data definition of a texture. default is **null**.
+     */
+    constructor(data: SourceData);
+
+    /**
+     * The actual data of a texture. The type of this property depends on the texture that uses this instance.
+     */
+    data: SourceData;
+
+    /**
+     * Set this to **true** to trigger a data upload to the GPU next time the source is used.
+     */
+    set needsUpdate(value: boolean);
+
+    /**
+     * [UUID](http://en.wikipedia.org/wiki/Universally_unique_identifier) of this object instance.
+     * This gets automatically assigned, so this shouldn't be edited.
+     */
+    uuid: string;
+
+    /**
+     * This starts at **0** and counts how many times [property:Boolean needsUpdate] is set to **true**.
+     */
+    version: number;
+
+    /**
+     * Convert the data source to three.js [JSON Object/Scene format](https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4).
+     *
+     * @param [meta] optional object containing metadata.
+     */
+    toJSON(meta: any): any;
+
+    readonly isTexture: true;
+}

--- a/types/three/src/textures/Source.d.ts
+++ b/types/three/src/textures/Source.d.ts
@@ -1,6 +1,11 @@
 import { DataTexture } from './DataTexture';
 
-export type SourceData = HTMLImageElement | HTMLCanvasElement | ImageBitmap | (HTMLImageElement | DataTexture)[];
+export type SourceData =
+    | HTMLImageElement
+    | HTMLCanvasElement
+    | ImageBitmap
+    | ImageData
+    | (HTMLImageElement | DataTexture)[];
 
 /**
  * Represents the data source of a texture.

--- a/types/three/src/textures/Source.d.ts
+++ b/types/three/src/textures/Source.d.ts
@@ -1,12 +1,3 @@
-import { DataTexture } from './DataTexture';
-
-export type SourceData =
-    | HTMLImageElement
-    | HTMLCanvasElement
-    | ImageBitmap
-    | ImageData
-    | (HTMLImageElement | DataTexture)[];
-
 /**
  * Represents the data source of a texture.
  */
@@ -14,12 +5,12 @@ export class Source {
     /**
      * @param [data] The data definition of a texture. default is **null**.
      */
-    constructor(data: SourceData);
+    constructor(data: any);
 
     /**
      * The actual data of a texture. The type of this property depends on the texture that uses this instance.
      */
-    data: SourceData;
+    data: any;
 
     /**
      * Set this to **true** to trigger a data upload to the GPU next time the source is used.

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -1,5 +1,6 @@
 import { Vector2 } from './../math/Vector2';
 import { Matrix3 } from './../math/Matrix3';
+import { Source, SourceData } from './Source';
 import { EventDispatcher } from './../core/EventDispatcher';
 import {
     Mapping,
@@ -47,9 +48,30 @@ export class Texture extends EventDispatcher {
     sourceFile: string;
 
     /**
-     * @default THREE.Texture.DEFAULT_IMAGE
+     * The data definition of a texture. A reference to the data source can be shared across textures.
+     * This is often useful in context of spritesheets where multiple textures render the same data but with different texture transformations.
      */
-    image: any; // HTMLImageElement or ImageData or { width: number, height: number } in some children;
+    source: Source;
+
+    /**
+     * An image object, typically created using the {@link TextureLoader.load} method.
+     * This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
+     *
+     * To use video as a texture you need to have a playing HTML5
+     * video element as a source for your texture image and continuously update this texture
+     * as long as video is playing - the {@link VideoTexture} class handles this automatically.
+     */
+    get image(): SourceData | HTMLVideoElement;
+
+    /**
+     * An image object, typically created using the {@link TextureLoader.load} method.
+     * This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
+     *
+     * To use video as a texture you need to have a playing HTML5
+     * video element as a source for your texture image and continuously update this texture
+     * as long as video is playing - the {@link VideoTexture} class handles this automatically.
+     */
+    set image(data: SourceData | HTMLVideoElement);
 
     /**
      * @default []
@@ -168,7 +190,7 @@ export class Texture extends EventDispatcher {
      * @default 0
      */
     version: number;
-    needsUpdate: boolean;
+    set needsUpdate(value: boolean);
     readonly isTexture: true;
 
     onUpdate: () => void;

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -1,6 +1,6 @@
 import { Vector2 } from './../math/Vector2';
 import { Matrix3 } from './../math/Matrix3';
-import { Source, SourceData } from './Source';
+import { Source } from './Source';
 import { EventDispatcher } from './../core/EventDispatcher';
 import {
     Mapping,
@@ -61,7 +61,7 @@ export class Texture extends EventDispatcher {
      * video element as a source for your texture image and continuously update this texture
      * as long as video is playing - the {@link VideoTexture} class handles this automatically.
      */
-    get image(): SourceData | HTMLVideoElement;
+    get image(): any;
 
     /**
      * An image object, typically created using the {@link TextureLoader.load} method.
@@ -71,7 +71,7 @@ export class Texture extends EventDispatcher {
      * video element as a source for your texture image and continuously update this texture
      * as long as video is playing - the {@link VideoTexture} class handles this automatically.
      */
-    set image(data: SourceData | HTMLVideoElement);
+    set image(data: any);
 
     /**
      * @default []

--- a/types/three/test/textures/textures-source.ts
+++ b/types/three/test/textures/textures-source.ts
@@ -1,0 +1,13 @@
+import * as THREE from 'three';
+
+// part of the code is taken from https://github.com/mrdoob/three.js/pull/22846
+
+const imageLoader = new THREE.ImageLoader();
+imageLoader.load('/path/to/image.png', image => {
+    const source = new THREE.Source(image);
+
+    const material = new THREE.MeshBasicMaterial();
+    material.map = new THREE.Texture();
+    material.map.source = source;
+    material.map.offset.x = 0.5;
+});

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -63,6 +63,7 @@
         "test/shadowmap/shadowmap-csm.ts",
         "test/shadowmap/shadowmap-progressive.ts",
         "test/shadowmap/shadowmap-vsm.ts",
+        "test/textures/textures-source.ts",
         "test/utils/utils-webgl-portal.ts",
         "test/utils/utils-webgl-marchingcubes.ts",
         "test/webxr/webxr-ar-lighting.ts",


### PR DESCRIPTION
### Why

To catch up with r138 changes

### What

Added `Source` class that is going to be introduced in r138.

I also added a test code `textures-source.ts` .

See: https://github.com/mrdoob/three.js/pull/22846
See: https://github.com/mrdoob/three.js/pull/23419

### Points need review

- [x] ~~I have very low confidence about the signature of `Source.data` and `Texture.image`~~
    - ~~@Mugen87 would you mind reviewing this?~~
      ~~I don't fully understand how `Source` works with video textures, compressed textures, ...~~
    - I decided to make it `any` for now.
- [x] ~~Is it reasonable to define a type `SourceData` ?~~

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
    - It's a r138 change
-   [x] Added myself to contributors table
-   [ ] Ready to be merged
