### PR TITLE
docs: add pragma note for contributors

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -5,10 +5,11 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // Minimum TypeScript Version: 3.6
 
+// To update three.js type definition, please make changes to the repository at:
+// https://github.com/three-types/three-ts-types.
+// Periodically, the updates from the repository are pushed to DefinitelyTyped
+// and released in the @types/three npm package.
+
 export * from './src/Three';
 
-/*~ If this module is a UMD module that exposes a global variable 'myLib' when
- *~ loaded outside a module loader environment, declare that global here.
- *~ Otherwise, delete this declaration.
- */
 export as namespace THREE;


### PR DESCRIPTION
Assuming most of us start with 'index.d.ts' file, this commit adds a
pragma note for contributors to add changes directly to
`three-types/three-ts-types` repo, not to DT project.

Thanks!

### Why

Avoid confusion where to add updates to `three.js` types in future (SSoT, KISS + save the planet)

[See: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59954#issuecomment-1102167718
](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/59954#issuecomment-1101961944)
