### PR TITLE
change (WebGLMultipleRenderTargets): Add Options to Constructor

### DIFF
--- a/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
+++ b/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
@@ -1,5 +1,6 @@
 import { EventDispatcher } from '../core/EventDispatcher';
 import { Texture } from '../textures/Texture';
+import { WebGLRenderTargetOptions } from './WebGLRenderTarget';
 
 /**
  * This class originall extended WebGLMultipleRenderTarget
@@ -10,7 +11,13 @@ export class WebGLMultipleRenderTargets extends EventDispatcher {
 
     readonly isWebGLMultipleRenderTargets = true;
 
-    constructor(width: number, height: number, count: number);
+    /**
+     * @param width The width of the render target.
+     * @param height The height of the render target.
+     * @param count The number of render targets.
+     * @param options object that holds texture parameters for an auto-generated target texture and depthBuffer/stencilBuffer booleans. For an explanation of the texture parameters see {@link Texture}.
+     */
+    constructor(width: number, height: number, count: number, options?: WebGLRenderTargetOptions);
 
     setSize(width: number, height: number, depth?: number): this;
     copy(source: WebGLMultipleRenderTargets): this;

--- a/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
+++ b/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
@@ -15,7 +15,8 @@ export class WebGLMultipleRenderTargets extends EventDispatcher {
      * @param width The width of the render target.
      * @param height The height of the render target.
      * @param count The number of render targets.
-     * @param options object that holds texture parameters for an auto-generated target texture and depthBuffer/stencilBuffer booleans. For an explanation of the texture parameters see {@link Texture}.
+     * @param options object that holds texture parameters for an auto-generated target texture and depthBuffer/stencilBuffer booleans.
+     * For an explanation of the texture parameters see {@link Texture}.
      */
     constructor(width: number, height: number, count: number, options?: WebGLRenderTargetOptions);
 


### PR DESCRIPTION
### Why

To catch up with r138

### What

See: https://github.com/mrdoob/three.js/pull/22772

- Add an `options` argument to the constructor of `WebGLMultipleRenderTargets`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
