### PR TITLE
change (Reflector, Refractor): add an option `multisample`

### DIFF
--- a/types/three/examples/jsm/objects/Reflector.d.ts
+++ b/types/three/examples/jsm/objects/Reflector.d.ts
@@ -7,6 +7,7 @@ export interface ReflectorOptions {
     clipBias?: number;
     shader?: object;
     encoding?: TextureEncoding;
+    multisample?: number;
 }
 
 export class Reflector extends Mesh {

--- a/types/three/examples/jsm/objects/Refractor.d.ts
+++ b/types/three/examples/jsm/objects/Refractor.d.ts
@@ -7,6 +7,7 @@ export interface RefractorOptions {
     clipBias?: number;
     shader?: object;
     encoding?: TextureEncoding;
+    multisample?: number;
 }
 
 export class Refractor extends Mesh {


### PR DESCRIPTION
### Why

To catch up with r138

### What

See: https://github.com/mrdoob/three.js/pull/23444

Add `multisample` to the options of `Reflector` and `Refractor` .

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
