### PR TITLE
Update GLTFExporter / GLTFLoader signatures

### DIFF
--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -1,4 +1,4 @@
-import { Object3D, AnimationClip } from '../../../src/Three';
+import { Object3D, AnimationClip, Texture, Material, Mesh } from '../../../src/Three';
 
 export interface GLTFExporterOptions {
     /**
@@ -50,6 +50,9 @@ export interface GLTFExporterOptions {
 export class GLTFExporter {
     constructor();
 
+    register(callback: (writer: GLTFWriter) => GLTFExporterPlugin): this;
+    unregister(callback: (writer: GLTFWriter) => GLTFExporterPlugin): this;
+
     /**
      * Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects)
      *
@@ -92,4 +95,32 @@ export class GLTFExporter {
         input: Object3D | Object3D[],
         options?: GLTFExporterOptions,
     ): Promise<ArrayBuffer | { [key: string]: any }>;
+}
+
+export class GLTFWriter {
+    constructor();
+
+    setPlugins(plugins: GLTFExporterPlugin[]);
+
+    /**
+     * Parse scenes and generate GLTF output
+     *
+     * @param input Scene or Array of THREE.Scenes
+     * @param onDone Callback on completed
+     * @param options options
+     */
+    write(
+        input: Object3D | Object3D[],
+        onDone: (gltf: ArrayBuffer | { [key: string]: any }) => void,
+        options?: GLTFExporterOptions,
+    ): Promise<void>;
+}
+
+export interface GLTFExporterPlugin {
+    writeTexture?: (map: Texture, textureDef: { [key: string]: any }) => void;
+    writeMaterial?: (material: Material, materialDef: { [key: string]: any }) => void;
+    writeMesh?: (mesh: Mesh, meshDef: { [key: string]: any }) => void;
+    writeNode?: (object: Object3D, nodeDef: { [key: string]: any }) => void;
+    beforeParse?: (input: Object3D | Object3D[]) => void;
+    afterParse?: (input: Object3D | Object3D[]) => void;
 }

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -82,15 +82,6 @@ export class GLTFExporter {
         options?: GLTFExporterOptions,
     ): void;
 
