### PR TITLE
change (GLTFLoader): add a new signature GLTFParser.loadImageSource

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -101,15 +101,7 @@ export class GLTFParser {
     loadBufferView: (bufferViewIndex: number) => Promise<ArrayBuffer>;
     loadAccessor: (accessorIndex: number) => Promise<BufferAttribute | InterleavedBufferAttribute>;
     loadTexture: (textureIndex: number) => Promise<Texture>;
-    loadTextureImage: (
-        textureIndex: number,
-        /**
-         * GLTF.Image
-         * See: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/image.schema.json
-         */
-        sourceIndex: number,
-        loader: Loader,
-    ) => Promise<Texture>;
+    loadTextureImage: (textureIndex: number, sourceIndex: number, loader: Loader) => Promise<Texture>;
     loadImageSource: (sourceIndex: number, loader: Loader) => Promise<Texture>;
     assignTexture: (
         materialParams: { [key: string]: any },

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -107,9 +107,10 @@ export class GLTFParser {
          * GLTF.Image
          * See: https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/image.schema.json
          */
-        source: { [key: string]: any },
+        sourceIndex: number,
         loader: Loader,
     ) => Promise<Texture>;
+    loadImageSource: (sourceIndex: number, loader: Loader) => Promise<Texture>;
     assignTexture: (
         materialParams: { [key: string]: any },
         mapName: string,


### PR DESCRIPTION
### Why

To catch up with r138

### What

See: https://github.com/mrdoob/three.js/pull/23420

- Add a new signature `GLTFParser.loadImageSource`
- Change a signature of `GLTFParser.loadTextureImage`
    - 2nd argument, `source: { [key: string]: any }` -> `sourceIndex: number`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
