### PR TITLE
[postprocessing] Some SSAARenderPass arguments are optional

### DIFF
--- a/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
@@ -3,7 +3,7 @@ import { Scene, Camera, ColorRepresentation, ShaderMaterial, WebGLRenderTarget }
 import { Pass } from './Pass';
 
 export class SSAARenderPass extends Pass {
-    constructor(scene: Scene, camera: Camera, clearColor: ColorRepresentation, clearAlpha: number);
+    constructor(scene: Scene, camera: Camera, clearColor?: ColorRepresentation, clearAlpha?: number);
     scene: Scene;
     camera: Camera;
     sampleLevel: number;


### PR DESCRIPTION
### Why

[SSAARenderPass implementation is robust to undefined for the last two arguments](https://github.com/mrdoob/three.js/blob/master/examples/jsm/postprocessing/SSAARenderPass.js#L36)

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table - not really bothered tbh, github keeps track anyway?
-   [x] Ready to be merged