-    /**
-     * @deprecated parse() expects options as the fourth argument now.
-     */
-    parse(
-        input: Object3D | Object3D[],
-        onDone: (gltf: { [key: string]: any }) => void,
-        options?: GLTFExporterOptions,
-    ): void;
-
     parseAsync(
         input: Object3D | Object3D[],
         options?: GLTFExporterOptions,

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -1,20 +1,95 @@
 import { Object3D, AnimationClip } from '../../../src/Three';
 
 export interface GLTFExporterOptions {
-    binary?: boolean;
+    /**
+     * Export position, rotation and scale instead of matrix per node. Default is false
+     */
     trs?: boolean;
+
+    /**
+     * Export only visible objects. Default is true.
+     */
     onlyVisible?: boolean;
+
+    /**
+     * Export just the attributes within the drawRange, if defined, instead of exporting the whole array. Default is true.
+     */
     truncateDrawRange?: boolean;
+
+    /**
+     * Export in binary (.glb) format, returning an ArrayBuffer. Default is false.
+     */
+    binary?: boolean;
+
+    /**
+     * Export with images embedded into the glTF asset. Default is true.
+     */
     embedImages?: boolean;
+
+    /**
+     * Restricts the image maximum size (both width and height) to the given value. This option works only if embedImages is true. Default is Infinity.
+     */
+    maxTextureSize?: number;
+
+    /**
+     * List of animations to be included in the export.
+     */
     animations?: AnimationClip[];
+
+    /**
+     * Generate indices for non-index geometry and export with them. Default is false.
+     */
     forceIndices?: boolean;
-    forcePowerOfTwoTextures?: boolean;
+
+    /**
+     * Export custom glTF extensions defined on an object's userData.gltfExtensions property. Default is false.
+     */
     includeCustomExtensions?: boolean;
 }
 
 export class GLTFExporter {
     constructor();
 
-    parse(input: Object3D, onCompleted: (gltf: object) => void, options: GLTFExporterOptions): void;
-    parseAsync(input: Object3D, options: GLTFExporterOptions): Promise<void>;
+    /**
+     * Generates a .gltf (JSON) or .glb (binary) output from the input (Scenes or Objects)
+     *
+     * @param input Scenes or objects to export. Valid options:
+     * - Export scenes
+     *   ```js
+     *   exporter.parse( scene1, ... )
+     *   exporter.parse( [ scene1, scene2 ], ... )
+     *   ```
+     * - Export objects (It will create a new Scene to hold all the objects)
+     *   ```js
+     *   exporter.parse( object1, ... )
+     *   exporter.parse( [ object1, object2 ], ... )
+     *   ```
+     * - Mix scenes and objects (It will export the scenes as usual but it will create a new scene to hold all the single objects).
+     *   ```js
+     *   exporter.parse( [ scene1, object1, object2, scene2 ], ... )
+     *   ```
+     * @param onDone Will be called when the export completes. The argument will be the generated glTF JSON or binary ArrayBuffer.
+     * @param onError Will be called if there are any errors during the gltf generation.
+     * @param options Export options
+     */
+    parse(
+        input: Object3D | Object3D[],
+        onDone: (gltf: ArrayBuffer | { [key: string]: any }) => void,
+        onError: (error: ErrorEvent) => void,
+        options?: GLTFExporterOptions,
+    ): void;
+
+    /**
+     * @deprecated parse() expects options as the fourth argument now.
+     */
+    parse(
+        input: Object3D | Object3D[],
+        onDone: (gltf: { [key: string]: any }) => void,
+        options?: GLTFExporterOptions,
+    ): void;
+
+    parseAsync(
+        input: Object3D | Object3D[],
+        options?: GLTFExporterOptions,
+    ): Promise<ArrayBuffer | { [key: string]: any }>;
 }

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -91,9 +91,14 @@ export class GLTFParser {
 
     fileLoader: FileLoader;
     textureLoader: TextureLoader | ImageBitmapLoader;
-    plugins: GLTFLoaderPlugin;
+    plugins: { [name: string]: GLTFLoaderPlugin };
     extensions: { [name: string]: any };
     associations: Map<Object3D | Material | Texture, GLTFReference>;
+
+    setExtensions(extensions: { [name: string]: any }): void;
+    setPlugins(plugins: { [name: string]: GLTFLoaderPlugin }): void;
+
+    parse(onLoad: (gltf: GLTF) => void, onError?: (event: ErrorEvent) => void): void;
 
     getDependency: (type: string, index: number) => Promise<any>;
     getDependencies: (type: string) => Promise<any[]>;


### PR DESCRIPTION
Will resolve #170

### Why

To catch up with the latest GLTFExporter / GLTFLoader APIs

### What

- [fix (GLTFExporter): update the signature of GLTFExporter.parse](https://github.com/three-types/three-ts-types/commit/ebd3a97a8dfb6c01e748643f22f43e4e25d2a307)
- [fix (GLTFLoader): fix several signatures about GLTFParser](https://github.com/three-types/three-ts-types/commit/0bce4d8590f9d36a16a978b74baa0d5adb4c5d18)
- [fix (GLTFExporter): add register / unregister](https://github.com/three-types/three-ts-types/commit/28fa72f7f33eb0671933ab683340d93bed018042)

Links for clues are inside of each commit logs

### Points need review

- [ ] I've used `ErrorEvent` for the error type of `onError`. I've just followed how it was in GLTFLoader definitions but have no confidence about it
    - Other possible candidates are `Error` or `any`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
    - These are `master` changes
-   [x] Added myself to contributors table
-   [x] Ready to be merged
