### PR TITLE
WebGLUtils isn't exported and WebGLUtils.convert() has wrong argument type

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -305,6 +305,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "DavidPeicho",
+      "name": "David Peicho",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8783766?v=4",
+      "profile": "https://davidpeicho.github.io/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://xk.io/"><img src="https://avatars.githubusercontent.com/u/1046448?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Max Kaye</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=XertroV" title="Documentation">📖</a></td>
     <td align="center"><a href="https://github.com/LauferAlex"><img src="https://avatars.githubusercontent.com/u/86115165?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alejandro Laufer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/issues?q=author%3ALauferAlex" title="Bug reports">🐛</a> <a href="https://github.com/three-types/three-ts-types/commits?author=LauferAlex" title="Code">💻</a></td>
     <td align="center"><a href="https://twitter.com/ggsimm"><img src="https://avatars.githubusercontent.com/u/1862172?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gianmarco</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=gsimone" title="Code">💻</a></td>
+    <td align="center"><a href="https://davidpeicho.github.io/"><img src="https://avatars.githubusercontent.com/u/8783766?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Peicho</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=DavidPeicho" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -209,6 +209,7 @@ export * from './renderers/webgl/WebGLUniforms';
 export * from './renderers/webxr/WebXR';
 export * from './renderers/webxr/WebXRController';
 export * from './renderers/webxr/WebXRManager';
+export { WebGLUtils } from './renderers/webgl/WebGLUtils.js';
 /**
  * Scenes
  */

--- a/types/three/src/renderers/webgl/WebGLUtils.d.ts
+++ b/types/three/src/renderers/webgl/WebGLUtils.d.ts
@@ -3,5 +3,5 @@ import { CompressedPixelFormat, PixelFormat, TextureEncoding } from '../../const
 export class WebGLUtils {
     constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, extensions: any, capabilities: any);
 
-    convert(p: PixelFormat | CompressedPixelFormat, encoding?: TextureEncoding | null): void;
+    convert(p: PixelFormat | CompressedPixelFormat, encoding?: TextureEncoding | null): number | null;
 }

--- a/types/three/src/renderers/webgl/WebGLUtils.d.ts
+++ b/types/three/src/renderers/webgl/WebGLUtils.d.ts
@@ -1,7 +1,7 @@
-import { CompressedPixelFormat, TextureEncoding } from '../../constants';
+import { CompressedPixelFormat, PixelFormat, TextureEncoding } from '../../constants';
 
 export class WebGLUtils {
     constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, extensions: any, capabilities: any);
 
-    convert(p: CompressedPixelFormat, encoding?: TextureEncoding | null): void;
+    convert(p: PixelFormat | CompressedPixelFormat, encoding?: TextureEncoding | null): void;
 }

--- a/types/three/src/renderers/webgl/WebGLUtils.d.ts
+++ b/types/three/src/renderers/webgl/WebGLUtils.d.ts
@@ -1,7 +1,7 @@
-import { CompressedPixelFormat, PixelFormat, TextureEncoding } from '../../constants';
+import { CompressedPixelFormat, PixelFormat, TextureEncoding, TextureDataType } from '../../constants';
 
 export class WebGLUtils {
     constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, extensions: any, capabilities: any);
 
-    convert(p: PixelFormat | CompressedPixelFormat, encoding?: TextureEncoding | null): number | null;
+    convert(p: PixelFormat | CompressedPixelFormat | TextureDataType, encoding?: TextureEncoding | null): number | null;
 }

--- a/types/three/test/renderers/webgl/utils.ts
+++ b/types/three/test/renderers/webgl/utils.ts
@@ -1,0 +1,8 @@
+import { WebGLUtils, WebGLRenderer, RGBAFormat } from 'three';
+
+const renderer = new WebGLRenderer();
+
+// WebGLUtils Tests.
+
+const glUtils = new WebGLUtils(renderer.getContext(), renderer.extensions, renderer.capabilities);
+glUtils.convert(RGBAFormat);

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -60,6 +60,7 @@
         "test/renderers/renderers-renderTarget-multiple.ts",
         "test/renderers/renderers-renderTarget-texture2DArray.ts",
         "test/renderers/webxr/webxr-vr-cube.ts",
+        "test/renderers/webgl/utils.ts",
         "test/shadowmap/shadowmap-csm.ts",
         "test/shadowmap/shadowmap-progressive.ts",
         "test/shadowmap/shadowmap-vsm.ts",


### PR DESCRIPTION
### Why

`WebGLUtils.d.ts` had several issues described in the [What](#what) section.

### What

1. `WebGLUtils` is exported by Three.js, but not by the typings. I personally use the `convert` method as well.
2. `WebGLUtils.convert()` accepts more than just compressed format.

### Checklist

-   [X] Checked the target branch (current goes `master`, next goes `dev`)
-   [X] Added myself to contributors table
-   [X] Ready to be merged
