### PR TITLE
change (WebGLMultisampleRenderTarget): make it deprecated

### DIFF
--- a/types/three/src/renderers/WebGLMultisampleRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLMultisampleRenderTarget.d.ts
@@ -1,13 +1,6 @@
-import { WebGLRenderTarget, WebGLRenderTargetOptions } from './WebGLRenderTarget';
+import { WebGLRenderTarget } from './WebGLRenderTarget';
 
-export class WebGLMultisampleRenderTarget extends WebGLRenderTarget {
-    constructor(width: number, height: number, options?: WebGLRenderTargetOptions);
-
-    readonly isWebGLMultisampleRenderTarget: true;
-
-    /**
-     * Specifies the number of samples to be used for the renderbuffer storage.However, the maximum supported size for multisampling is platform dependent and defined via gl.MAX_SAMPLES.
-     * @default 4
-     */
-    samples: number;
-}
+/**
+ * @deprecated THREE.WebGLMultisampleRenderTarget has been removed. Use a normal {@link WebGLRenderTarget render target} and set the "samples" property to greater 0 to enable multisampling.
+ */
+export class WebGLMultisampleRenderTarget extends WebGLRenderTarget {}

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -49,6 +49,13 @@ export class WebGLRenderTarget extends EventDispatcher {
      * @default null
      */
     depthTexture: DepthTexture;
+
+    /**
+     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
+     * @default 0
+     */
+    samples: number;
+
     readonly isWebGLRenderTarget: true;
 
     /**


### PR DESCRIPTION
### Why

To catch up with r138

### What

See: https://github.com/mrdoob/three.js/pull/23455

- Add `.samples` to `WebGLRenderTarget` .
- Mark `WebGLMultisampleRenderTarget` as deprecated.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
