### PR TITLE
examples/WebGL checks moved to examples/capabilities/WebGL

### DIFF
--- a/types/three/examples/jsm/capabilities/WebGL.d.ts
+++ b/types/three/examples/jsm/capabilities/WebGL.d.ts
@@ -1,4 +1,4 @@
-export namespace WEBGL {
+export namespace WebGL {
     function isWebGLAvailable(): boolean;
     function isWebGL2Available(): boolean;
     function getWebGLErrorMessage(): HTMLElement;

--- a/types/three/examples/jsm/capabilities/WebGL.d.ts
+++ b/types/three/examples/jsm/capabilities/WebGL.d.ts
@@ -1,7 +1,9 @@
-export namespace WebGL {
+declare namespace WebGL {
     function isWebGLAvailable(): boolean;
     function isWebGL2Available(): boolean;
     function getWebGLErrorMessage(): HTMLElement;
     function getWebGL2ErrorMessage(): HTMLElement;
     function getErrorMessage(version: number): HTMLElement;
 }
+
+export default WebGL;


### PR DESCRIPTION
The webgl capabilities example has moved to examples/capabilities

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged


