### PR TITLE
change: Added Vector3.setFromEuler(); removed Euler.toVector3()

### DIFF
--- a/types/three/src/math/Euler.d.ts
+++ b/types/three/src/math/Euler.d.ts
@@ -38,7 +38,12 @@ export class Euler {
     equals(euler: Euler): boolean;
     fromArray(xyzo: any[]): Euler;
     toArray(array?: number[], offset?: number): number[];
+
+    /**
+     * @deprecated .toVector3() has been removed. Use {@link Vector3.setFromEuler Vector3.setFromEuler()} instead
+     */
     toVector3(optionalResult?: Vector3): Vector3;
+
     _onChange(callback: () => void): this;
 
     static RotationOrders: string[];

--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -253,6 +253,11 @@ export class Vector3 implements Vector {
     setFromMatrix3Column(matrix: Matrix3, index: number): this;
 
     /**
+     * Sets this vector's {@link x}, {@link y} and {@link z} components from the x, y, and z components of the specified {@link Euler Euler Angle}.
+     */
+    setFromEuler(e: Euler): this;
+
+    /**
      * Checks for strict equality of this vector and v.
      */
     equals(v: Vector3): boolean;


### PR DESCRIPTION
### Why

To catch up with r138

### What

See: https://github.com/mrdoob/three.js/pull/23494

- Add `Vector3.setFromEuler`
- Make `Euler.toVector3` deprecated

### Points need review

- [ ] `Euler.toVector3` actually does not fallback to the new `Vector3.setFromEuler` ([code](https://github.com/mrdoob/three.js/pull/23494/files#diff-5b25cb6d07a2d314fa35eb2138d99f2484837dcc079fd06e0cb108e8aa70618aR405-R409)). Is this okay to mark this be deprecated or should I remove the signature instead?

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
