### PR TITLE
Fix parameter type in Raycaster::intersectObject(s)

### DIFF
--- a/types/three/src/core/Raycaster.d.ts
+++ b/types/three/src/core/Raycaster.d.ts
@@ -99,7 +99,7 @@ export class Raycaster {
      * @param optionalTarget (optional) target to set the result. Otherwise a new Array is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
      */
     intersectObject<TIntersected extends Object3D>(
-        object: Object3D,
+        object: TIntersected,
         recursive?: boolean,
         optionalTarget?: Array<Intersection<TIntersected>>,
     ): Array<Intersection<TIntersected>>;
@@ -113,7 +113,7 @@ export class Raycaster {
      * @param optionalTarget (optional) target to set the result. Otherwise a new Array is instantiated. If set, you must clear this array prior to each call (i.e., array.length = 0;).
      */
     intersectObjects<TIntersected extends Object3D>(
-        objects: Object3D[],
+        objects: TIntersected[],
         recursive?: boolean,
         optionalTarget?: Array<Intersection<TIntersected>>,
     ): Array<Intersection<TIntersected>>;


### PR DESCRIPTION
### Why
#130 added generic typing to the Intersection type, so that we could get back the same type that we passed in to the intersect methods.
That pr missed the Raycaster::intersectObject(s)'s 'object' & 'objects' parameters. This problem causes the following:
```ts
const raycaster: Raycaster = null;
const mesh: Mesh = null;
const meshes: Mesh[] = null;

const result1: Mesh = raycaster.intersectObject(mesh)[0].object;
const result2: Mesh = raycaster.intersectObjects(meshes)[0].object;
```
This code doesn't compile because the type of result1 is still not a Mesh, it's a Object3D<Event>. This is because according to the current typing we pass in a Object3D and we get back an Object3D.
After these changes the given code compiles without any errors.
### What
Made the 'object' and 'objects' parameters generic in intersectObject & intersectObjects
### Checklist
-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [ ] Ready to be merged