### PR TITLE
feat: Generate constructor interfaces

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -314,6 +314,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "capnmidnight",
+      "name": "Sean T. McBeth",
+      "avatar_url": "https://avatars.githubusercontent.com/u/298046?v=4",
+      "profile": "http://www.seanmcbeth.com/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/LauferAlex"><img src="https://avatars.githubusercontent.com/u/86115165?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Alejandro Laufer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/issues?q=author%3ALauferAlex" title="Bug reports">🐛</a> <a href="https://github.com/three-types/three-ts-types/commits?author=LauferAlex" title="Code">💻</a></td>
     <td align="center"><a href="https://twitter.com/ggsimm"><img src="https://avatars.githubusercontent.com/u/1862172?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gianmarco</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=gsimone" title="Code">💻</a></td>
     <td align="center"><a href="https://davidpeicho.github.io/"><img src="https://avatars.githubusercontent.com/u/8783766?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Peicho</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=DavidPeicho" title="Code">💻</a></td>
+    <td align="center"><a href="http://www.seanmcbeth.com/"><img src="https://avatars.githubusercontent.com/u/298046?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Sean T. McBeth</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=capnmidnight" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/animation/CCDIKSolver.d.ts
+++ b/types/three/examples/jsm/animation/CCDIKSolver.d.ts
@@ -20,6 +20,16 @@ export class CCDIKSolver {
     createHelper(): CCDIKHelper;
 }
 
+export interface CCDIKSolverConstructor {
+    new (mesh: SkinnedMesh, iks: IKS[]): CCDIKSolver;
+    prototype: CCDIKSolver;
+}
+
 export class CCDIKHelper extends Object3D {
     constructor(mesh: SkinnedMesh, iks: IKS[]);
+}
+
+export interface CCDIKHelperConstructor {
+    new (mesh: SkinnedMesh, iks: IKS[]): CCDIKHelper;
+    prototype: CCDIKHelper;
 }

--- a/types/three/examples/jsm/animation/MMDAnimationHelper.d.ts
+++ b/types/three/examples/jsm/animation/MMDAnimationHelper.d.ts
@@ -76,6 +76,11 @@ export class MMDAnimationHelper {
     createGrantSolver(mesh: SkinnedMesh): GrantSolver;
 }
 
+export interface MMDAnimationHelperConstructor {
+    new (params?: MMDAnimationHelperParameter): MMDAnimationHelper;
+    prototype: MMDAnimationHelper;
+}
+
 export interface AudioManagerParameter {
     delayTime?: number | undefined;
 }
@@ -92,6 +97,11 @@ export class AudioManager {
     control(delta: number): this;
 }
 
+export interface AudioManagerConstructor {
+    new (audio: Audio, params?: AudioManagerParameter): AudioManager;
+    prototype: AudioManager;
+}
+
 export class GrantSolver {
     constructor(mesh: SkinnedMesh, grants: object[]);
     mesh: SkinnedMesh;
@@ -100,4 +110,9 @@ export class GrantSolver {
     update(): this;
     updateOne(gran: object[]): this;
     addGrantRotation(bone: Bone, q: Quaternion, ratio: number): this;
+}
+
+export interface GrantSolverConstructor {
+    new (mesh: SkinnedMesh, grants: object[]): GrantSolver;
+    prototype: GrantSolver;
 }

--- a/types/three/examples/jsm/animation/MMDPhysics.d.ts
+++ b/types/three/examples/jsm/animation/MMDPhysics.d.ts
@@ -29,6 +29,16 @@ export class MMDPhysics {
     createHelper(): MMDPhysicsHelper;
 }
 
+export interface MMDPhysicsConstructor {
+    new (
+        mesh: SkinnedMesh,
+        rigidBodyParams: object[],
+        constraintParams?: object[],
+        params?: MMDPhysicsParameter,
+    ): MMDPhysics;
+    prototype: MMDPhysics;
+}
+
 export class ResourceManager {
     constructor();
     threeVector3s: Vector3[];
@@ -79,6 +89,11 @@ export class ResourceManager {
     matrix3ToQuaternion(m: object): object;
 }
 
+export interface ResourceManagerConstructor {
+    new (): ResourceManager;
+    prototype: ResourceManager;
+}
+
 export class RigidBody {
     constructor(mesh: SkinnedMesh, world: object, params: object, manager: ResourceManager);
     mesh: SkinnedMesh;
@@ -94,6 +109,11 @@ export class RigidBody {
     reset(): this;
     updateFromBone(): this;
     updateBone(): this;
+}
+
+export interface RigidBodyConstructor {
+    new (mesh: SkinnedMesh, world: object, params: object, manager: ResourceManager): RigidBody;
+    prototype: RigidBody;
 }
 
 export class Constraint {
@@ -114,6 +134,23 @@ export class Constraint {
     manager: ResourceManager;
 }
 
+export interface ConstraintConstructor {
+    new (
+        mesh: SkinnedMesh,
+        world: object,
+        bodyA: RigidBody,
+        bodyB: RigidBody,
+        params: object,
+        manager: ResourceManager,
+    ): Constraint;
+    prototype: Constraint;
+}
+
 export class MMDPhysicsHelper extends Object3D {
     constructor();
+}
+
+export interface MMDPhysicsHelperConstructor {
+    new (): MMDPhysicsHelper;
+    prototype: MMDPhysicsHelper;
 }

--- a/types/three/examples/jsm/cameras/CinematicCamera.d.ts
+++ b/types/three/examples/jsm/cameras/CinematicCamera.d.ts
@@ -39,3 +39,8 @@ export class CinematicCamera extends PerspectiveCamera {
     renderCinematic(scene: Scene, renderer: WebGLRenderer): void;
     setLens(focalLength: number, frameHeight?: number, fNumber?: number, coc?: number): void;
 }
+
+export interface CinematicCameraConstructor {
+    new (fov: number, aspect: number, near: number, far: number): CinematicCamera;
+    prototype: CinematicCamera;
+}

--- a/types/three/examples/jsm/controls/ArcballControls.d.ts
+++ b/types/three/examples/jsm/controls/ArcballControls.d.ts
@@ -156,3 +156,8 @@ export class ArcballControls extends EventDispatcher {
 
     dispose(): void;
 }
+
+export interface ArcballControlsConstructor {
+    new (camera: Camera, domElement: HTMLElement, scene?: Scene | null): ArcballControls;
+    prototype: ArcballControls;
+}

--- a/types/three/examples/jsm/controls/DragControls.d.ts
+++ b/types/three/examples/jsm/controls/DragControls.d.ts
@@ -16,3 +16,8 @@ export class DragControls extends EventDispatcher {
     getObjects(): Object3D[];
     getRaycaster(): Raycaster;
 }
+
+export interface DragControlsConstructor {
+    new (objects: Object3D[], camera: Camera, domElement?: HTMLElement): DragControls;
+    prototype: DragControls;
+}

--- a/types/three/examples/jsm/controls/FirstPersonControls.d.ts
+++ b/types/three/examples/jsm/controls/FirstPersonControls.d.ts
@@ -26,3 +26,8 @@ export class FirstPersonControls {
     update(delta: number): this;
     dispose(): void;
 }
+
+export interface FirstPersonControlsConstructor {
+    new (object: Camera, domElement?: HTMLElement): FirstPersonControls;
+    prototype: FirstPersonControls;
+}

--- a/types/three/examples/jsm/controls/FlyControls.d.ts
+++ b/types/three/examples/jsm/controls/FlyControls.d.ts
@@ -14,3 +14,8 @@ export class FlyControls extends EventDispatcher {
     update(delta: number): void;
     dispose(): void;
 }
+
+export interface FlyControlsConstructor {
+    new (object: Camera, domElement?: HTMLElement): FlyControls;
+    prototype: FlyControls;
+}

--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -76,6 +76,16 @@ export class OrbitControls {
     dispatchEvent(event: { type: string; target: any }): void;
 }
 
+export interface OrbitControlsConstructor {
+    new (object: Camera, domElement?: HTMLElement): OrbitControls;
+    prototype: OrbitControls;
+}
+
 export class MapControls extends OrbitControls {
     constructor(object: Camera, domElement?: HTMLElement);
+}
+
+export interface MapControlsConstructor {
+    new (object: Camera, domElement?: HTMLElement): MapControls;
+    prototype: MapControls;
 }

--- a/types/three/examples/jsm/controls/PointerLockControls.d.ts
+++ b/types/three/examples/jsm/controls/PointerLockControls.d.ts
@@ -22,3 +22,8 @@ export class PointerLockControls extends EventDispatcher {
     lock(): void;
     unlock(): void;
 }
+
+export interface PointerLockControlsConstructor {
+    new (camera: Camera, domElement?: HTMLElement): PointerLockControls;
+    prototype: PointerLockControls;
+}

--- a/types/three/examples/jsm/controls/TrackballControls.d.ts
+++ b/types/three/examples/jsm/controls/TrackballControls.d.ts
@@ -44,3 +44,8 @@ export class TrackballControls extends EventDispatcher {
 
     handleResize(): void;
 }
+
+export interface TrackballControlsConstructor {
+    new (object: Camera, domElement?: HTMLElement): TrackballControls;
+    prototype: TrackballControls;
+}

--- a/types/three/examples/jsm/controls/TransformControls.d.ts
+++ b/types/three/examples/jsm/controls/TransformControls.d.ts
@@ -40,3 +40,8 @@ export class TransformControls extends Object3D {
     reset(): void;
     dispose(): void;
 }
+
+export interface TransformControlsConstructor {
+    new (object: Camera, domElement?: HTMLElement): TransformControls;
+    prototype: TransformControls;
+}

--- a/types/three/examples/jsm/csm/CSM.d.ts
+++ b/types/three/examples/jsm/csm/CSM.d.ts
@@ -58,4 +58,9 @@ export class CSM {
     dispose(): void;
 }
 
+export interface CSMConstructor {
+    new (data?: CMSParameters): CSM;
+    prototype: CSM;
+}
+
 import CSMFrustrum from './CSMFrustum.js';

--- a/types/three/examples/jsm/csm/CSMHelper.d.ts
+++ b/types/three/examples/jsm/csm/CSMHelper.d.ts
@@ -24,3 +24,8 @@ export class CSMHelper<TCSM extends CSM = CSM> extends Group {
     updateVisibility(): void;
     update(): void;
 }
+
+export interface CSMHelperConstructor<TCSM extends CSM = CSM> {
+    new (csm: TCSM): CSMHelper<TCSM>;
+    prototype: CSMHelper<TCSM>;
+}

--- a/types/three/examples/jsm/curves/CurveExtras.d.ts
+++ b/types/three/examples/jsm/curves/CurveExtras.d.ts
@@ -4,9 +4,19 @@ export class GrannyKnot extends Curve<Vector3> {
     constructor();
 }
 
+export interface GrannyKnotConstructor {
+    new (): GrannyKnot;
+    prototype: GrannyKnot;
+}
+
 export class HeartCurve extends Curve<Vector3> {
     constructor(scale?: number);
     scale: number;
+}
+
+export interface HeartCurveConstructor {
+    new (scale?: number): HeartCurve;
+    prototype: HeartCurve;
 }
 
 export class VivianiCurve extends Curve<Vector3> {
@@ -14,12 +24,27 @@ export class VivianiCurve extends Curve<Vector3> {
     scale: number;
 }
 
+export interface VivianiCurveConstructor {
+    new (scale?: number): VivianiCurve;
+    prototype: VivianiCurve;
+}
+
 export class KnotCurve extends Curve<Vector3> {
     constructor();
 }
 
+export interface KnotCurveConstructor {
+    new (): KnotCurve;
+    prototype: KnotCurve;
+}
+
 export class HelixCurve extends Curve<Vector3> {
     constructor();
+}
+
+export interface HelixCurveConstructor {
+    new (): HelixCurve;
+    prototype: HelixCurve;
 }
 
 export class TrefoilKnot extends Curve<Vector3> {
@@ -27,9 +52,19 @@ export class TrefoilKnot extends Curve<Vector3> {
     scale: number;
 }
 
+export interface TrefoilKnotConstructor {
+    new (scale?: number): TrefoilKnot;
+    prototype: TrefoilKnot;
+}
+
 export class TorusKnot extends Curve<Vector3> {
     constructor(scale?: number);
     scale: number;
+}
+
+export interface TorusKnotConstructor {
+    new (scale?: number): TorusKnot;
+    prototype: TorusKnot;
 }
 
 export class CinquefoilKnot extends Curve<Vector3> {
@@ -37,9 +72,19 @@ export class CinquefoilKnot extends Curve<Vector3> {
     scale: number;
 }
 
+export interface CinquefoilKnotConstructor {
+    new (scale?: number): CinquefoilKnot;
+    prototype: CinquefoilKnot;
+}
+
 export class TrefoilPolynomialKnot extends Curve<Vector3> {
     constructor(scale?: number);
     scale: number;
+}
+
+export interface TrefoilPolynomialKnotConstructor {
+    new (scale?: number): TrefoilPolynomialKnot;
+    prototype: TrefoilPolynomialKnot;
 }
 
 export class FigureEightPolynomialKnot extends Curve<Vector3> {
@@ -47,9 +92,19 @@ export class FigureEightPolynomialKnot extends Curve<Vector3> {
     scale: number;
 }
 
+export interface FigureEightPolynomialKnotConstructor {
+    new (scale?: number): FigureEightPolynomialKnot;
+    prototype: FigureEightPolynomialKnot;
+}
+
 export class DecoratedTorusKnot4a extends Curve<Vector3> {
     constructor(scale?: number);
     scale: number;
+}
+
+export interface DecoratedTorusKnot4aConstructor {
+    new (scale?: number): DecoratedTorusKnot4a;
+    prototype: DecoratedTorusKnot4a;
 }
 
 export class DecoratedTorusKnot4b extends Curve<Vector3> {
@@ -57,12 +112,27 @@ export class DecoratedTorusKnot4b extends Curve<Vector3> {
     scale: number;
 }
 
+export interface DecoratedTorusKnot4bConstructor {
+    new (scale?: number): DecoratedTorusKnot4b;
+    prototype: DecoratedTorusKnot4b;
+}
+
 export class DecoratedTorusKnot5a extends Curve<Vector3> {
     constructor(scale?: number);
     scale: number;
 }
 
+export interface DecoratedTorusKnot5aConstructor {
+    new (scale?: number): DecoratedTorusKnot5a;
+    prototype: DecoratedTorusKnot5a;
+}
+
 export class DecoratedTorusKnot5c extends Curve<Vector3> {
     constructor(scale?: number);
     scale: number;
+}
+
+export interface DecoratedTorusKnot5cConstructor {
+    new (scale?: number): DecoratedTorusKnot5c;
+    prototype: DecoratedTorusKnot5c;
 }

--- a/types/three/examples/jsm/curves/NURBSCurve.d.ts
+++ b/types/three/examples/jsm/curves/NURBSCurve.d.ts
@@ -9,3 +9,14 @@ export class NURBSCurve extends Curve<Vector3> {
         endKnot: number,
     );
 }
+
+export interface NURBSCurveConstructor {
+    new (
+        degree: number,
+        knots: number[],
+        controlPoints: Vector2[] | Vector3[] | Vector4[],
+        startKnot: number,
+        endKnot: number,
+    ): NURBSCurve;
+    prototype: NURBSCurve;
+}

--- a/types/three/examples/jsm/curves/NURBSSurface.d.ts
+++ b/types/three/examples/jsm/curves/NURBSSurface.d.ts
@@ -11,3 +11,14 @@ export class NURBSSurface {
 
     getPoint(t1: number, t2: number, target: Vector3): void;
 }
+
+export interface NURBSSurfaceConstructor {
+    new (
+        degree1: number,
+        degree2: number,
+        knots1: number[],
+        knots2: number[],
+        controlPoints: Vector2[][] | Vector3[][] | Vector4[][],
+    ): NURBSSurface;
+    prototype: NURBSSurface;
+}

--- a/types/three/examples/jsm/deprecated/Geometry.d.ts
+++ b/types/three/examples/jsm/deprecated/Geometry.d.ts
@@ -271,6 +271,11 @@ export class Geometry extends EventDispatcher {
     animations: AnimationClip[];
 }
 
+export interface GeometryConstructor {
+    new (): Geometry;
+    prototype: Geometry;
+}
+
 /**
  * Triangle face.
  */
@@ -339,4 +344,16 @@ export class Face3 {
 
     clone(): this;
     copy(source: Face3): this;
+}
+
+export interface Face3Constructor {
+    new (
+        a: number,
+        b: number,
+        c: number,
+        normal?: Vector3 | Vector3[],
+        color?: Color | Color[],
+        materialIndex?: number,
+    ): Face3;
+    prototype: Face3;
 }

--- a/types/three/examples/jsm/effects/AnaglyphEffect.d.ts
+++ b/types/three/examples/jsm/effects/AnaglyphEffect.d.ts
@@ -9,3 +9,8 @@ export class AnaglyphEffect {
     render(scene: Scene, camera: Camera): void;
     setSize(width: number, height: number): void;
 }
+
+export interface AnaglyphEffectConstructor {
+    new (renderer: WebGLRenderer, width?: number, height?: number): AnaglyphEffect;
+    prototype: AnaglyphEffect;
+}

--- a/types/three/examples/jsm/effects/AsciiEffect.d.ts
+++ b/types/three/examples/jsm/effects/AsciiEffect.d.ts
@@ -16,3 +16,8 @@ export class AsciiEffect {
     render(scene: Scene, camera: Camera): void;
     setSize(width: number, height: number): void;
 }
+
+export interface AsciiEffectConstructor {
+    new (renderer: WebGLRenderer, charSet?: string, options?: AsciiEffectOptions): AsciiEffect;
+    prototype: AsciiEffect;
+}

--- a/types/three/examples/jsm/effects/OutlineEffect.d.ts
+++ b/types/three/examples/jsm/effects/OutlineEffect.d.ts
@@ -26,3 +26,8 @@ export class OutlineEffect {
     setSize(width: number, height: number, updateStyle?: boolean): void;
     setViewport(x: Vector4 | number, y?: number, width?: number, height?: number): void;
 }
+
+export interface OutlineEffectConstructor {
+    new (renderer: WebGLRenderer, parameters?: OutlineEffectParameters): OutlineEffect;
+    prototype: OutlineEffect;
+}

--- a/types/three/examples/jsm/effects/ParallaxBarrierEffect.d.ts
+++ b/types/three/examples/jsm/effects/ParallaxBarrierEffect.d.ts
@@ -6,3 +6,8 @@ export class ParallaxBarrierEffect {
     render(scene: Scene, camera: Camera): void;
     setSize(width: number, height: number): void;
 }
+
+export interface ParallaxBarrierEffectConstructor {
+    new (renderer: WebGLRenderer): ParallaxBarrierEffect;
+    prototype: ParallaxBarrierEffect;
+}

--- a/types/three/examples/jsm/effects/PeppersGhostEffect.d.ts
+++ b/types/three/examples/jsm/effects/PeppersGhostEffect.d.ts
@@ -8,3 +8,8 @@ export class PeppersGhostEffect {
     render(scene: Scene, camera: Camera): void;
     setSize(width: number, height: number): void;
 }
+
+export interface PeppersGhostEffectConstructor {
+    new (renderer: WebGLRenderer): PeppersGhostEffect;
+    prototype: PeppersGhostEffect;
+}

--- a/types/three/examples/jsm/effects/StereoEffect.d.ts
+++ b/types/three/examples/jsm/effects/StereoEffect.d.ts
@@ -7,3 +7,8 @@ export class StereoEffect {
     render(scene: Scene, camera: Camera): void;
     setSize(width: number, height: number): void;
 }
+
+export interface StereoEffectConstructor {
+    new (renderer: WebGLRenderer): StereoEffect;
+    prototype: StereoEffect;
+}

--- a/types/three/examples/jsm/environments/RoomEnvironment.d.ts
+++ b/types/three/examples/jsm/environments/RoomEnvironment.d.ts
@@ -3,3 +3,8 @@ import { Scene } from '../../../src/Three';
 export class RoomEnvironment extends Scene {
     constructor();
 }
+
+export interface RoomEnvironmentConstructor {
+    new (): RoomEnvironment;
+    prototype: RoomEnvironment;
+}

--- a/types/three/examples/jsm/exporters/ColladaExporter.d.ts
+++ b/types/three/examples/jsm/exporters/ColladaExporter.d.ts
@@ -20,3 +20,8 @@ export class ColladaExporter {
         options: ColladaExporterOptions,
     ): ColladaExporterResult | null;
 }
+
+export interface ColladaExporterConstructor {
+    new (): ColladaExporter;
+    prototype: ColladaExporter;
+}

--- a/types/three/examples/jsm/exporters/DRACOExporter.d.ts
+++ b/types/three/examples/jsm/exporters/DRACOExporter.d.ts
@@ -15,3 +15,8 @@ export class DRACOExporter {
 
     parse(object: Mesh | Points, options: DRACOExporterOptions): Int8Array;
 }
+
+export interface DRACOExporterConstructor {
+    new (): DRACOExporter;
+    prototype: DRACOExporter;
+}

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -18,3 +18,8 @@ export class GLTFExporter {
     parse(input: Object3D, onCompleted: (gltf: object) => void, options: GLTFExporterOptions): void;
     parseAsync(input: Object3D, options: GLTFExporterOptions): Promise<void>;
 }
+
+export interface GLTFExporterConstructor {
+    new (): GLTFExporter;
+    prototype: GLTFExporter;
+}

--- a/types/three/examples/jsm/exporters/MMDExporter.d.ts
+++ b/types/three/examples/jsm/exporters/MMDExporter.d.ts
@@ -5,3 +5,8 @@ export class MMDExporter {
 
     parseVpd(skin: Object3D, outputShiftJis: boolean, useOriginalBones: boolean): [] | Uint8Array;
 }
+
+export interface MMDExporterConstructor {
+    new (): MMDExporter;
+    prototype: MMDExporter;
+}

--- a/types/three/examples/jsm/exporters/OBJExporter.d.ts
+++ b/types/three/examples/jsm/exporters/OBJExporter.d.ts
@@ -5,3 +5,8 @@ export class OBJExporter {
 
     parse(object: Object3D): string;
 }
+
+export interface OBJExporterConstructor {
+    new (): OBJExporter;
+    prototype: OBJExporter;
+}

--- a/types/three/examples/jsm/exporters/PLYExporter.d.ts
+++ b/types/three/examples/jsm/exporters/PLYExporter.d.ts
@@ -11,3 +11,8 @@ export class PLYExporter {
 
     parse(object: Object3D, onDone: (res: string) => void, options: PLYExporterOptions): string | null;
 }
+
+export interface PLYExporterConstructor {
+    new (): PLYExporter;
+    prototype: PLYExporter;
+}

--- a/types/three/examples/jsm/exporters/STLExporter.d.ts
+++ b/types/three/examples/jsm/exporters/STLExporter.d.ts
@@ -9,3 +9,8 @@ export class STLExporter {
 
     parse(scene: Object3D, options?: STLExporterOptions): string;
 }
+
+export interface STLExporterConstructor {
+    new (): STLExporter;
+    prototype: STLExporter;
+}

--- a/types/three/examples/jsm/exporters/USDZExporter.d.ts
+++ b/types/three/examples/jsm/exporters/USDZExporter.d.ts
@@ -5,3 +5,8 @@ export class USDZExporter {
 
     parse(scene: Object3D): Promise<Uint8Array>;
 }
+
+export interface USDZExporterConstructor {
+    new (): USDZExporter;
+    prototype: USDZExporter;
+}

--- a/types/three/examples/jsm/geometries/BoxLineGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/BoxLineGeometry.d.ts
@@ -10,3 +10,15 @@ export class BoxLineGeometry extends BufferGeometry {
         depthSegments?: number,
     );
 }
+
+export interface BoxLineGeometryConstructor {
+    new (
+        width?: number,
+        height?: number,
+        depth?: number,
+        widthSegments?: number,
+        heightSegments?: number,
+        depthSegments?: number,
+    ): BoxLineGeometry;
+    prototype: BoxLineGeometry;
+}

--- a/types/three/examples/jsm/geometries/ConvexGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/ConvexGeometry.d.ts
@@ -3,3 +3,8 @@ import { BufferGeometry, Vector3 } from '../../../src/Three';
 export class ConvexGeometry extends BufferGeometry {
     constructor(points?: Vector3[]);
 }
+
+export interface ConvexGeometryConstructor {
+    new (points?: Vector3[]): ConvexGeometry;
+    prototype: ConvexGeometry;
+}

--- a/types/three/examples/jsm/geometries/DecalGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/DecalGeometry.d.ts
@@ -4,7 +4,17 @@ export class DecalGeometry extends BufferGeometry {
     constructor(mesh: Mesh, position: Vector3, orientation: Euler, size: Vector3);
 }
 
+export interface DecalGeometryConstructor {
+    new (mesh: Mesh, position: Vector3, orientation: Euler, size: Vector3): DecalGeometry;
+    prototype: DecalGeometry;
+}
+
 export class DecalVertex {
     constructor(position: Vector3, normal: Vector3);
     clone(): this;
+}
+
+export interface DecalVertexConstructor {
+    new (position: Vector3, normal: Vector3): DecalVertex;
+    prototype: DecalVertex;
 }

--- a/types/three/examples/jsm/geometries/LightningStrike.d.ts
+++ b/types/three/examples/jsm/geometries/LightningStrike.d.ts
@@ -106,3 +106,8 @@ export class LightningStrike {
     copy(source: LightningStrike): LightningStrike;
     clone(): this;
 }
+
+export interface LightningStrikeConstructor {
+    new (rayParameters?: RayParameters): LightningStrike;
+    prototype: LightningStrike;
+}

--- a/types/three/examples/jsm/geometries/ParametricGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/ParametricGeometry.d.ts
@@ -15,4 +15,9 @@ export class ParametricGeometry extends BufferGeometry {
     };
 }
 
+export interface ParametricGeometryConstructor {
+    new (func?: (u: number, v: number, target: Vector3) => void, slices?: number, stacks?: number): ParametricGeometry;
+    prototype: ParametricGeometry;
+}
+
 export { ParametricGeometry as ParametricBufferGeometry };

--- a/types/three/examples/jsm/geometries/RoundedBoxGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/RoundedBoxGeometry.d.ts
@@ -3,3 +3,8 @@ import { BoxGeometry } from '../../../src/Three';
 export class RoundedBoxGeometry extends BoxGeometry {
     constructor(width?: number, height?: number, depth?: number, segments?: number, radius?: number);
 }
+
+export interface RoundedBoxGeometryConstructor {
+    new (width?: number, height?: number, depth?: number, segments?: number, radius?: number): RoundedBoxGeometry;
+    prototype: RoundedBoxGeometry;
+}

--- a/types/three/examples/jsm/geometries/TeapotGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/TeapotGeometry.d.ts
@@ -11,3 +11,16 @@ export class TeapotGeometry extends BufferGeometry {
         blinn?: number,
     );
 }
+
+export interface TeapotGeometryConstructor {
+    new (
+        size?: number,
+        segments?: number,
+        bottom?: boolean,
+        lid?: boolean,
+        body?: boolean,
+        fitLid?: boolean,
+        blinn?: number,
+    ): TeapotGeometry;
+    prototype: TeapotGeometry;
+}

--- a/types/three/examples/jsm/geometries/TextGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/TextGeometry.d.ts
@@ -35,4 +35,9 @@ export class TextGeometry extends ExtrudeGeometry {
     };
 }
 
+export interface TextGeometryConstructor {
+    new (text: string, parameters: TextGeometryParameters): TextGeometry;
+    prototype: TextGeometry;
+}
+
 export { TextGeometry as TextBufferGeometry };

--- a/types/three/examples/jsm/helpers/LightProbeHelper.d.ts
+++ b/types/three/examples/jsm/helpers/LightProbeHelper.d.ts
@@ -8,3 +8,8 @@ export class LightProbeHelper extends Mesh {
 
     dispose(): void;
 }
+
+export interface LightProbeHelperConstructor {
+    new (lightProbe: LightProbe, size: number): LightProbeHelper;
+    prototype: LightProbeHelper;
+}

--- a/types/three/examples/jsm/helpers/OctreeHelper.d.ts
+++ b/types/three/examples/jsm/helpers/OctreeHelper.d.ts
@@ -12,3 +12,8 @@ export class OctreeHelper extends LineSegments {
      */
     type: 'OctreeHelper' | string;
 }
+
+export interface OctreeHelperConstructor {
+    new (octree: Octree, color: ColorRepresentation): OctreeHelper;
+    prototype: OctreeHelper;
+}

--- a/types/three/examples/jsm/helpers/PositionalAudioHelper.d.ts
+++ b/types/three/examples/jsm/helpers/PositionalAudioHelper.d.ts
@@ -11,3 +11,13 @@ export class PositionalAudioHelper extends Line {
     dispose(): void;
     update(): void;
 }
+
+export interface PositionalAudioHelperConstructor {
+    new (
+        audio: PositionalAudio,
+        range?: number,
+        divisionsInnerAngle?: number,
+        divisionsOuterAngle?: number,
+    ): PositionalAudioHelper;
+    prototype: PositionalAudioHelper;
+}

--- a/types/three/examples/jsm/helpers/RectAreaLightHelper.d.ts
+++ b/types/three/examples/jsm/helpers/RectAreaLightHelper.d.ts
@@ -8,3 +8,8 @@ export class RectAreaLightHelper extends Line {
 
     dispose(): void;
 }
+
+export interface RectAreaLightHelperConstructor {
+    new (light: RectAreaLight, color?: ColorRepresentation): RectAreaLightHelper;
+    prototype: RectAreaLightHelper;
+}

--- a/types/three/examples/jsm/helpers/VertexNormalsHelper.d.ts
+++ b/types/three/examples/jsm/helpers/VertexNormalsHelper.d.ts
@@ -8,3 +8,8 @@ export class VertexNormalsHelper extends LineSegments {
 
     update(): void;
 }
+
+export interface VertexNormalsHelperConstructor {
+    new (object: Object3D, size?: number, hex?: number): VertexNormalsHelper;
+    prototype: VertexNormalsHelper;
+}

--- a/types/three/examples/jsm/helpers/VertexTangentsHelper.d.ts
+++ b/types/three/examples/jsm/helpers/VertexTangentsHelper.d.ts
@@ -8,3 +8,8 @@ export class VertexTangentsHelper extends LineSegments {
 
     update(): void;
 }
+
+export interface VertexTangentsHelperConstructor {
+    new (object: Object3D, size?: number, hex?: number): VertexTangentsHelper;
+    prototype: VertexTangentsHelper;
+}

--- a/types/three/examples/jsm/interactive/HTMLMesh.d.ts
+++ b/types/three/examples/jsm/interactive/HTMLMesh.d.ts
@@ -4,3 +4,8 @@ export class HTMLMesh extends Mesh {
     constructor(dom: HTMLElement);
     dispose(): void;
 }
+
+export interface HTMLMeshConstructor {
+    new (dom: HTMLElement): HTMLMesh;
+    prototype: HTMLMesh;
+}

--- a/types/three/examples/jsm/interactive/InteractiveGroup.d.ts
+++ b/types/three/examples/jsm/interactive/InteractiveGroup.d.ts
@@ -3,3 +3,8 @@ import { WebGLRenderer, Camera, Group } from 'three';
 export class InteractiveGroup extends Group {
     constructor(renderer: WebGLRenderer, camera: Camera);
 }
+
+export interface InteractiveGroupConstructor {
+    new (renderer: WebGLRenderer, camera: Camera): InteractiveGroup;
+    prototype: InteractiveGroup;
+}

--- a/types/three/examples/jsm/interactive/SelectionBox.d.ts
+++ b/types/three/examples/jsm/interactive/SelectionBox.d.ts
@@ -13,3 +13,8 @@ export class SelectionBox {
     updateFrustum(startPoint: Vector3, endPoint: Vector3): void;
     searchChildInFrustum(frustum: Frustum, object: Object3D): void;
 }
+
+export interface SelectionBoxConstructor {
+    new (camera: Camera, scene: Scene, deep?: number): SelectionBox;
+    prototype: SelectionBox;
+}

--- a/types/three/examples/jsm/interactive/SelectionHelper.d.ts
+++ b/types/three/examples/jsm/interactive/SelectionHelper.d.ts
@@ -15,3 +15,8 @@ export class SelectionHelper {
     onSelectMove(event: Event): void;
     onSelectOver(event: Event): void;
 }
+
+export interface SelectionHelperConstructor {
+    new (selectionBox: SelectionBox, renderer: WebGLRenderer, cssClassName: string): SelectionHelper;
+    prototype: SelectionHelper;
+}

--- a/types/three/examples/jsm/libs/fflate.module.min.d.ts
+++ b/types/three/examples/jsm/libs/fflate.module.min.d.ts
@@ -139,6 +139,12 @@ export class Deflate {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface DeflateConstructor {
+    new (opts: DeflateOptions, cb?: FlateStreamHandler): Deflate;
+    new (cb?: FlateStreamHandler): Deflate;
+    prototype: Deflate;
+}
 /**
  * Asynchronous streaming DEFLATE compression
  */
@@ -169,6 +175,12 @@ export class AsyncDeflate {
      * push() will silently fail.
      */
     terminate: AsyncTerminable;
+}
+
+export interface AsyncDeflateConstructor {
+    new (opts: DeflateOptions, cb?: AsyncFlateStreamHandler): AsyncDeflate;
+    new (cb?: AsyncFlateStreamHandler): AsyncDeflate;
+    prototype: AsyncDeflate;
 }
 /**
  * Asynchronously compresses data with DEFLATE without any wrapper
@@ -217,6 +229,11 @@ export class Inflate {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface InflateConstructor {
+    new (cb?: FlateStreamHandler): Inflate;
+    prototype: Inflate;
+}
 /**
  * Asynchronous streaming DEFLATE decompression
  */
@@ -241,6 +258,11 @@ export class AsyncInflate {
      * push() will silently fail.
      */
     terminate: AsyncTerminable;
+}
+
+export interface AsyncInflateConstructor {
+    new (cb?: AsyncFlateStreamHandler): AsyncInflate;
+    prototype: AsyncInflate;
 }
 /**
  * Asynchronously expands DEFLATE data with no wrapper
@@ -295,6 +317,12 @@ export class Gzip {
     push(chunk: Uint8Array, final?: boolean): void;
     private p;
 }
+
+export interface GzipConstructor {
+    new (opts: GzipOptions, cb?: FlateStreamHandler): Gzip;
+    new (cb?: FlateStreamHandler): Gzip;
+    prototype: Gzip;
+}
 /**
  * Asynchronous streaming GZIP compression
  */
@@ -325,6 +353,12 @@ export class AsyncGzip {
      * push() will silently fail.
      */
     terminate: AsyncTerminable;
+}
+
+export interface AsyncGzipConstructor {
+    new (opts: GzipOptions, cb?: AsyncFlateStreamHandler): AsyncGzip;
+    new (cb?: AsyncFlateStreamHandler): AsyncGzip;
+    prototype: AsyncGzip;
 }
 /**
  * Asynchronously compresses data with GZIP
@@ -370,6 +404,11 @@ export class Gunzip {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface GunzipConstructor {
+    new (cb?: FlateStreamHandler): Gunzip;
+    prototype: Gunzip;
+}
 /**
  * Asynchronous streaming GZIP decompression
  */
@@ -394,6 +433,11 @@ export class AsyncGunzip {
      * push() will silently fail.
      */
     terminate: AsyncTerminable;
+}
+
+export interface AsyncGunzipConstructor {
+    new (cb: AsyncFlateStreamHandler): AsyncGunzip;
+    prototype: AsyncGunzip;
 }
 /**
  * Asynchronously expands GZIP data
@@ -447,6 +491,12 @@ export class Zlib {
     push(chunk: Uint8Array, final?: boolean): void;
     private p;
 }
+
+export interface ZlibConstructor {
+    new (opts: ZlibOptions, cb?: FlateStreamHandler): Zlib;
+    new (cb?: FlateStreamHandler): Zlib;
+    prototype: Zlib;
+}
 /**
  * Asynchronous streaming Zlib compression
  */
@@ -477,6 +527,12 @@ export class AsyncZlib {
      * push() will silently fail.
      */
     terminate: AsyncTerminable;
+}
+
+export interface AsyncZlibConstructor {
+    new (opts: ZlibOptions, cb?: AsyncFlateStreamHandler): AsyncZlib;
+    new (cb?: AsyncFlateStreamHandler): AsyncZlib;
+    prototype: AsyncZlib;
 }
 /**
  * Asynchronously compresses data with Zlib
@@ -521,6 +577,11 @@ export class Unzlib {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface UnzlibConstructor {
+    new (cb?: FlateStreamHandler): Unzlib;
+    prototype: Unzlib;
+}
 /**
  * Asynchronous streaming Zlib decompression
  */
@@ -545,6 +606,11 @@ export class AsyncUnzlib {
      * push() will silently fail.
      */
     terminate: AsyncTerminable;
+}
+
+export interface AsyncUnzlibConstructor {
+    new (cb?: AsyncFlateStreamHandler): AsyncUnzlib;
+    prototype: AsyncUnzlib;
 }
 /**
  * Asynchronously expands Zlib data
@@ -595,6 +661,11 @@ export class Decompress {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface DecompressConstructor {
+    new (cb?: FlateStreamHandler): Decompress;
+    prototype: Decompress;
+}
 /**
  * Asynchronous streaming GZIP, Zlib, or raw DEFLATE decompression
  */
@@ -617,6 +688,11 @@ export class AsyncDecompress {
      * @param final Whether this is the last chunk
      */
     push(chunk: Uint8Array, final?: boolean): void;
+}
+
+export interface AsyncDecompressConstructor {
+    new (cb?: AsyncFlateStreamHandler): AsyncDecompress;
+    prototype: AsyncDecompress;
 }
 /**
  * Asynchrononously expands compressed GZIP, Zlib, or raw DEFLATE data, automatically detecting the format
@@ -768,6 +844,11 @@ export class DecodeUTF8 {
      */
     ondata: StringStreamHandler;
 }
+
+export interface DecodeUTF8Constructor {
+    new (cb?: StringStreamHandler): DecodeUTF8;
+    prototype: DecodeUTF8;
+}
 /**
  * Streaming UTF-8 encoding
  */
@@ -787,6 +868,11 @@ export class EncodeUTF8 {
      * The handler to call whenever data is available
      */
     ondata: FlateStreamHandler;
+}
+
+export interface EncodeUTF8Constructor {
+    new (cb?: FlateStreamHandler): EncodeUTF8;
+    prototype: EncodeUTF8;
 }
 /**
  * Converts a string into a Uint8Array for use with compression/decompression methods
@@ -906,6 +992,11 @@ export class ZipPassThrough implements ZipInputFile {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface ZipPassThroughConstructor {
+    new (filename: string): ZipPassThrough;
+    prototype: ZipPassThrough;
+}
 /**
  * Streaming DEFLATE compression for ZIP archives. Prefer using AsyncZipDeflate
  * for better performance
@@ -937,6 +1028,11 @@ export class ZipDeflate implements ZipInputFile {
      */
     push(chunk: Uint8Array, final?: boolean): void;
 }
+
+export interface ZipDeflateConstructor {
+    new (filename: string, opts?: DeflateOptions): ZipDeflate;
+    prototype: ZipDeflate;
+}
 /**
  * Asynchronous streaming DEFLATE compression for ZIP archives
  */
@@ -967,6 +1063,11 @@ export class AsyncZipDeflate implements ZipInputFile {
      * @param final Whether this is the last chunk
      */
     push(chunk: Uint8Array, final?: boolean): void;
+}
+
+export interface AsyncZipDeflateConstructor {
+    new (filename: string, opts?: DeflateOptions): AsyncZipDeflate;
+    prototype: AsyncZipDeflate;
 }
 /**
  * A zippable archive to which files can incrementally be added
@@ -1001,6 +1102,11 @@ export class Zip {
      * The handler to call whenever data is available
      */
     ondata: AsyncFlateStreamHandler;
+}
+
+export interface ZipConstructor {
+    new (cb?: AsyncFlateStreamHandler): Zip;
+    prototype: Zip;
 }
 /**
  * Asynchronously creates a ZIP file
@@ -1124,6 +1230,11 @@ export class UnzipInflate implements UnzipDecoder {
     constructor();
     push(data: Uint8Array, final: boolean): void;
 }
+
+export interface UnzipInflateConstructor {
+    new (): UnzipInflate;
+    prototype: UnzipInflate;
+}
 /**
  * Asynchronous streaming DEFLATE decompression for ZIP archives
  */
@@ -1137,6 +1248,11 @@ export class AsyncUnzipInflate implements UnzipDecoder {
      */
     constructor(_: string, sz?: number);
     push(data: Uint8Array, final: boolean): void;
+}
+
+export interface AsyncUnzipInflateConstructor {
+    new (_: string, sz?: number): AsyncUnzipInflate;
+    prototype: AsyncUnzipInflate;
 }
 /**
  * A ZIP archive decompression stream that emits files as they are discovered
@@ -1168,6 +1284,11 @@ export class Unzip {
      * The handler to call whenever a file is discovered
      */
     onfile: UnzipFileHandler;
+}
+
+export interface UnzipConstructor {
+    new (cb?: UnzipFileHandler): Unzip;
+    prototype: Unzip;
 }
 /**
  * Asynchronously decompresses a ZIP archive

--- a/types/three/examples/jsm/lines/Line2.d.ts
+++ b/types/three/examples/jsm/lines/Line2.d.ts
@@ -9,3 +9,8 @@ export class Line2 extends LineSegments2 {
     constructor(geometry?: LineGeometry, material?: LineMaterial);
     readonly isLine2: true;
 }
+
+export interface Line2Constructor {
+    new (geometry?: LineGeometry, material?: LineMaterial): Line2;
+    prototype: Line2;
+}

--- a/types/three/examples/jsm/lines/LineGeometry.d.ts
+++ b/types/three/examples/jsm/lines/LineGeometry.d.ts
@@ -8,3 +8,8 @@ export class LineGeometry extends LineSegmentsGeometry {
 
     fromLine(line: Line): this;
 }
+
+export interface LineGeometryConstructor {
+    new (): LineGeometry;
+    prototype: LineGeometry;
+}

--- a/types/three/examples/jsm/lines/LineMaterial.d.ts
+++ b/types/three/examples/jsm/lines/LineMaterial.d.ts
@@ -29,3 +29,8 @@ export class LineMaterial extends ShaderMaterial {
     alphaToCoverage: boolean;
     worldUnits: boolean;
 }
+
+export interface LineMaterialConstructor {
+    new (parameters?: LineMaterialParameters): LineMaterial;
+    prototype: LineMaterial;
+}

--- a/types/three/examples/jsm/lines/LineSegments2.d.ts
+++ b/types/three/examples/jsm/lines/LineSegments2.d.ts
@@ -12,3 +12,8 @@ export class LineSegments2 extends Mesh {
 
     computeLineDistances(): this;
 }
+
+export interface LineSegments2Constructor {
+    new (geometry?: LineSegmentsGeometry, material?: LineMaterial): LineSegments2;
+    prototype: LineSegments2;
+}

--- a/types/three/examples/jsm/lines/LineSegmentsGeometry.d.ts
+++ b/types/three/examples/jsm/lines/LineSegmentsGeometry.d.ts
@@ -21,3 +21,8 @@ export class LineSegmentsGeometry extends InstancedBufferGeometry {
     setColors(array: number[] | Float32Array): this;
     setPositions(array: number[] | Float32Array): this;
 }
+
+export interface LineSegmentsGeometryConstructor {
+    new (): LineSegmentsGeometry;
+    prototype: LineSegmentsGeometry;
+}

--- a/types/three/examples/jsm/lines/Wireframe.d.ts
+++ b/types/three/examples/jsm/lines/Wireframe.d.ts
@@ -9,3 +9,8 @@ export class Wireframe extends Mesh {
 
     computeLineDistances(): this;
 }
+
+export interface WireframeConstructor {
+    new (geometry?: LineSegmentsGeometry, material?: LineMaterial): Wireframe;
+    prototype: Wireframe;
+}

--- a/types/three/examples/jsm/lines/WireframeGeometry2.d.ts
+++ b/types/three/examples/jsm/lines/WireframeGeometry2.d.ts
@@ -6,3 +6,8 @@ export class WireframeGeometry2 extends LineSegmentsGeometry {
     constructor(geometry: BufferGeometry);
     readonly sWireframeGeometry2: boolean;
 }
+
+export interface WireframeGeometry2Constructor {
+    new (geometry: BufferGeometry): WireframeGeometry2;
+    prototype: WireframeGeometry2;
+}

--- a/types/three/examples/jsm/loaders/3DMLoader.d.ts
+++ b/types/three/examples/jsm/loaders/3DMLoader.d.ts
@@ -15,3 +15,8 @@ export class Rhino3dmLoader extends Loader {
     setWorkerLimit(workerLimit: number): Rhino3dmLoader;
     dispose(): Rhino3dmLoader;
 }
+
+export interface Rhino3dmLoaderConstructor {
+    new (manager?: LoadingManager): Rhino3dmLoader;
+    prototype: Rhino3dmLoader;
+}

--- a/types/three/examples/jsm/loaders/3MFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/3MFLoader.d.ts
@@ -14,3 +14,8 @@ export class ThreeMFLoader extends Loader {
     parse(data: ArrayBuffer): Group;
     addExtension(extension: object): void;
 }
+
+export interface ThreeMFLoaderConstructor {
+    new (manager?: LoadingManager): ThreeMFLoader;
+    prototype: ThreeMFLoader;
+}

--- a/types/three/examples/jsm/loaders/AMFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/AMFLoader.d.ts
@@ -12,3 +12,8 @@ export class AMFLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Group>;
     parse(data: ArrayBuffer): Group;
 }
+
+export interface AMFLoaderConstructor {
+    new (manager?: LoadingManager): AMFLoader;
+    prototype: AMFLoader;
+}

--- a/types/three/examples/jsm/loaders/BVHLoader.d.ts
+++ b/types/three/examples/jsm/loaders/BVHLoader.d.ts
@@ -19,3 +19,8 @@ export class BVHLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<BVH>;
     parse(text: string): BVH;
 }
+
+export interface BVHLoaderConstructor {
+    new (manager?: LoadingManager): BVHLoader;
+    prototype: BVHLoader;
+}

--- a/types/three/examples/jsm/loaders/BasisTextureLoader.d.ts
+++ b/types/three/examples/jsm/loaders/BasisTextureLoader.d.ts
@@ -30,3 +30,8 @@ export class BasisTextureLoader extends Loader {
     setWorkerLimit(workerLimit: number): this;
     dispose(): void;
 }
+
+export interface BasisTextureLoaderConstructor {
+    new (manager?: LoadingManager): BasisTextureLoader;
+    prototype: BasisTextureLoader;
+}

--- a/types/three/examples/jsm/loaders/ColladaLoader.d.ts
+++ b/types/three/examples/jsm/loaders/ColladaLoader.d.ts
@@ -18,3 +18,8 @@ export class ColladaLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Collada>;
     parse(text: string, path: string): Collada;
 }
+
+export interface ColladaLoaderConstructor {
+    new (manager?: LoadingManager): ColladaLoader;
+    prototype: ColladaLoader;
+}

--- a/types/three/examples/jsm/loaders/DDSLoader.d.ts
+++ b/types/three/examples/jsm/loaders/DDSLoader.d.ts
@@ -14,3 +14,8 @@ export class DDSLoader extends CompressedTextureLoader {
 
     parse(buffer: ArrayBuffer, loadMipmaps: boolean): DDS;
 }
+
+export interface DDSLoaderConstructor {
+    new (manager?: LoadingManager): DDSLoader;
+    prototype: DDSLoader;
+}

--- a/types/three/examples/jsm/loaders/DRACOLoader.d.ts
+++ b/types/three/examples/jsm/loaders/DRACOLoader.d.ts
@@ -16,3 +16,8 @@ export class DRACOLoader extends Loader {
     preload(): DRACOLoader;
     dispose(): DRACOLoader;
 }
+
+export interface DRACOLoaderConstructor {
+    new (manager?: LoadingManager): DRACOLoader;
+    prototype: DRACOLoader;
+}

--- a/types/three/examples/jsm/loaders/EXRLoader.d.ts
+++ b/types/three/examples/jsm/loaders/EXRLoader.d.ts
@@ -16,3 +16,8 @@ export class EXRLoader extends DataTextureLoader {
     parse(buffer: ArrayBuffer): EXR;
     setDataType(type: TextureDataType): this;
 }
+
+export interface EXRLoaderConstructor {
+    new (manager?: LoadingManager): EXRLoader;
+    prototype: EXRLoader;
+}

--- a/types/three/examples/jsm/loaders/FBXLoader.d.ts
+++ b/types/three/examples/jsm/loaders/FBXLoader.d.ts
@@ -12,3 +12,8 @@ export class FBXLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Group>;
     parse(FBXBuffer: ArrayBuffer | string, path: string): Group;
 }
+
+export interface FBXLoaderConstructor {
+    new (manager?: LoadingManager): FBXLoader;
+    prototype: FBXLoader;
+}

--- a/types/three/examples/jsm/loaders/FontLoader.d.ts
+++ b/types/three/examples/jsm/loaders/FontLoader.d.ts
@@ -13,6 +13,11 @@ export class FontLoader extends Loader {
     parse(json: any): Font;
 }
 
+export interface FontLoaderConstructor {
+    new (manager?: LoadingManager): FontLoader;
+    prototype: FontLoader;
+}
+
 export class Font {
     constructor(jsondata: any);
 
@@ -24,4 +29,9 @@ export class Font {
     data: string;
 
     generateShapes(text: string, size: number): Shape[];
+}
+
+export interface FontConstructor {
+    new (jsondata: any): Font;
+    prototype: Font;
 }

--- a/types/three/examples/jsm/loaders/GCodeLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GCodeLoader.d.ts
@@ -13,3 +13,8 @@ export class GCodeLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Group>;
     parse(data: string): Group;
 }
+
+export interface GCodeLoaderConstructor {
+    new (manager?: LoadingManager): GCodeLoader;
+    prototype: GCodeLoader;
+}

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -68,6 +68,11 @@ export class GLTFLoader extends Loader {
     parseAsync(data: ArrayBuffer | string, path: string): Promise<void>;
 }
 
+export interface GLTFLoaderConstructor {
+    new (manager?: LoadingManager): GLTFLoader;
+    prototype: GLTFLoader;
+}
+
 export type GLTFReferenceType = 'materials' | 'nodes' | 'textures' | 'meshes';
 
 export interface GLTFReference {

--- a/types/three/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
+++ b/types/three/examples/jsm/loaders/HDRCubeTextureLoader.d.ts
@@ -16,3 +16,8 @@ export class HDRCubeTextureLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<CubeTexture>;
     setDataType(type: TextureDataType): this;
 }
+
+export interface HDRCubeTextureLoaderConstructor {
+    new (manager?: LoadingManager): HDRCubeTextureLoader;
+    prototype: HDRCubeTextureLoader;
+}

--- a/types/three/examples/jsm/loaders/KMZLoader.d.ts
+++ b/types/three/examples/jsm/loaders/KMZLoader.d.ts
@@ -14,3 +14,8 @@ export class KMZLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Collada>;
     parse(data: ArrayBuffer): Collada;
 }
+
+export interface KMZLoaderConstructor {
+    new (manager?: LoadingManager): KMZLoader;
+    prototype: KMZLoader;
+}

--- a/types/three/examples/jsm/loaders/KTX2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/KTX2Loader.d.ts
@@ -14,3 +14,8 @@ export class KTX2Loader extends CompressedTextureLoader {
         onError?: (event: ErrorEvent) => void,
     ): KTX2Loader;
 }
+
+export interface KTX2LoaderConstructor {
+    new (manager?: LoadingManager): KTX2Loader;
+    prototype: KTX2Loader;
+}

--- a/types/three/examples/jsm/loaders/KTXLoader.d.ts
+++ b/types/three/examples/jsm/loaders/KTXLoader.d.ts
@@ -14,3 +14,8 @@ export class KTXLoader extends CompressedTextureLoader {
 
     parse(buffer: ArrayBuffer, loadMipmaps: boolean): KTX;
 }
+
+export interface KTXLoaderConstructor {
+    new (manager?: LoadingManager): KTXLoader;
+    prototype: KTXLoader;
+}

--- a/types/three/examples/jsm/loaders/LDrawLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LDrawLoader.d.ts
@@ -24,3 +24,8 @@ export class LDrawLoader extends Loader {
     addMaterial(material: Material): void;
     getMaterial(colourCode: string): Material | null;
 }
+
+export interface LDrawLoaderConstructor {
+    new (manager?: LoadingManager): LDrawLoader;
+    prototype: LDrawLoader;
+}

--- a/types/three/examples/jsm/loaders/LUT3dlLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LUT3dlLoader.d.ts
@@ -18,3 +18,8 @@ export class LUT3dlLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<LUT3dlResult>;
     parse(data: string): LUT3dlResult;
 }
+
+export interface LUT3dlLoaderConstructor {
+    new (manager?: LoadingManager): LUT3dlLoader;
+    prototype: LUT3dlLoader;
+}

--- a/types/three/examples/jsm/loaders/LUTCubeLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LUTCubeLoader.d.ts
@@ -21,3 +21,8 @@ export class LUTCubeLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<LUTCubeResult>;
     parse(data: string): LUTCubeResult;
 }
+
+export interface LUTCubeLoaderConstructor {
+    new (manager?: LoadingManager): LUTCubeLoader;
+    prototype: LUTCubeLoader;
+}

--- a/types/three/examples/jsm/loaders/LWOLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LWOLoader.d.ts
@@ -24,3 +24,8 @@ export class LWOLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<LWO>;
     parse(data: ArrayBuffer, path: string, modelName: string): LWO;
 }
+
+export interface LWOLoaderConstructor {
+    new (manager?: LoadingManager, parameters?: LWOLoaderParameters): LWOLoader;
+    prototype: LWOLoader;
+}

--- a/types/three/examples/jsm/loaders/LogLuvLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LogLuvLoader.d.ts
@@ -17,3 +17,8 @@ export class LogLuvLoader extends DataTextureLoader {
 
     setDataType(value: TextureDataType): this;
 }
+
+export interface LogLuvLoaderConstructor {
+    new (manager: LoadingManager): LogLuvLoader;
+    prototype: LogLuvLoader;
+}

--- a/types/three/examples/jsm/loaders/LottieLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LottieLoader.d.ts
@@ -13,3 +13,8 @@ export class LottieLoader extends Loader {
 
     setQuality(value: number): void;
 }
+
+export interface LottieLoaderConstructor {
+    new (manager?: LoadingManager): LottieLoader;
+    prototype: LottieLoader;
+}

--- a/types/three/examples/jsm/loaders/MD2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/MD2Loader.d.ts
@@ -12,3 +12,8 @@ export class MD2Loader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<BufferGeometry>;
     parse(data: ArrayBuffer): BufferGeometry;
 }
+
+export interface MD2LoaderConstructor {
+    new (manager?: LoadingManager): MD2Loader;
+    prototype: MD2Loader;
+}

--- a/types/three/examples/jsm/loaders/MDDLoader.d.ts
+++ b/types/three/examples/jsm/loaders/MDDLoader.d.ts
@@ -17,3 +17,8 @@ export class MDDLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<MDD>;
     parse(data: ArrayBuffer): MDD;
 }
+
+export interface MDDLoaderConstructor {
+    new (manager?: LoadingManager): MDDLoader;
+    prototype: MDDLoader;
+}

--- a/types/three/examples/jsm/loaders/MMDLoader.d.ts
+++ b/types/three/examples/jsm/loaders/MMDLoader.d.ts
@@ -61,3 +61,8 @@ export class MMDLoader extends Loader {
     ): void;
     setAnimationPath(animationPath: string): this;
 }
+
+export interface MMDLoaderConstructor {
+    new (manager?: LoadingManager): MMDLoader;
+    prototype: MMDLoader;
+}

--- a/types/three/examples/jsm/loaders/MTLLoader.d.ts
+++ b/types/three/examples/jsm/loaders/MTLLoader.d.ts
@@ -55,6 +55,11 @@ export class MTLLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<MTLLoader.MaterialCreator>;
 }
 
+export interface MTLLoaderConstructor {
+    new (manager?: LoadingManager): MTLLoader;
+    prototype: MTLLoader;
+}
+
 export interface MaterialInfo {
     ks?: number[] | undefined;
     kd?: number[] | undefined;

--- a/types/three/examples/jsm/loaders/NRRDLoader.d.ts
+++ b/types/three/examples/jsm/loaders/NRRDLoader.d.ts
@@ -19,3 +19,8 @@ export class NRRDLoader {
     parseChars(array: number[], start?: number, end?: number): string;
     setPath(value: string): this;
 }
+
+export interface NRRDLoaderConstructor {
+    new (manager?: LoadingManager): NRRDLoader;
+    prototype: NRRDLoader;
+}

--- a/types/three/examples/jsm/loaders/OBJLoader.d.ts
+++ b/types/three/examples/jsm/loaders/OBJLoader.d.ts
@@ -15,3 +15,8 @@ export class OBJLoader extends Loader {
     parse(data: string): Group;
     setMaterials(materials: MTLLoader.MaterialCreator): this;
 }
+
+export interface OBJLoaderConstructor {
+    new (manager?: LoadingManager): OBJLoader;
+    prototype: OBJLoader;
+}

--- a/types/three/examples/jsm/loaders/PCDLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PCDLoader.d.ts
@@ -13,3 +13,8 @@ export class PCDLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Points>;
     parse(data: ArrayBuffer | string, url: string): Points;
 }
+
+export interface PCDLoaderConstructor {
+    new (manager?: LoadingManager): PCDLoader;
+    prototype: PCDLoader;
+}

--- a/types/three/examples/jsm/loaders/PDBLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PDBLoader.d.ts
@@ -20,3 +20,8 @@ export class PDBLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<PDB>;
     parse(text: string): PDB;
 }
+
+export interface PDBLoaderConstructor {
+    new (manager?: LoadingManager): PDBLoader;
+    prototype: PDBLoader;
+}

--- a/types/three/examples/jsm/loaders/PLYLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PLYLoader.d.ts
@@ -14,3 +14,8 @@ export class PLYLoader extends Loader {
     setPropertyNameMapping(mapping: object): void;
     parse(data: ArrayBuffer | string): BufferGeometry;
 }
+
+export interface PLYLoaderConstructor {
+    new (manager?: LoadingManager): PLYLoader;
+    prototype: PLYLoader;
+}

--- a/types/three/examples/jsm/loaders/PRWMLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PRWMLoader.d.ts
@@ -14,3 +14,8 @@ export class PRWMLoader extends Loader {
 
     static isBigEndianPlatform(): boolean;
 }
+
+export interface PRWMLoaderConstructor {
+    new (manager?: LoadingManager): PRWMLoader;
+    prototype: PRWMLoader;
+}

--- a/types/three/examples/jsm/loaders/PVRLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PVRLoader.d.ts
@@ -14,3 +14,8 @@ export class PVRLoader extends CompressedTextureLoader {
 
     parse(buffer: ArrayBuffer, loadMipmaps: boolean): PVR;
 }
+
+export interface PVRLoaderConstructor {
+    new (manager?: LoadingManager): PVRLoader;
+    prototype: PVRLoader;
+}

--- a/types/three/examples/jsm/loaders/RGBELoader.d.ts
+++ b/types/three/examples/jsm/loaders/RGBELoader.d.ts
@@ -18,3 +18,8 @@ export class RGBELoader extends DataTextureLoader {
     parse(buffer: ArrayBuffer): RGBE;
     setDataType(type: TextureDataType): this;
 }
+
+export interface RGBELoaderConstructor {
+    new (manager?: LoadingManager): RGBELoader;
+    prototype: RGBELoader;
+}

--- a/types/three/examples/jsm/loaders/RGBMLoader.d.ts
+++ b/types/three/examples/jsm/loaders/RGBMLoader.d.ts
@@ -30,3 +30,8 @@ export class RGBMLoader extends DataTextureLoader {
 
     setMaxRange(value: number): this;
 }
+
+export interface RGBMLoaderConstructor {
+    new (manager?: LoadingManager): RGBMLoader;
+    prototype: RGBMLoader;
+}

--- a/types/three/examples/jsm/loaders/STLLoader.d.ts
+++ b/types/three/examples/jsm/loaders/STLLoader.d.ts
@@ -12,3 +12,8 @@ export class STLLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<BufferGeometry>;
     parse(data: ArrayBuffer | string): BufferGeometry;
 }
+
+export interface STLLoaderConstructor {
+    new (manager?: LoadingManager): STLLoader;
+    prototype: STLLoader;
+}

--- a/types/three/examples/jsm/loaders/SVGLoader.d.ts
+++ b/types/three/examples/jsm/loaders/SVGLoader.d.ts
@@ -61,3 +61,8 @@ export class SVGLoader extends Loader {
     ): number;
     static createShapes(shapePath: ShapePath): Shape[];
 }
+
+export interface SVGLoaderConstructor {
+    new (manager?: LoadingManager): SVGLoader;
+    prototype: SVGLoader;
+}

--- a/types/three/examples/jsm/loaders/TDSLoader.d.ts
+++ b/types/three/examples/jsm/loaders/TDSLoader.d.ts
@@ -40,3 +40,8 @@ export class TDSLoader extends Loader {
     readWord(data: DataView): number;
     resetPosition(): void;
 }
+
+export interface TDSLoaderConstructor {
+    new (manager?: LoadingManager): TDSLoader;
+    prototype: TDSLoader;
+}

--- a/types/three/examples/jsm/loaders/TGALoader.d.ts
+++ b/types/three/examples/jsm/loaders/TGALoader.d.ts
@@ -12,3 +12,8 @@ export class TGALoader extends DataTextureLoader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<DataTexture>;
     parse(data: ArrayBuffer): DataTexture;
 }
+
+export interface TGALoaderConstructor {
+    new (manager?: LoadingManager): TGALoader;
+    prototype: TGALoader;
+}

--- a/types/three/examples/jsm/loaders/TTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/TTFLoader.d.ts
@@ -13,3 +13,8 @@ export class TTFLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<object>;
     parse(arraybuffer: ArrayBuffer): object;
 }
+
+export interface TTFLoaderConstructor {
+    new (manager?: LoadingManager): TTFLoader;
+    prototype: TTFLoader;
+}

--- a/types/three/examples/jsm/loaders/TiltLoader.d.ts
+++ b/types/three/examples/jsm/loaders/TiltLoader.d.ts
@@ -12,3 +12,8 @@ export class TiltLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Group>;
     parse(data: ArrayBuffer): Group;
 }
+
+export interface TiltLoaderConstructor {
+    new (manager?: LoadingManager): TiltLoader;
+    prototype: TiltLoader;
+}

--- a/types/three/examples/jsm/loaders/VOXLoader.d.ts
+++ b/types/three/examples/jsm/loaders/VOXLoader.d.ts
@@ -19,10 +19,25 @@ export class VOXLoader extends Loader {
     parse(data: ArrayBuffer): object[];
 }
 
+export interface VOXLoaderConstructor {
+    new (manager?: LoadingManager): VOXLoader;
+    prototype: VOXLoader;
+}
+
 export class VOXMesh extends Mesh {
     constructor(chunk: Chunk);
 }
 
+export interface VOXMeshConstructor {
+    new (chunk: Chunk): VOXMesh;
+    prototype: VOXMesh;
+}
+
 export class VOXData3DTexture extends Data3DTexture {
     constructor(chunk: Chunk);
+}
+
+export interface VOXData3DTextureConstructor {
+    new (chunk: Chunk): VOXData3DTexture;
+    prototype: VOXData3DTexture;
 }

--- a/types/three/examples/jsm/loaders/VRMLLoader.d.ts
+++ b/types/three/examples/jsm/loaders/VRMLLoader.d.ts
@@ -12,3 +12,8 @@ export class VRMLLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Scene>;
     parse(data: string, path: string): Scene;
 }
+
+export interface VRMLLoaderConstructor {
+    new (manager?: LoadingManager): VRMLLoader;
+    prototype: VRMLLoader;
+}

--- a/types/three/examples/jsm/loaders/VTKLoader.d.ts
+++ b/types/three/examples/jsm/loaders/VTKLoader.d.ts
@@ -12,3 +12,8 @@ export class VTKLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<BufferGeometry>;
     parse(data: ArrayBuffer | string, path: string): BufferGeometry;
 }
+
+export interface VTKLoaderConstructor {
+    new (manager?: LoadingManager): VTKLoader;
+    prototype: VTKLoader;
+}

--- a/types/three/examples/jsm/loaders/XYZLoader.d.ts
+++ b/types/three/examples/jsm/loaders/XYZLoader.d.ts
@@ -12,3 +12,8 @@ export class XYZLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<BufferGeometry>;
     parse(data: string, onLoad: (geometry: BufferGeometry) => void): object;
 }
+
+export interface XYZLoaderConstructor {
+    new (manager?: LoadingManager): XYZLoader;
+    prototype: XYZLoader;
+}

--- a/types/three/examples/jsm/math/Capsule.d.ts
+++ b/types/three/examples/jsm/math/Capsule.d.ts
@@ -25,3 +25,8 @@ export class Capsule {
     intersectsBox(box: Box3): boolean;
     lineLineMinimumPoints(line1: Line3, line2: Line3): Vector3[];
 }
+
+export interface CapsuleConstructor {
+    new (start?: Vector3, end?: Vector3, radius?: number): Capsule;
+    prototype: Capsule;
+}

--- a/types/three/examples/jsm/math/ConvexHull.d.ts
+++ b/types/three/examples/jsm/math/ConvexHull.d.ts
@@ -16,6 +16,11 @@ export class Face {
     getEdge(i: number): HalfEdge;
 }
 
+export interface FaceConstructor {
+    new (): Face;
+    prototype: Face;
+}
+
 export class HalfEdge {
     constructor(vertex: VertexNode, face: Face);
     vertex: VertexNode;
@@ -31,12 +36,22 @@ export class HalfEdge {
     tail(): VertexNode;
 }
 
+export interface HalfEdgeConstructor {
+    new (vertex: VertexNode, face: Face): HalfEdge;
+    prototype: HalfEdge;
+}
+
 export class VertexNode {
     constructor(point: Vector3);
     point: Vector3;
     prev: VertexNode;
     next: VertexNode;
     face: Face;
+}
+
+export interface VertexNodeConstructor {
+    new (point: Vector3): VertexNode;
+    prototype: VertexNode;
 }
 
 export class VertexList {
@@ -54,6 +69,11 @@ export class VertexList {
     last(): VertexNode;
     remove(vertex: VertexNode): this;
     removeSubList(a: VertexNode, b: VertexNode): this;
+}
+
+export interface VertexListConstructor {
+    new (): VertexList;
+    prototype: VertexList;
 }
 
 export class ConvexHull {
@@ -86,4 +106,9 @@ export class ConvexHull {
     resolveUnassignedPoints(newFaces: Face[]): this;
     setFromPoints(points: Vector3[]): this;
     setFromObject(object: Object3D): this;
+}
+
+export interface ConvexHullConstructor {
+    new (): ConvexHull;
+    prototype: ConvexHull;
 }

--- a/types/three/examples/jsm/math/ImprovedNoise.d.ts
+++ b/types/three/examples/jsm/math/ImprovedNoise.d.ts
@@ -2,3 +2,8 @@ export class ImprovedNoise {
     constructor();
     noise(x: number, y: number, z: number): number;
 }
+
+export interface ImprovedNoiseConstructor {
+    new (): ImprovedNoise;
+    prototype: ImprovedNoise;
+}

--- a/types/three/examples/jsm/math/Lut.d.ts
+++ b/types/three/examples/jsm/math/Lut.d.ts
@@ -19,6 +19,11 @@ export class Lut {
     updateCanvas(canvas: HTMLCanvasElement): HTMLCanvasElement;
 }
 
+export interface LutConstructor {
+    new (colormap?: string, numberofcolors?: number): Lut;
+    prototype: Lut;
+}
+
 export interface ColorMapKeywords {
     rainbow: number[][];
     cooltowarm: number[][];

--- a/types/three/examples/jsm/math/MeshSurfaceSampler.d.ts
+++ b/types/three/examples/jsm/math/MeshSurfaceSampler.d.ts
@@ -13,3 +13,8 @@ export class MeshSurfaceSampler {
     sampleFace(faceIndex: number, targetPosition: Vector3, targetNormal?: Vector3, targetColor?: Color): this;
     setWeightAttribute(name: string | null): this;
 }
+
+export interface MeshSurfaceSamplerConstructor {
+    new (mesh: Mesh): MeshSurfaceSampler;
+    prototype: MeshSurfaceSampler;
+}

--- a/types/three/examples/jsm/math/OBB.d.ts
+++ b/types/three/examples/jsm/math/OBB.d.ts
@@ -22,3 +22,8 @@ export class OBB {
     equals(obb: OBB): boolean;
     applyMatrix4(matrix: Matrix4): this;
 }
+
+export interface OBBConstructor {
+    new (center?: Vector3, halfSize?: Vector3, rotation?: Matrix3): OBB;
+    prototype: OBB;
+}

--- a/types/three/examples/jsm/math/Octree.d.ts
+++ b/types/three/examples/jsm/math/Octree.d.ts
@@ -22,3 +22,8 @@ export class Octree {
     rayIntersect(ray: Ray): any;
     fromGraphNode(group: Object3D): this;
 }
+
+export interface OctreeConstructor {
+    new (box?: Box3): Octree;
+    prototype: Octree;
+}

--- a/types/three/examples/jsm/math/SimplexNoise.d.ts
+++ b/types/three/examples/jsm/math/SimplexNoise.d.ts
@@ -7,3 +7,8 @@ export class SimplexNoise {
     noise3d(xin: number, yin: number, zin: number): number;
     noise4d(x: number, y: number, z: number, w: number): number;
 }
+
+export interface SimplexNoiseConstructor {
+    new (r?: object): SimplexNoise;
+    prototype: SimplexNoise;
+}

--- a/types/three/examples/jsm/misc/ConvexObjectBreaker.d.ts
+++ b/types/three/examples/jsm/misc/ConvexObjectBreaker.d.ts
@@ -23,3 +23,8 @@ export class ConvexObjectBreaker {
     ): Object3D[];
     cutByPlane(object: Object3D, plane: Plane, output: CutByPlaneOutput): number;
 }
+
+export interface ConvexObjectBreakerConstructor {
+    new (minSizeForBreak?: number, smallDelta?: number): ConvexObjectBreaker;
+    prototype: ConvexObjectBreaker;
+}

--- a/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -50,3 +50,8 @@ export class GPUComputationRenderer {
     renderTexture(input: Texture, output: Texture): void;
     doRenderTarget(material: Material, output: WebGLRenderTarget): void;
 }
+
+export interface GPUComputationRendererConstructor {
+    new (sizeX: number, sizeY: number, renderer: WebGLRenderer): GPUComputationRenderer;
+    prototype: GPUComputationRenderer;
+}

--- a/types/three/examples/jsm/misc/Gyroscope.d.ts
+++ b/types/three/examples/jsm/misc/Gyroscope.d.ts
@@ -3,3 +3,8 @@ import { Object3D } from '../../../src/Three';
 export class Gyroscope extends Object3D {
     constructor();
 }
+
+export interface GyroscopeConstructor {
+    new (): Gyroscope;
+    prototype: Gyroscope;
+}

--- a/types/three/examples/jsm/misc/MD2Character.d.ts
+++ b/types/three/examples/jsm/misc/MD2Character.d.ts
@@ -31,3 +31,8 @@ export class MD2Character {
     syncWeaponAnimation(): void;
     update(delta: number): void;
 }
+
+export interface MD2CharacterConstructor {
+    new (): MD2Character;
+    prototype: MD2Character;
+}

--- a/types/three/examples/jsm/misc/MD2CharacterComplex.d.ts
+++ b/types/three/examples/jsm/misc/MD2CharacterComplex.d.ts
@@ -45,3 +45,8 @@ export class MD2CharacterComplex {
     updateBehaviors(): void;
     updateMovementModel(delta: number): void;
 }
+
+export interface MD2CharacterComplexConstructor {
+    new (): MD2CharacterComplex;
+    prototype: MD2CharacterComplex;
+}

--- a/types/three/examples/jsm/misc/MorphAnimMesh.d.ts
+++ b/types/three/examples/jsm/misc/MorphAnimMesh.d.ts
@@ -11,3 +11,8 @@ export class MorphAnimMesh extends Mesh {
     updateAnimation(delta: number): void;
     copy(source: MorphAnimMesh): this;
 }
+
+export interface MorphAnimMeshConstructor {
+    new (geometry: BufferGeometry, material: Material): MorphAnimMesh;
+    prototype: MorphAnimMesh;
+}

--- a/types/three/examples/jsm/misc/MorphBlendMesh.d.ts
+++ b/types/three/examples/jsm/misc/MorphBlendMesh.d.ts
@@ -19,3 +19,8 @@ export class MorphBlendMesh extends Mesh {
     stopAnimation(name: string): void;
     update(delta: number): void;
 }
+
+export interface MorphBlendMeshConstructor {
+    new (geometry: BufferGeometry, material: Material): MorphBlendMesh;
+    prototype: MorphBlendMesh;
+}

--- a/types/three/examples/jsm/misc/ProgressiveLightMap.d.ts
+++ b/types/three/examples/jsm/misc/ProgressiveLightMap.d.ts
@@ -59,3 +59,8 @@ export class ProgressiveLightMap {
 
     private _initializeBlurPlane(res: number, lightMap?: Texture | null): void;
 }
+
+export interface ProgressiveLightMapConstructor {
+    new (renderer: WebGLRenderer, res?: number): ProgressiveLightMap;
+    prototype: ProgressiveLightMap;
+}

--- a/types/three/examples/jsm/misc/RollerCoaster.d.ts
+++ b/types/three/examples/jsm/misc/RollerCoaster.d.ts
@@ -4,18 +4,43 @@ export class RollerCoasterGeometry extends BufferGeometry {
     constructor(curve: Curve<Vector3>, divisions: number);
 }
 
+export interface RollerCoasterGeometryConstructor {
+    new (curve: Curve<Vector3>, divisions: number): RollerCoasterGeometry;
+    prototype: RollerCoasterGeometry;
+}
+
 export class RollerCoasterLiftersGeometry extends BufferGeometry {
     constructor(curve: Curve<Vector3>, divisions: number);
+}
+
+export interface RollerCoasterLiftersGeometryConstructor {
+    new (curve: Curve<Vector3>, divisions: number): RollerCoasterLiftersGeometry;
+    prototype: RollerCoasterLiftersGeometry;
 }
 
 export class RollerCoasterShadowGeometry extends BufferGeometry {
     constructor(curve: Curve<Vector3>, divisions: number);
 }
 
+export interface RollerCoasterShadowGeometryConstructor {
+    new (curve: Curve<Vector3>, divisions: number): RollerCoasterShadowGeometry;
+    prototype: RollerCoasterShadowGeometry;
+}
+
 export class SkyGeometry extends BufferGeometry {
     constructor(curve: Curve<Vector3>, divisions: number);
 }
 
+export interface SkyGeometryConstructor {
+    new (curve: Curve<Vector3>, divisions: number): SkyGeometry;
+    prototype: SkyGeometry;
+}
+
 export class TreesGeometry extends BufferGeometry {
     constructor(landscape: Mesh);
+}
+
+export interface TreesGeometryConstructor {
+    new (landscape: Mesh): TreesGeometry;
+    prototype: TreesGeometry;
 }

--- a/types/three/examples/jsm/misc/TubePainter.d.ts
+++ b/types/three/examples/jsm/misc/TubePainter.d.ts
@@ -8,3 +8,8 @@ export class TubePainter {
     stroke(position1: Vector3, position2: Vector3, matrix1: Matrix4, matrix2: Matrix4): void;
     updateGeometry(start: number, end: number): void;
 }
+
+export interface TubePainterConstructor {
+    new (): TubePainter;
+    prototype: TubePainter;
+}

--- a/types/three/examples/jsm/misc/Volume.d.ts
+++ b/types/three/examples/jsm/misc/Volume.d.ts
@@ -35,3 +35,8 @@ export class Volume {
     repaintAllSlices(): this;
     computeMinMax(): number[];
 }
+
+export interface VolumeConstructor {
+    new (xLength?: number, yLength?: number, zLength?: number, type?: string, arrayBuffer?: ArrayLike<number>): Volume;
+    prototype: Volume;
+}

--- a/types/three/examples/jsm/misc/VolumeSlice.d.ts
+++ b/types/three/examples/jsm/misc/VolumeSlice.d.ts
@@ -26,3 +26,8 @@ export class VolumeSlice {
     repaint(): void;
     updateGeometry(): void;
 }
+
+export interface VolumeSliceConstructor {
+    new (volume: Volume, index?: number, axis?: string): VolumeSlice;
+    prototype: VolumeSlice;
+}

--- a/types/three/examples/jsm/modifiers/CurveModifier.d.ts
+++ b/types/three/examples/jsm/modifiers/CurveModifier.d.ts
@@ -35,6 +35,11 @@ export class Flow {
     moveAlongCurve(amount: number): void;
 }
 
+export interface FlowConstructor {
+    new (mesh: Mesh, numberOfCurves?: number): Flow;
+    prototype: Flow;
+}
+
 export class InstancedFlow extends Flow {
     constructor(count: number, curveCount: number, geometry: BufferGeometry, material: Material);
     object3D: InstancedMesh;
@@ -43,4 +48,9 @@ export class InstancedFlow extends Flow {
 
     moveIndividualAlongCurve(index: number, offset: number): void;
     setCurve(index: number, curveNo: number): void;
+}
+
+export interface InstancedFlowConstructor {
+    new (count: number, curveCount: number, geometry: BufferGeometry, material: Material): InstancedFlow;
+    prototype: InstancedFlow;
 }

--- a/types/three/examples/jsm/modifiers/EdgeSplitModifier.d.ts
+++ b/types/three/examples/jsm/modifiers/EdgeSplitModifier.d.ts
@@ -17,3 +17,8 @@ export class EdgeSplitModifier {
      */
     modify(geometry: BufferGeometry, cutOffPoint: number, tryKeepNormals: boolean): BufferGeometry;
 }
+
+export interface EdgeSplitModifierConstructor {
+    new (): EdgeSplitModifier;
+    prototype: EdgeSplitModifier;
+}

--- a/types/three/examples/jsm/modifiers/SimplifyModifier.d.ts
+++ b/types/three/examples/jsm/modifiers/SimplifyModifier.d.ts
@@ -4,3 +4,8 @@ export class SimplifyModifier {
     constructor();
     modify(geometry: BufferGeometry, count: number): BufferGeometry;
 }
+
+export interface SimplifyModifierConstructor {
+    new (): SimplifyModifier;
+    prototype: SimplifyModifier;
+}

--- a/types/three/examples/jsm/modifiers/TessellateModifier.d.ts
+++ b/types/three/examples/jsm/modifiers/TessellateModifier.d.ts
@@ -7,3 +7,8 @@ export class TessellateModifier {
 
     modify<TGeometry extends BufferGeometry>(geometry: TGeometry): TGeometry;
 }
+
+export interface TessellateModifierConstructor {
+    new (maxEdgeLength?: number, maxIterations?: number): TessellateModifier;
+    prototype: TessellateModifier;
+}

--- a/types/three/examples/jsm/objects/Lensflare.d.ts
+++ b/types/three/examples/jsm/objects/Lensflare.d.ts
@@ -8,10 +8,20 @@ export class LensflareElement {
     color: Color;
 }
 
+export interface LensflareElementConstructor {
+    new (texture: Texture, size?: number, distance?: number, color?: Color): LensflareElement;
+    prototype: LensflareElement;
+}
+
 export class Lensflare extends Mesh {
     constructor();
     readonly isLensflare: true;
 
     addElement(element: LensflareElement): void;
     dispose(): void;
+}
+
+export interface LensflareConstructor {
+    new (): Lensflare;
+    prototype: Lensflare;
 }

--- a/types/three/examples/jsm/objects/LightningStorm.d.ts
+++ b/types/three/examples/jsm/objects/LightningStorm.d.ts
@@ -30,3 +30,8 @@ export class LightningStorm {
     copy(source: LightningStorm): LightningStorm;
     clone(): this;
 }
+
+export interface LightningStormConstructor {
+    new (stormParams?: StormParams): LightningStorm;
+    prototype: LightningStorm;
+}

--- a/types/three/examples/jsm/objects/MarchingCubes.d.ts
+++ b/types/three/examples/jsm/objects/MarchingCubes.d.ts
@@ -71,5 +71,16 @@ export class MarchingCubes extends Mesh {
     generateBufferGeometry(): BufferGeometry;
 }
 
+export interface MarchingCubesConstructor {
+    new (
+        resolution: number,
+        material: Material,
+        enableUvs?: boolean,
+        enableColors?: boolean,
+        maxPolyCount?: number,
+    ): MarchingCubes;
+    prototype: MarchingCubes;
+}
+
 export const edgeTable: Int32Array[];
 export const triTable: Int32Array[];

--- a/types/three/examples/jsm/objects/Reflector.d.ts
+++ b/types/three/examples/jsm/objects/Reflector.d.ts
@@ -17,3 +17,8 @@ export class Reflector extends Mesh {
 
     dispose(): void;
 }
+
+export interface ReflectorConstructor {
+    new (geometry?: BufferGeometry, options?: ReflectorOptions): Reflector;
+    prototype: Reflector;
+}

--- a/types/three/examples/jsm/objects/ReflectorForSSRPass.d.ts
+++ b/types/three/examples/jsm/objects/ReflectorForSSRPass.d.ts
@@ -55,3 +55,8 @@ export class Reflector<TGeometry extends BufferGeometry = BufferGeometry> extend
 
     getRenderTarget: () => WebGLRenderTarget;
 }
+
+export interface ReflectorConstructor<TGeometry extends BufferGeometry = BufferGeometry> {
+    new (geometry: TGeometry, options: ReflectorOptions): Reflector<TGeometry>;
+    prototype: Reflector<TGeometry>;
+}

--- a/types/three/examples/jsm/objects/Refractor.d.ts
+++ b/types/three/examples/jsm/objects/Refractor.d.ts
@@ -17,3 +17,8 @@ export class Refractor extends Mesh {
 
     dispose(): void;
 }
+
+export interface RefractorConstructor {
+    new (geometry?: BufferGeometry, options?: RefractorOptions): Refractor;
+    prototype: Refractor;
+}

--- a/types/three/examples/jsm/objects/ShadowMesh.d.ts
+++ b/types/three/examples/jsm/objects/ShadowMesh.d.ts
@@ -5,3 +5,8 @@ export class ShadowMesh extends Mesh {
 
     update(plane: Plane, lightPosition4D: Vector4): void;
 }
+
+export interface ShadowMeshConstructor {
+    new (): ShadowMesh;
+    prototype: ShadowMesh;
+}

--- a/types/three/examples/jsm/objects/Sky.d.ts
+++ b/types/three/examples/jsm/objects/Sky.d.ts
@@ -8,3 +8,8 @@ export class Sky extends Mesh {
 
     static SkyShader: object;
 }
+
+export interface SkyConstructor {
+    new (): Sky;
+    prototype: Sky;
+}

--- a/types/three/examples/jsm/objects/Water.d.ts
+++ b/types/three/examples/jsm/objects/Water.d.ts
@@ -20,3 +20,8 @@ export class Water extends Mesh {
     material: ShaderMaterial;
     constructor(geometry: BufferGeometry, options: WaterOptions);
 }
+
+export interface WaterConstructor {
+    new (geometry: BufferGeometry, options: WaterOptions): Water;
+    prototype: Water;
+}

--- a/types/three/examples/jsm/objects/Water2.d.ts
+++ b/types/three/examples/jsm/objects/Water2.d.ts
@@ -28,3 +28,8 @@ export class Water extends Mesh {
     material: ShaderMaterial;
     constructor(geometry: BufferGeometry, options: Water2Options);
 }
+
+export interface WaterConstructor {
+    new (geometry: BufferGeometry, options: Water2Options): Water;
+    prototype: Water;
+}

--- a/types/three/examples/jsm/physics/AmmoPhysics.d.ts
+++ b/types/three/examples/jsm/physics/AmmoPhysics.d.ts
@@ -5,3 +5,8 @@ export class AmmoPhysics {
     addMesh(mesh: Mesh, mass: number): void;
     setMeshPosition(mesh: Mesh, position: Vector3, index: number): void;
 }
+
+export interface AmmoPhysicsConstructor {
+    new (): AmmoPhysics;
+    prototype: AmmoPhysics;
+}

--- a/types/three/examples/jsm/postprocessing/AdaptiveToneMappingPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/AdaptiveToneMappingPass.d.ts
@@ -27,3 +27,8 @@ export class AdaptiveToneMappingPass extends Pass {
     setMiddleGrey(middleGrey: number): void;
     dispose(): void;
 }
+
+export interface AdaptiveToneMappingPassConstructor {
+    new (adaptive?: boolean, resolution?: number): AdaptiveToneMappingPass;
+    prototype: AdaptiveToneMappingPass;
+}

--- a/types/three/examples/jsm/postprocessing/AfterimagePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/AfterimagePass.d.ts
@@ -12,3 +12,8 @@ export class AfterimagePass extends Pass {
     compFsQuad: object;
     copyFsQuad: object;
 }
+
+export interface AfterimagePassConstructor {
+    new (damp?: number): AfterimagePass;
+    prototype: AfterimagePass;
+}

--- a/types/three/examples/jsm/postprocessing/BloomPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/BloomPass.d.ts
@@ -12,3 +12,8 @@ export class BloomPass extends Pass {
     materialConvolution: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface BloomPassConstructor {
+    new (strength?: number, kernelSize?: number, sigma?: number, resolution?: number): BloomPass;
+    prototype: BloomPass;
+}

--- a/types/three/examples/jsm/postprocessing/BokehPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/BokehPass.d.ts
@@ -23,3 +23,8 @@ export class BokehPass extends Pass {
     fsQuad: object;
     oldClearColor: Color;
 }
+
+export interface BokehPassConstructor {
+    new (scene: Scene, camera: Camera, params: BokehPassParamters): BokehPass;
+    prototype: BokehPass;
+}

--- a/types/three/examples/jsm/postprocessing/ClearPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ClearPass.d.ts
@@ -7,3 +7,8 @@ export class ClearPass extends Pass {
     clearColor: ColorRepresentation;
     clearAlpha: number;
 }
+
+export interface ClearPassConstructor {
+    new (clearColor?: ColorRepresentation, clearAlpha?: number): ClearPass;
+    prototype: ClearPass;
+}

--- a/types/three/examples/jsm/postprocessing/CubeTexturePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/CubeTexturePass.d.ts
@@ -12,3 +12,8 @@ export class CubeTexturePass extends Pass {
     cubeScene: Scene;
     cubeCamera: PerspectiveCamera;
 }
+
+export interface CubeTexturePassConstructor {
+    new (camera: PerspectiveCamera, envMap?: CubeTexture, opacity?: number): CubeTexturePass;
+    prototype: CubeTexturePass;
+}

--- a/types/three/examples/jsm/postprocessing/DotScreenPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/DotScreenPass.d.ts
@@ -8,3 +8,8 @@ export class DotScreenPass extends Pass {
     material: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface DotScreenPassConstructor {
+    new (center?: Vector2, angle?: number, scale?: number): DotScreenPass;
+    prototype: DotScreenPass;
+}

--- a/types/three/examples/jsm/postprocessing/EffectComposer.d.ts
+++ b/types/three/examples/jsm/postprocessing/EffectComposer.d.ts
@@ -28,3 +28,8 @@ export class EffectComposer {
     setSize(width: number, height: number): void;
     setPixelRatio(pixelRatio: number): void;
 }
+
+export interface EffectComposerConstructor {
+    new (renderer: WebGLRenderer, renderTarget?: WebGLRenderTarget): EffectComposer;
+    prototype: EffectComposer;
+}

--- a/types/three/examples/jsm/postprocessing/FilmPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/FilmPass.d.ts
@@ -8,3 +8,8 @@ export class FilmPass extends Pass {
     material: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface FilmPassConstructor {
+    new (noiseIntensity?: number, scanlinesIntensity?: number, scanlinesCount?: number, grayscale?: number): FilmPass;
+    prototype: FilmPass;
+}

--- a/types/three/examples/jsm/postprocessing/GlitchPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/GlitchPass.d.ts
@@ -14,3 +14,8 @@ export class GlitchPass extends Pass {
     generateTrigger(): void;
     generateHeightmap(dt_size: number): DataTexture;
 }
+
+export interface GlitchPassConstructor {
+    new (dt_size?: number): GlitchPass;
+    prototype: GlitchPass;
+}

--- a/types/three/examples/jsm/postprocessing/HalftonePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/HalftonePass.d.ts
@@ -21,3 +21,8 @@ export class HalftonePass extends Pass {
     material: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface HalftonePassConstructor {
+    new (width: number, height: number, params: HalftonePassParameters): HalftonePass;
+    prototype: HalftonePass;
+}

--- a/types/three/examples/jsm/postprocessing/LUTPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/LUTPass.d.ts
@@ -11,3 +11,8 @@ export class LUTPass extends ShaderPass {
     intensity?: number;
     constructor(params: LUTPassParameters);
 }
+
+export interface LUTPassConstructor {
+    new (params: LUTPassParameters): LUTPass;
+    prototype: LUTPass;
+}

--- a/types/three/examples/jsm/postprocessing/MaskPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/MaskPass.d.ts
@@ -9,6 +9,16 @@ export class MaskPass extends Pass {
     inverse: boolean;
 }
 
+export interface MaskPassConstructor {
+    new (scene: Scene, camera: Camera): MaskPass;
+    prototype: MaskPass;
+}
+
 export class ClearMaskPass extends Pass {
     constructor();
+}
+
+export interface ClearMaskPassConstructor {
+    new (): ClearMaskPass;
+    prototype: ClearMaskPass;
 }

--- a/types/three/examples/jsm/postprocessing/OutlinePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/OutlinePass.d.ts
@@ -62,3 +62,8 @@ export class OutlinePass extends Pass {
     getSeperableBlurMaterial(): ShaderMaterial;
     getOverlayMaterial(): ShaderMaterial;
 }
+
+export interface OutlinePassConstructor {
+    new (resolution: Vector2, scene: Scene, camera: Camera, selectedObjects?: Object3D[]): OutlinePass;
+    prototype: OutlinePass;
+}

--- a/types/three/examples/jsm/postprocessing/Pass.d.ts
+++ b/types/three/examples/jsm/postprocessing/Pass.d.ts
@@ -17,6 +17,11 @@ export class Pass {
     ): void;
 }
 
+export interface PassConstructor {
+    new (): Pass;
+    prototype: Pass;
+}
+
 export class FullScreenQuad {
     constructor(material?: Material);
 
@@ -24,4 +29,9 @@ export class FullScreenQuad {
     dispose(): void;
 
     material: Material;
+}
+
+export interface FullScreenQuadConstructor {
+    new (material?: Material): FullScreenQuad;
+    prototype: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/RenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/RenderPass.d.ts
@@ -11,3 +11,14 @@ export class RenderPass extends Pass {
     clearAlpha: number;
     clearDepth: boolean;
 }
+
+export interface RenderPassConstructor {
+    new (
+        scene: Scene,
+        camera: Camera,
+        overrideMaterial?: Material,
+        clearColor?: Color,
+        clearAlpha?: number,
+    ): RenderPass;
+    prototype: RenderPass;
+}

--- a/types/three/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SAOPass.d.ts
@@ -77,3 +77,8 @@ export class SAOPass extends Pass {
         clearAlpha?: number,
     ): void;
 }
+
+export interface SAOPassConstructor {
+    new (scene: Scene, camera: Camera, depthTexture?: boolean, useNormals?: boolean, resolution?: Vector2): SAOPass;
+    prototype: SAOPass;
+}

--- a/types/three/examples/jsm/postprocessing/SMAAPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SMAAPass.d.ts
@@ -19,3 +19,8 @@ export class SMAAPass extends Pass {
     getAreaTexture(): string;
     getSearchTexture(): string;
 }
+
+export interface SMAAPassConstructor {
+    new (width: number, height: number): SMAAPass;
+    prototype: SMAAPass;
+}

--- a/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
@@ -15,3 +15,8 @@ export class SSAARenderPass extends Pass {
     fsQuad: object;
     sampleRenderTarget: undefined | WebGLRenderTarget;
 }
+
+export interface SSAARenderPassConstructor {
+    new (scene: Scene, camera: Camera, clearColor?: ColorRepresentation, clearAlpha?: number): SSAARenderPass;
+    prototype: SSAARenderPass;
+}

--- a/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -69,3 +69,8 @@ export class SSAOPass extends Pass {
         clearAlpha?: number,
     ): void;
 }
+
+export interface SSAOPassConstructor {
+    new (scene: Scene, camera: Camera, width?: number, height?: number): SSAOPass;
+    prototype: SSAOPass;
+}

--- a/types/three/examples/jsm/postprocessing/SSRPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSRPass.d.ts
@@ -122,3 +122,8 @@ export class SSRPass extends Pass {
         clearAlpha: ColorRepresentation,
     ) => void;
 }
+
+export interface SSRPassConstructor {
+    new (params: SSRPassParams): SSRPass;
+    prototype: SSRPass;
+}

--- a/types/three/examples/jsm/postprocessing/SavePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SavePass.d.ts
@@ -10,3 +10,8 @@ export class SavePass extends Pass {
     material: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface SavePassConstructor {
+    new (renderTarget: WebGLRenderTarget): SavePass;
+    prototype: SavePass;
+}

--- a/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
@@ -9,3 +9,8 @@ export class ShaderPass extends Pass {
     material: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface ShaderPassConstructor {
+    new (shader: object, textureID?: string): ShaderPass;
+    prototype: ShaderPass;
+}

--- a/types/three/examples/jsm/postprocessing/TAARenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/TAARenderPass.d.ts
@@ -6,3 +6,8 @@ export class TAARenderPass extends SSAARenderPass {
     constructor(scene: Scene, camera: Camera, clearColor: ColorRepresentation, clearAlpha: number);
     accumulate: boolean;
 }
+
+export interface TAARenderPassConstructor {
+    new (scene: Scene, camera: Camera, clearColor: ColorRepresentation, clearAlpha: number): TAARenderPass;
+    prototype: TAARenderPass;
+}

--- a/types/three/examples/jsm/postprocessing/TexturePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/TexturePass.d.ts
@@ -10,3 +10,8 @@ export class TexturePass extends Pass {
     material: ShaderMaterial;
     fsQuad: object;
 }
+
+export interface TexturePassConstructor {
+    new (map: Texture, opacity?: number): TexturePass;
+    prototype: TexturePass;
+}

--- a/types/three/examples/jsm/postprocessing/UnrealBloomPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/UnrealBloomPass.d.ts
@@ -29,3 +29,8 @@ export class UnrealBloomPass extends Pass {
     getSeperableBlurMaterial(): ShaderMaterial;
     getCompositeMaterial(): ShaderMaterial;
 }
+
+export interface UnrealBloomPassConstructor {
+    new (resolution: Vector2, strength: number, radius: number, threshold: number): UnrealBloomPass;
+    prototype: UnrealBloomPass;
+}

--- a/types/three/examples/jsm/renderers/CSS2DRenderer.d.ts
+++ b/types/three/examples/jsm/renderers/CSS2DRenderer.d.ts
@@ -8,6 +8,11 @@ export class CSS2DObject extends Object3D {
     onAfterRender: (renderer: unknown, scene: Scene, camera: Camera) => void;
 }
 
+export interface CSS2DObjectConstructor {
+    new (element: HTMLElement): CSS2DObject;
+    prototype: CSS2DObject;
+}
+
 export type CSS2DParameters = {
     element?: HTMLElement;
 };
@@ -19,4 +24,9 @@ export class CSS2DRenderer {
     getSize(): { width: number; height: number };
     setSize(width: number, height: number): void;
     render(scene: Scene, camera: Camera): void;
+}
+
+export interface CSS2DRendererConstructor {
+    new (parameters?: CSS2DParameters): CSS2DRenderer;
+    prototype: CSS2DRenderer;
 }

--- a/types/three/examples/jsm/renderers/CSS3DRenderer.d.ts
+++ b/types/three/examples/jsm/renderers/CSS3DRenderer.d.ts
@@ -8,8 +8,18 @@ export class CSS3DObject extends Object3D {
     onAfterRender: (renderer: unknown, scene: Scene, camera: Camera) => void;
 }
 
+export interface CSS3DObjectConstructor {
+    new (element: HTMLElement): CSS3DObject;
+    prototype: CSS3DObject;
+}
+
 export class CSS3DSprite extends CSS3DObject {
     constructor(element: HTMLElement);
+}
+
+export interface CSS3DSpriteConstructor {
+    new (element: HTMLElement): CSS3DSprite;
+    prototype: CSS3DSprite;
 }
 
 export type CSS3DParameters = {
@@ -23,4 +33,9 @@ export class CSS3DRenderer {
     getSize(): { width: number; height: number };
     setSize(width: number, height: number): void;
     render(scene: Scene, camera: Camera): void;
+}
+
+export interface CSS3DRendererConstructor {
+    new (parameters?: CSS3DParameters): CSS3DRenderer;
+    prototype: CSS3DRenderer;
 }

--- a/types/three/examples/jsm/renderers/Projector.d.ts
+++ b/types/three/examples/jsm/renderers/Projector.d.ts
@@ -58,3 +58,8 @@ export class Projector {
 
     projectScene(scene: Scene, camera: Camera, sortObjects: boolean, sortElements: boolean): any;
 }
+
+export interface ProjectorConstructor {
+    new (): Projector;
+    prototype: Projector;
+}

--- a/types/three/examples/jsm/renderers/SVGRenderer.d.ts
+++ b/types/three/examples/jsm/renderers/SVGRenderer.d.ts
@@ -5,6 +5,11 @@ export class SVGObject extends Object3D {
     node: SVGElement;
 }
 
+export interface SVGObjectConstructor {
+    new (node: SVGElement): SVGObject;
+    prototype: SVGObject;
+}
+
 export class SVGRenderer {
     constructor();
     domElement: SVGElement;
@@ -22,4 +27,9 @@ export class SVGRenderer {
     setPrecision(precision: number): void;
     clear(): void;
     render(scene: Scene, camera: Camera): void;
+}
+
+export interface SVGRendererConstructor {
+    new (): SVGRenderer;
+    prototype: SVGRenderer;
 }

--- a/types/three/examples/jsm/utils/PackedPhongMaterial.d.ts
+++ b/types/three/examples/jsm/utils/PackedPhongMaterial.d.ts
@@ -8,3 +8,8 @@ import { MeshPhongMaterial, MeshPhongMaterialParameters } from '../../../src/Thr
 export class PackedPhongMaterial extends MeshPhongMaterial {
     constructor(parameters: MeshPhongMaterialParameters);
 }
+
+export interface PackedPhongMaterialConstructor {
+    new (parameters: MeshPhongMaterialParameters): PackedPhongMaterial;
+    prototype: PackedPhongMaterial;
+}

--- a/types/three/examples/jsm/utils/ShadowMapViewer.d.ts
+++ b/types/three/examples/jsm/utils/ShadowMapViewer.d.ts
@@ -22,3 +22,8 @@ export class ShadowMapViewer {
     updateForWindowResize(): void;
     update(): void;
 }
+
+export interface ShadowMapViewerConstructor {
+    new (light: Light): ShadowMapViewer;
+    prototype: ShadowMapViewer;
+}

--- a/types/three/examples/jsm/webxr/OculusHandModel.d.ts
+++ b/types/three/examples/jsm/webxr/OculusHandModel.d.ts
@@ -17,3 +17,8 @@ export class OculusHandModel extends Object3D {
 
     checkButton(button: Object3D): void;
 }
+
+export interface OculusHandModelConstructor {
+    new (controller: Object3D): OculusHandModel;
+    prototype: OculusHandModel;
+}

--- a/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
+++ b/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
@@ -61,3 +61,8 @@ export class OculusHandPointerModel extends Object3D {
 
     public setCursor(distance: number): void;
 }
+
+export interface OculusHandPointerModelConstructor {
+    new (hand: Object3D, controller: Object3D): OculusHandPointerModel;
+    prototype: OculusHandPointerModel;
+}

--- a/types/three/examples/jsm/webxr/XRControllerModelFactory.d.ts
+++ b/types/three/examples/jsm/webxr/XRControllerModelFactory.d.ts
@@ -10,10 +10,20 @@ export class XRControllerModel extends Object3D {
     setEnvironmentMap(envMap: Texture): XRControllerModel;
 }
 
+export interface XRControllerModelConstructor {
+    new (): XRControllerModel;
+    prototype: XRControllerModel;
+}
+
 export class XRControllerModelFactory {
     constructor(gltfLoader?: GLTFLoader);
     gltfLoader: GLTFLoader | null;
     path: string;
 
     createControllerModel(controller: Group): XRControllerModel;
+}
+
+export interface XRControllerModelFactoryConstructor {
+    new (gltfLoader?: GLTFLoader): XRControllerModelFactory;
+    prototype: XRControllerModelFactory;
 }

--- a/types/three/examples/jsm/webxr/XREstimatedLight.d.ts
+++ b/types/three/examples/jsm/webxr/XREstimatedLight.d.ts
@@ -23,10 +23,26 @@ export class SessionLightProbe {
     dispose: () => void;
 }
 
+export interface SessionLightProbeConstructor {
+    new (
+        xrLight: XREstimatedLight,
+        renderer: WebGLRenderer,
+        lightProbe: unknown,
+        environmentEstimation: boolean,
+        estimationStartCallback: () => void,
+    ): SessionLightProbe;
+    prototype: SessionLightProbe;
+}
+
 export class XREstimatedLight extends Group {
     lightProbe: LightProbe;
     directionalLight: DirectionalLight;
     environment: Texture;
 
     constructor(renderer: WebGLRenderer, environmentEstimation?: boolean);
+}
+
+export interface XREstimatedLightConstructor {
+    new (renderer: WebGLRenderer, environmentEstimation?: boolean): XREstimatedLight;
+    prototype: XREstimatedLight;
 }

--- a/types/three/examples/jsm/webxr/XRHandMeshModel.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandMeshModel.d.ts
@@ -9,3 +9,8 @@ export class XRHandMeshModel {
 
     updateMesh(): void;
 }
+
+export interface XRHandMeshModelConstructor {
+    new (handModel: Object3D, controller: Object3D, path: string, handedness: string): XRHandMeshModel;
+    prototype: XRHandMeshModel;
+}

--- a/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -11,6 +11,11 @@ export class XRHandModel extends Object3D {
     motionController: XRHandPrimitiveModel | XRHandMeshModel;
 }
 
+export interface XRHandModelConstructor {
+    new (): XRHandModel;
+    prototype: XRHandModel;
+}
+
 export class XRHandModelFactory {
     constructor();
     path: string;
@@ -22,4 +27,9 @@ export class XRHandModelFactory {
         profile?: 'spheres' | 'boxes' | 'oculus',
         options?: XRHandPrimitiveModelOptions,
     ): XRHandModel;
+}
+
+export interface XRHandModelFactoryConstructor {
+    new (): XRHandModelFactory;
+    prototype: XRHandModelFactory;
 }

--- a/types/three/examples/jsm/webxr/XRHandPrimitiveModel.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandPrimitiveModel.d.ts
@@ -22,3 +22,14 @@ export class XRHandPrimitiveModel {
 
     updateMesh: () => void;
 }
+
+export interface XRHandPrimitiveModelConstructor {
+    new (
+        handModel: XRHandModel,
+        controller: Group,
+        path: string,
+        handedness: XRHandModelHandedness,
+        options: XRHandPrimitiveModelOptions,
+    ): XRHandPrimitiveModel;
+    prototype: XRHandPrimitiveModel;
+}

--- a/types/three/src/animation/AnimationAction.d.ts
+++ b/types/three/src/animation/AnimationAction.d.ts
@@ -84,3 +84,13 @@ export class AnimationAction {
     getClip(): AnimationClip;
     getRoot(): Object3D;
 }
+
+export interface AnimationActionConstructor {
+    new (
+        mixer: AnimationMixer,
+        clip: AnimationClip,
+        localRoot?: Object3D,
+        blendMode?: AnimationBlendMode,
+    ): AnimationAction;
+    prototype: AnimationAction;
+}

--- a/types/three/src/animation/AnimationClip.d.ts
+++ b/types/three/src/animation/AnimationClip.d.ts
@@ -49,3 +49,8 @@ export class AnimationClip {
     static parseAnimation(animation: any, bones: Bone[]): AnimationClip;
     static toJSON(clip: AnimationClip): any;
 }
+
+export interface AnimationClipConstructor {
+    new (name?: string, duration?: number, tracks?: KeyframeTrack[], blendMode?: AnimationBlendMode): AnimationClip;
+    prototype: AnimationClip;
+}

--- a/types/three/src/animation/AnimationMixer.d.ts
+++ b/types/three/src/animation/AnimationMixer.d.ts
@@ -32,3 +32,8 @@ export class AnimationMixer extends EventDispatcher {
     uncacheRoot(root: Object3D | AnimationObjectGroup): void;
     uncacheAction(clip: AnimationClip, root?: Object3D | AnimationObjectGroup): void;
 }
+
+export interface AnimationMixerConstructor {
+    new (root: Object3D | AnimationObjectGroup): AnimationMixer;
+    prototype: AnimationMixer;
+}

--- a/types/three/src/animation/AnimationObjectGroup.d.ts
+++ b/types/three/src/animation/AnimationObjectGroup.d.ts
@@ -15,3 +15,8 @@ export class AnimationObjectGroup {
     remove(...args: any[]): void;
     uncache(...args: any[]): void;
 }
+
+export interface AnimationObjectGroupConstructor {
+    new (...args: any[]): AnimationObjectGroup;
+    prototype: AnimationObjectGroup;
+}

--- a/types/three/src/animation/KeyframeTrack.d.ts
+++ b/types/three/src/animation/KeyframeTrack.d.ts
@@ -43,3 +43,13 @@ export class KeyframeTrack {
 
     static toJSON(track: KeyframeTrack): any;
 }
+
+export interface KeyframeTrackConstructor {
+    new (
+        name: string,
+        times: ArrayLike<any>,
+        values: ArrayLike<any>,
+        interpolation?: InterpolationModes,
+    ): KeyframeTrack;
+    prototype: KeyframeTrack;
+}

--- a/types/three/src/animation/PropertyBinding.d.ts
+++ b/types/three/src/animation/PropertyBinding.d.ts
@@ -31,6 +31,11 @@ export class PropertyBinding {
     static findNode(root: any, nodeName: string): any;
 }
 
+export interface PropertyBindingConstructor {
+    new (rootNode: any, path: string, parsedPath?: any): PropertyBinding;
+    prototype: PropertyBinding;
+}
+
 export namespace PropertyBinding {
     class Composite {
         constructor(targetGroup: any, path: any, parsedPath?: any);

--- a/types/three/src/animation/PropertyMixer.d.ts
+++ b/types/three/src/animation/PropertyMixer.d.ts
@@ -15,3 +15,8 @@ export class PropertyMixer {
     saveOriginalState(): void;
     restoreOriginalState(): void;
 }
+
+export interface PropertyMixerConstructor {
+    new (binding: any, typeName: string, valueSize: number): PropertyMixer;
+    prototype: PropertyMixer;
+}

--- a/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
@@ -8,3 +8,8 @@ export class BooleanKeyframeTrack extends KeyframeTrack {
      */
     ValueTypeName: string;
 }
+
+export interface BooleanKeyframeTrackConstructor {
+    new (name: string, times: any[], values: any[]): BooleanKeyframeTrack;
+    prototype: BooleanKeyframeTrack;
+}

--- a/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
@@ -9,3 +9,8 @@ export class ColorKeyframeTrack extends KeyframeTrack {
      */
     ValueTypeName: string;
 }
+
+export interface ColorKeyframeTrackConstructor {
+    new (name: string, times: any[], values: any[], interpolation?: InterpolationModes): ColorKeyframeTrack;
+    prototype: ColorKeyframeTrack;
+}

--- a/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
@@ -9,3 +9,8 @@ export class NumberKeyframeTrack extends KeyframeTrack {
      */
     ValueTypeName: string;
 }
+
+export interface NumberKeyframeTrackConstructor {
+    new (name: string, times: any[], values: any[], interpolation?: InterpolationModes): NumberKeyframeTrack;
+    prototype: NumberKeyframeTrack;
+}

--- a/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
@@ -9,3 +9,8 @@ export class QuaternionKeyframeTrack extends KeyframeTrack {
      */
     ValueTypeName: string;
 }
+
+export interface QuaternionKeyframeTrackConstructor {
+    new (name: string, times: any[], values: any[], interpolation?: InterpolationModes): QuaternionKeyframeTrack;
+    prototype: QuaternionKeyframeTrack;
+}

--- a/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
@@ -9,3 +9,8 @@ export class StringKeyframeTrack extends KeyframeTrack {
      */
     ValueTypeName: string;
 }
+
+export interface StringKeyframeTrackConstructor {
+    new (name: string, times: any[], values: any[], interpolation?: InterpolationModes): StringKeyframeTrack;
+    prototype: StringKeyframeTrack;
+}

--- a/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
@@ -9,3 +9,8 @@ export class VectorKeyframeTrack extends KeyframeTrack {
      */
     ValueTypeName: string;
 }
+
+export interface VectorKeyframeTrackConstructor {
+    new (name: string, times: any[], values: any[], interpolation?: InterpolationModes): VectorKeyframeTrack;
+    prototype: VectorKeyframeTrack;
+}

--- a/types/three/src/audio/Audio.d.ts
+++ b/types/three/src/audio/Audio.d.ts
@@ -104,3 +104,8 @@ export class Audio<NodeType extends AudioNode = GainNode> extends Object3D {
      */
     load(file: string): Audio;
 }
+
+export interface AudioConstructor<NodeType extends AudioNode = GainNode> {
+    new (listener: AudioListener): Audio<NodeType>;
+    prototype: Audio<NodeType>;
+}

--- a/types/three/src/audio/AudioAnalyser.d.ts
+++ b/types/three/src/audio/AudioAnalyser.d.ts
@@ -18,3 +18,8 @@ export class AudioAnalyser {
      */
     getData(file: any): any;
 }
+
+export interface AudioAnalyserConstructor {
+    new (audio: Audio<AudioNode>, fftSize?: number): AudioAnalyser;
+    prototype: AudioAnalyser;
+}

--- a/types/three/src/audio/AudioListener.d.ts
+++ b/types/three/src/audio/AudioListener.d.ts
@@ -26,3 +26,8 @@ export class AudioListener extends Object3D {
     getMasterVolume(): number;
     updateMatrixWorld(force?: boolean): void;
 }
+
+export interface AudioListenerConstructor {
+    new (): AudioListener;
+    prototype: AudioListener;
+}

--- a/types/three/src/audio/PositionalAudio.d.ts
+++ b/types/three/src/audio/PositionalAudio.d.ts
@@ -18,3 +18,8 @@ export class PositionalAudio extends Audio<PannerNode> {
     setDirectionalCone(coneInnerAngle: number, coneOuterAngle: number, coneOuterGain: number): this;
     updateMatrixWorld(force?: boolean): void;
 }
+
+export interface PositionalAudioConstructor {
+    new (listener: AudioListener): PositionalAudio;
+    prototype: PositionalAudio;
+}

--- a/types/three/src/cameras/ArrayCamera.d.ts
+++ b/types/three/src/cameras/ArrayCamera.d.ts
@@ -9,3 +9,8 @@ export class ArrayCamera extends PerspectiveCamera {
     cameras: PerspectiveCamera[];
     readonly isArrayCamera: true;
 }
+
+export interface ArrayCameraConstructor {
+    new (cameras?: PerspectiveCamera[]): ArrayCamera;
+    prototype: ArrayCamera;
+}

--- a/types/three/src/cameras/Camera.d.ts
+++ b/types/three/src/cameras/Camera.d.ts
@@ -37,3 +37,8 @@ export class Camera extends Object3D {
 
     updateMatrixWorld(force?: boolean): void;
 }
+
+export interface CameraConstructor {
+    new (): Camera;
+    prototype: Camera;
+}

--- a/types/three/src/cameras/CubeCamera.d.ts
+++ b/types/three/src/cameras/CubeCamera.d.ts
@@ -12,3 +12,8 @@ export class CubeCamera extends Object3D {
 
     update(renderer: WebGLRenderer, scene: Scene): void;
 }
+
+export interface CubeCameraConstructor {
+    new (near: number, far: number, renderTarget: WebGLCubeRenderTarget): CubeCamera;
+    prototype: CubeCamera;
+}

--- a/types/three/src/cameras/OrthographicCamera.d.ts
+++ b/types/three/src/cameras/OrthographicCamera.d.ts
@@ -93,3 +93,8 @@ export class OrthographicCamera extends Camera {
     clearViewOffset(): void;
     toJSON(meta?: any): any;
 }
+
+export interface OrthographicCameraConstructor {
+    new (left?: number, right?: number, top?: number, bottom?: number, near?: number, far?: number): OrthographicCamera;
+    prototype: OrthographicCamera;
+}

--- a/types/three/src/cameras/PerspectiveCamera.d.ts
+++ b/types/three/src/cameras/PerspectiveCamera.d.ts
@@ -132,3 +132,8 @@ export class PerspectiveCamera extends Camera {
      */
     setLens(focalLength: number, frameHeight?: number): void;
 }
+
+export interface PerspectiveCameraConstructor {
+    new (fov?: number, aspect?: number, near?: number, far?: number): PerspectiveCamera;
+    prototype: PerspectiveCamera;
+}

--- a/types/three/src/cameras/StereoCamera.d.ts
+++ b/types/three/src/cameras/StereoCamera.d.ts
@@ -21,3 +21,8 @@ export class StereoCamera extends Camera {
 
     update(camera: PerspectiveCamera): void;
 }
+
+export interface StereoCameraConstructor {
+    new (): StereoCamera;
+    prototype: StereoCamera;
+}

--- a/types/three/src/core/BufferAttribute.d.ts
+++ b/types/three/src/core/BufferAttribute.d.ts
@@ -79,11 +79,21 @@ export class BufferAttribute {
     };
 }
 
+export interface BufferAttributeConstructor {
+    new (array: ArrayLike<number>, itemSize: number, normalized?: boolean): BufferAttribute;
+    prototype: BufferAttribute;
+}
+
 /**
  * @deprecated THREE.Int8Attribute has been removed. Use new THREE.Int8BufferAttribute() instead.
  */
 export class Int8Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
+}
+
+export interface Int8AttributeConstructor {
+    new (array: any, itemSize: number): Int8Attribute;
+    prototype: Int8Attribute;
 }
 
 /**
@@ -93,11 +103,21 @@ export class Uint8Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
 }
 
+export interface Uint8AttributeConstructor {
+    new (array: any, itemSize: number): Uint8Attribute;
+    prototype: Uint8Attribute;
+}
+
 /**
  * @deprecated THREE.Uint8ClampedAttribute has been removed. Use new THREE.Uint8ClampedBufferAttribute() instead.
  */
 export class Uint8ClampedAttribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
+}
+
+export interface Uint8ClampedAttributeConstructor {
+    new (array: any, itemSize: number): Uint8ClampedAttribute;
+    prototype: Uint8ClampedAttribute;
 }
 
 /**
@@ -107,11 +127,21 @@ export class Int16Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
 }
 
+export interface Int16AttributeConstructor {
+    new (array: any, itemSize: number): Int16Attribute;
+    prototype: Int16Attribute;
+}
+
 /**
  * @deprecated THREE.Uint16Attribute has been removed. Use new THREE.Uint16BufferAttribute() instead.
  */
 export class Uint16Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
+}
+
+export interface Uint16AttributeConstructor {
+    new (array: any, itemSize: number): Uint16Attribute;
+    prototype: Uint16Attribute;
 }
 
 /**
@@ -121,11 +151,21 @@ export class Int32Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
 }
 
+export interface Int32AttributeConstructor {
+    new (array: any, itemSize: number): Int32Attribute;
+    prototype: Int32Attribute;
+}
+
 /**
  * @deprecated THREE.Uint32Attribute has been removed. Use new THREE.Uint32BufferAttribute() instead.
  */
 export class Uint32Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
+}
+
+export interface Uint32AttributeConstructor {
+    new (array: any, itemSize: number): Uint32Attribute;
+    prototype: Uint32Attribute;
 }
 
 /**
@@ -135,11 +175,21 @@ export class Float32Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
 }
 
+export interface Float32AttributeConstructor {
+    new (array: any, itemSize: number): Float32Attribute;
+    prototype: Float32Attribute;
+}
+
 /**
  * @deprecated THREE.Float64Attribute has been removed. Use new THREE.Float64BufferAttribute() instead.
  */
 export class Float64Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
+}
+
+export interface Float64AttributeConstructor {
+    new (array: any, itemSize: number): Float64Attribute;
+    prototype: Float64Attribute;
 }
 
 export class Int8BufferAttribute extends BufferAttribute {
@@ -150,12 +200,30 @@ export class Int8BufferAttribute extends BufferAttribute {
     );
 }
 
+export interface Int8BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Int8BufferAttribute;
+    prototype: Int8BufferAttribute;
+}
+
 export class Uint8BufferAttribute extends BufferAttribute {
     constructor(
         array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
         itemSize: number,
         normalized?: boolean,
     );
+}
+
+export interface Uint8BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Uint8BufferAttribute;
+    prototype: Uint8BufferAttribute;
 }
 
 export class Uint8ClampedBufferAttribute extends BufferAttribute {
@@ -166,12 +234,30 @@ export class Uint8ClampedBufferAttribute extends BufferAttribute {
     );
 }
 
+export interface Uint8ClampedBufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Uint8ClampedBufferAttribute;
+    prototype: Uint8ClampedBufferAttribute;
+}
+
 export class Int16BufferAttribute extends BufferAttribute {
     constructor(
         array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
         itemSize: number,
         normalized?: boolean,
     );
+}
+
+export interface Int16BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Int16BufferAttribute;
+    prototype: Int16BufferAttribute;
 }
 
 export class Uint16BufferAttribute extends BufferAttribute {
@@ -182,12 +268,30 @@ export class Uint16BufferAttribute extends BufferAttribute {
     );
 }
 
+export interface Uint16BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Uint16BufferAttribute;
+    prototype: Uint16BufferAttribute;
+}
+
 export class Int32BufferAttribute extends BufferAttribute {
     constructor(
         array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
         itemSize: number,
         normalized?: boolean,
     );
+}
+
+export interface Int32BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Int32BufferAttribute;
+    prototype: Int32BufferAttribute;
 }
 
 export class Uint32BufferAttribute extends BufferAttribute {
@@ -198,12 +302,30 @@ export class Uint32BufferAttribute extends BufferAttribute {
     );
 }
 
+export interface Uint32BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Uint32BufferAttribute;
+    prototype: Uint32BufferAttribute;
+}
+
 export class Float16BufferAttribute extends BufferAttribute {
     constructor(
         array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
         itemSize: number,
         normalized?: boolean,
     );
+}
+
+export interface Float16BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Float16BufferAttribute;
+    prototype: Float16BufferAttribute;
 }
 
 export class Float32BufferAttribute extends BufferAttribute {
@@ -214,10 +336,28 @@ export class Float32BufferAttribute extends BufferAttribute {
     );
 }
 
+export interface Float32BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Float32BufferAttribute;
+    prototype: Float32BufferAttribute;
+}
+
 export class Float64BufferAttribute extends BufferAttribute {
     constructor(
         array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
         itemSize: number,
         normalized?: boolean,
     );
+}
+
+export interface Float64BufferAttributeConstructor {
+    new (
+        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
+        itemSize: number,
+        normalized?: boolean,
+    ): Float64BufferAttribute;
+    prototype: Float64BufferAttribute;
 }

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -194,3 +194,8 @@ export class BufferGeometry extends EventDispatcher {
      */
     removeAttribute(name: string): BufferGeometry;
 }
+
+export interface BufferGeometryConstructor {
+    new (): BufferGeometry;
+    prototype: BufferGeometry;
+}

--- a/types/three/src/core/Clock.d.ts
+++ b/types/three/src/core/Clock.d.ts
@@ -62,3 +62,8 @@ export class Clock {
      */
     getDelta(): number;
 }
+
+export interface ClockConstructor {
+    new (autoStart?: boolean): Clock;
+    prototype: Clock;
+}

--- a/types/three/src/core/EventDispatcher.d.ts
+++ b/types/three/src/core/EventDispatcher.d.ts
@@ -49,3 +49,8 @@ export class EventDispatcher<E extends BaseEvent = Event> {
      */
     dispatchEvent(event: E): void;
 }
+
+export interface EventDispatcherConstructor<E extends BaseEvent = Event> {
+    new (): EventDispatcher<E>;
+    prototype: EventDispatcher<E>;
+}

--- a/types/three/src/core/GLBufferAttribute.d.ts
+++ b/types/three/src/core/GLBufferAttribute.d.ts
@@ -21,3 +21,8 @@ export class GLBufferAttribute {
     setItemSize(itemSize: number): this;
     setCount(count: number): this;
 }
+
+export interface GLBufferAttributeConstructor {
+    new (buffer: WebGLBuffer, type: number, itemSize: number, elementSize: 1 | 2 | 4, count: number): GLBufferAttribute;
+    prototype: GLBufferAttribute;
+}

--- a/types/three/src/core/InstancedBufferAttribute.d.ts
+++ b/types/three/src/core/InstancedBufferAttribute.d.ts
@@ -35,3 +35,13 @@ export class InstancedBufferAttribute extends BufferAttribute {
      */
     meshPerAttribute: number;
 }
+
+export interface InstancedBufferAttributeConstructor {
+    new (
+        array: ArrayLike<number>,
+        itemSize: number,
+        normalized?: boolean,
+        meshPerAttribute?: number,
+    ): InstancedBufferAttribute;
+    prototype: InstancedBufferAttribute;
+}

--- a/types/three/src/core/InstancedBufferGeometry.d.ts
+++ b/types/three/src/core/InstancedBufferGeometry.d.ts
@@ -18,3 +18,8 @@ export class InstancedBufferGeometry extends BufferGeometry {
      */
     instanceCount: number;
 }
+
+export interface InstancedBufferGeometryConstructor {
+    new (): InstancedBufferGeometry;
+    prototype: InstancedBufferGeometry;
+}

--- a/types/three/src/core/InstancedInterleavedBuffer.d.ts
+++ b/types/three/src/core/InstancedInterleavedBuffer.d.ts
@@ -11,3 +11,8 @@ export class InstancedInterleavedBuffer extends InterleavedBuffer {
      */
     meshPerAttribute: number;
 }
+
+export interface InstancedInterleavedBufferConstructor {
+    new (array: ArrayLike<number>, stride: number, meshPerAttribute?: number): InstancedInterleavedBuffer;
+    prototype: InstancedInterleavedBuffer;
+}

--- a/types/three/src/core/InterleavedBuffer.d.ts
+++ b/types/three/src/core/InterleavedBuffer.d.ts
@@ -46,3 +46,8 @@ export class InterleavedBuffer {
         stride: number;
     };
 }
+
+export interface InterleavedBufferConstructor {
+    new (array: ArrayLike<number>, stride: number): InterleavedBuffer;
+    prototype: InterleavedBuffer;
+}

--- a/types/three/src/core/InterleavedBufferAttribute.d.ts
+++ b/types/three/src/core/InterleavedBufferAttribute.d.ts
@@ -50,3 +50,13 @@ export class InterleavedBufferAttribute {
     applyNormalMatrix(matrix: Matrix): this;
     transformDirection(matrix: Matrix): this;
 }
+
+export interface InterleavedBufferAttributeConstructor {
+    new (
+        interleavedBuffer: InterleavedBuffer,
+        itemSize: number,
+        offset: number,
+        normalized?: boolean,
+    ): InterleavedBufferAttribute;
+    prototype: InterleavedBufferAttribute;
+}

--- a/types/three/src/core/Layers.d.ts
+++ b/types/three/src/core/Layers.d.ts
@@ -15,3 +15,8 @@ export class Layers {
     test(layers: Layers): boolean;
     isEnabled(channel: number): boolean;
 }
+
+export interface LayersConstructor {
+    new (): Layers;
+    prototype: Layers;
+}

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -406,3 +406,8 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
      */
     copy(source: this, recursive?: boolean): this;
 }
+
+export interface Object3DConstructor<E extends BaseEvent = Event> {
+    new (): Object3D<E>;
+    prototype: Object3D<E>;
+}

--- a/types/three/src/core/Raycaster.d.ts
+++ b/types/three/src/core/Raycaster.d.ts
@@ -118,3 +118,8 @@ export class Raycaster {
         optionalTarget?: Array<Intersection<TIntersected>>,
     ): Array<Intersection<TIntersected>>;
 }
+
+export interface RaycasterConstructor {
+    new (origin?: Vector3, direction?: Vector3, near?: number, far?: number): Raycaster;
+    prototype: Raycaster;
+}

--- a/types/three/src/core/Uniform.d.ts
+++ b/types/three/src/core/Uniform.d.ts
@@ -19,3 +19,9 @@ export class Uniform {
      */
     onUpdate(callback: () => void): Uniform;
 }
+
+export interface UniformConstructor {
+    new (value: any): Uniform;
+    new (type: string, value: any): Uniform;
+    prototype: Uniform;
+}

--- a/types/three/src/extras/PMREMGenerator.d.ts
+++ b/types/three/src/extras/PMREMGenerator.d.ts
@@ -13,3 +13,8 @@ export class PMREMGenerator {
     compileEquirectangularShader(): void;
     dispose(): void;
 }
+
+export interface PMREMGeneratorConstructor {
+    new (renderer: WebGLRenderer): PMREMGenerator;
+    prototype: PMREMGenerator;
+}

--- a/types/three/src/extras/core/Curve.d.ts
+++ b/types/three/src/extras/core/Curve.d.ts
@@ -99,3 +99,8 @@ export class Curve<T extends Vector> {
      */
     static create(constructorFunc: () => void, getPointFunc: () => void): () => void;
 }
+
+export interface CurveConstructor<T extends Vector> {
+    new (): Curve<T>;
+    prototype: Curve<T>;
+}

--- a/types/three/src/extras/core/CurvePath.d.ts
+++ b/types/three/src/extras/core/CurvePath.d.ts
@@ -24,3 +24,8 @@ export class CurvePath<T extends Vector> extends Curve<T> {
     getPoint(t: number, optionalTarget?: T): T;
     getCurveLengths(): number[];
 }
+
+export interface CurvePathConstructor<T extends Vector> {
+    new (): CurvePath<T>;
+    prototype: CurvePath<T>;
+}

--- a/types/three/src/extras/core/Path.d.ts
+++ b/types/three/src/extras/core/Path.d.ts
@@ -50,3 +50,8 @@ export class Path extends CurvePath<Vector2> {
         aRotation: number,
     ): this;
 }
+
+export interface PathConstructor {
+    new (points?: Vector2[]): Path;
+    prototype: Path;
+}

--- a/types/three/src/extras/core/Shape.d.ts
+++ b/types/three/src/extras/core/Shape.d.ts
@@ -26,3 +26,8 @@ export class Shape extends Path {
         holes: Vector2[][];
     };
 }
+
+export interface ShapeConstructor {
+    new (points?: Vector2[]): Shape;
+    prototype: Shape;
+}

--- a/types/three/src/extras/core/ShapePath.d.ts
+++ b/types/three/src/extras/core/ShapePath.d.ts
@@ -32,3 +32,8 @@ export class ShapePath {
     splineThru(pts: Vector2[]): this;
     toShapes(isCCW: boolean, noHoles?: boolean): Shape[];
 }
+
+export interface ShapePathConstructor {
+    new (): ShapePath;
+    prototype: ShapePath;
+}

--- a/types/three/src/extras/curves/ArcCurve.d.ts
+++ b/types/three/src/extras/curves/ArcCurve.d.ts
@@ -7,3 +7,15 @@ export class ArcCurve extends EllipseCurve {
      */
     type: string;
 }
+
+export interface ArcCurveConstructor {
+    new (
+        aX: number,
+        aY: number,
+        aRadius: number,
+        aStartAngle: number,
+        aEndAngle: number,
+        aClockwise: boolean,
+    ): ArcCurve;
+    prototype: ArcCurve;
+}

--- a/types/three/src/extras/curves/CatmullRomCurve3.d.ts
+++ b/types/three/src/extras/curves/CatmullRomCurve3.d.ts
@@ -28,3 +28,8 @@ export class CatmullRomCurve3 extends Curve<Vector3> {
      */
     points: Vector3[];
 }
+
+export interface CatmullRomCurve3Constructor {
+    new (points?: Vector3[], closed?: boolean, curveType?: string, tension?: number): CatmullRomCurve3;
+    prototype: CatmullRomCurve3;
+}

--- a/types/three/src/extras/curves/CubicBezierCurve.d.ts
+++ b/types/three/src/extras/curves/CubicBezierCurve.d.ts
@@ -29,3 +29,8 @@ export class CubicBezierCurve extends Curve<Vector2> {
      */
     v3: Vector2;
 }
+
+export interface CubicBezierCurveConstructor {
+    new (v0: Vector2, v1: Vector2, v2: Vector2, v3: Vector2): CubicBezierCurve;
+    prototype: CubicBezierCurve;
+}

--- a/types/three/src/extras/curves/CubicBezierCurve3.d.ts
+++ b/types/three/src/extras/curves/CubicBezierCurve3.d.ts
@@ -29,3 +29,8 @@ export class CubicBezierCurve3 extends Curve<Vector3> {
      */
     v3: Vector3;
 }
+
+export interface CubicBezierCurve3Constructor {
+    new (v0: Vector3, v1: Vector3, v2: Vector3, v3: Vector3): CubicBezierCurve3;
+    prototype: CubicBezierCurve3;
+}

--- a/types/three/src/extras/curves/EllipseCurve.d.ts
+++ b/types/three/src/extras/curves/EllipseCurve.d.ts
@@ -58,3 +58,17 @@ export class EllipseCurve extends Curve<Vector2> {
      */
     aRotation: number;
 }
+
+export interface EllipseCurveConstructor {
+    new (
+        aX: number,
+        aY: number,
+        xRadius: number,
+        yRadius: number,
+        aStartAngle: number,
+        aEndAngle: number,
+        aClockwise: boolean,
+        aRotation: number,
+    ): EllipseCurve;
+    prototype: EllipseCurve;
+}

--- a/types/three/src/extras/curves/LineCurve.d.ts
+++ b/types/three/src/extras/curves/LineCurve.d.ts
@@ -19,3 +19,8 @@ export class LineCurve extends Curve<Vector2> {
      */
     v2: Vector2;
 }
+
+export interface LineCurveConstructor {
+    new (v1: Vector2, v2: Vector2): LineCurve;
+    prototype: LineCurve;
+}

--- a/types/three/src/extras/curves/LineCurve3.d.ts
+++ b/types/three/src/extras/curves/LineCurve3.d.ts
@@ -19,3 +19,8 @@ export class LineCurve3 extends Curve<Vector3> {
      */
     v2: Vector3;
 }
+
+export interface LineCurve3Constructor {
+    new (v1: Vector3, v2: Vector3): LineCurve3;
+    prototype: LineCurve3;
+}

--- a/types/three/src/extras/curves/QuadraticBezierCurve.d.ts
+++ b/types/three/src/extras/curves/QuadraticBezierCurve.d.ts
@@ -24,3 +24,8 @@ export class QuadraticBezierCurve extends Curve<Vector2> {
      */
     v2: Vector2;
 }
+
+export interface QuadraticBezierCurveConstructor {
+    new (v0: Vector2, v1: Vector2, v2: Vector2): QuadraticBezierCurve;
+    prototype: QuadraticBezierCurve;
+}

--- a/types/three/src/extras/curves/QuadraticBezierCurve3.d.ts
+++ b/types/three/src/extras/curves/QuadraticBezierCurve3.d.ts
@@ -24,3 +24,8 @@ export class QuadraticBezierCurve3 extends Curve<Vector3> {
      */
     v2: Vector3;
 }
+
+export interface QuadraticBezierCurve3Constructor {
+    new (v0: Vector3, v1: Vector3, v2: Vector3): QuadraticBezierCurve3;
+    prototype: QuadraticBezierCurve3;
+}

--- a/types/three/src/extras/curves/SplineCurve.d.ts
+++ b/types/three/src/extras/curves/SplineCurve.d.ts
@@ -14,3 +14,8 @@ export class SplineCurve extends Curve<Vector2> {
      */
     points: Vector2[];
 }
+
+export interface SplineCurveConstructor {
+    new (points?: Vector2[]): SplineCurve;
+    prototype: SplineCurve;
+}

--- a/types/three/src/geometries/BoxGeometry.d.ts
+++ b/types/three/src/geometries/BoxGeometry.d.ts
@@ -35,4 +35,16 @@ export class BoxGeometry extends BufferGeometry {
     static fromJSON(data: any): BoxGeometry;
 }
 
+export interface BoxGeometryConstructor {
+    new (
+        width?: number,
+        height?: number,
+        depth?: number,
+        widthSegments?: number,
+        heightSegments?: number,
+        depthSegments?: number,
+    ): BoxGeometry;
+    prototype: BoxGeometry;
+}
+
 export { BoxGeometry as BoxBufferGeometry };

--- a/types/three/src/geometries/CapsuleGeometry.d.ts
+++ b/types/three/src/geometries/CapsuleGeometry.d.ts
@@ -24,4 +24,9 @@ export class CapsuleGeometry extends BufferGeometry {
     static fromJSON(data: any): CapsuleGeometry;
 }
 
+export interface CapsuleGeometryConstructor {
+    new (radius?: number, length?: number, capSegments?: number, radialSegments?: number): CapsuleGeometry;
+    prototype: CapsuleGeometry;
+}
+
 export { CapsuleGeometry as CapsuleBufferGeometry };

--- a/types/three/src/geometries/CircleGeometry.d.ts
+++ b/types/three/src/geometries/CircleGeometry.d.ts
@@ -24,4 +24,9 @@ export class CircleGeometry extends BufferGeometry {
     static fromJSON(data: any): CircleGeometry;
 }
 
+export interface CircleGeometryConstructor {
+    new (radius?: number, segments?: number, thetaStart?: number, thetaLength?: number): CircleGeometry;
+    prototype: CircleGeometry;
+}
+
 export { CircleGeometry as CircleBufferGeometry };

--- a/types/three/src/geometries/ConeGeometry.d.ts
+++ b/types/three/src/geometries/ConeGeometry.d.ts
@@ -28,4 +28,17 @@ export class ConeGeometry extends CylinderGeometry {
     static fromJSON(data: any): ConeGeometry;
 }
 
+export interface ConeGeometryConstructor {
+    new (
+        radius?: number,
+        height?: number,
+        radialSegments?: number,
+        heightSegments?: number,
+        openEnded?: boolean,
+        thetaStart?: number,
+        thetaLength?: number,
+    ): ConeGeometry;
+    prototype: ConeGeometry;
+}
+
 export { ConeGeometry as ConeBufferGeometry };

--- a/types/three/src/geometries/CylinderGeometry.d.ts
+++ b/types/three/src/geometries/CylinderGeometry.d.ts
@@ -41,4 +41,18 @@ export class CylinderGeometry extends BufferGeometry {
     static fromJSON(data: any): CylinderGeometry;
 }
 
+export interface CylinderGeometryConstructor {
+    new (
+        radiusTop?: number,
+        radiusBottom?: number,
+        height?: number,
+        radialSegments?: number,
+        heightSegments?: number,
+        openEnded?: boolean,
+        thetaStart?: number,
+        thetaLength?: number,
+    ): CylinderGeometry;
+    prototype: CylinderGeometry;
+}
+
 export { CylinderGeometry as CylinderBufferGeometry };

--- a/types/three/src/geometries/DodecahedronGeometry.d.ts
+++ b/types/three/src/geometries/DodecahedronGeometry.d.ts
@@ -15,4 +15,9 @@ export class DodecahedronGeometry extends PolyhedronGeometry {
     static fromJSON(data: any): DodecahedronGeometry;
 }
 
+export interface DodecahedronGeometryConstructor {
+    new (radius?: number, detail?: number): DodecahedronGeometry;
+    prototype: DodecahedronGeometry;
+}
+
 export { DodecahedronGeometry as DodecahedronBufferGeometry };

--- a/types/three/src/geometries/EdgesGeometry.d.ts
+++ b/types/three/src/geometries/EdgesGeometry.d.ts
@@ -17,3 +17,8 @@ export class EdgesGeometry<TBufferGeometry extends BufferGeometry = BufferGeomet
         thresholdAngle: number;
     };
 }
+
+export interface EdgesGeometryConstructor<TBufferGeometry extends BufferGeometry = BufferGeometry> {
+    new (geometry?: TBufferGeometry, thresholdAngle?: number): EdgesGeometry<TBufferGeometry>;
+    prototype: EdgesGeometry<TBufferGeometry>;
+}

--- a/types/three/src/geometries/ExtrudeGeometry.d.ts
+++ b/types/three/src/geometries/ExtrudeGeometry.d.ts
@@ -70,4 +70,9 @@ export class ExtrudeGeometry extends BufferGeometry {
     static fromJSON(data: any): ExtrudeGeometry;
 }
 
+export interface ExtrudeGeometryConstructor {
+    new (shapes?: Shape | Shape[], options?: ExtrudeGeometryOptions): ExtrudeGeometry;
+    prototype: ExtrudeGeometry;
+}
+
 export { ExtrudeGeometry as ExtrudeBufferGeometry };

--- a/types/three/src/geometries/IcosahedronGeometry.d.ts
+++ b/types/three/src/geometries/IcosahedronGeometry.d.ts
@@ -15,4 +15,9 @@ export class IcosahedronGeometry extends PolyhedronGeometry {
     static fromJSON(data: any): IcosahedronGeometry;
 }
 
+export interface IcosahedronGeometryConstructor {
+    new (radius?: number, detail?: number): IcosahedronGeometry;
+    prototype: IcosahedronGeometry;
+}
+
 export { IcosahedronGeometry as IcosahedronBufferGeometry };

--- a/types/three/src/geometries/LatheGeometry.d.ts
+++ b/types/three/src/geometries/LatheGeometry.d.ts
@@ -25,4 +25,9 @@ export class LatheGeometry extends BufferGeometry {
     static fromJSON(data: any): LatheGeometry;
 }
 
+export interface LatheGeometryConstructor {
+    new (points?: Vector2[], segments?: number, phiStart?: number, phiLength?: number): LatheGeometry;
+    prototype: LatheGeometry;
+}
+
 export { LatheGeometry as LatheBufferGeometry };

--- a/types/three/src/geometries/OctahedronGeometry.d.ts
+++ b/types/three/src/geometries/OctahedronGeometry.d.ts
@@ -15,4 +15,9 @@ export class OctahedronGeometry extends PolyhedronGeometry {
     static fromJSON(data: any): OctahedronGeometry;
 }
 
+export interface OctahedronGeometryConstructor {
+    new (radius?: number, detail?: number): OctahedronGeometry;
+    prototype: OctahedronGeometry;
+}
+
 export { OctahedronGeometry as OctahedronBufferGeometry };

--- a/types/three/src/geometries/PlaneGeometry.d.ts
+++ b/types/three/src/geometries/PlaneGeometry.d.ts
@@ -24,4 +24,9 @@ export class PlaneGeometry extends BufferGeometry {
     static fromJSON(data: any): PlaneGeometry;
 }
 
+export interface PlaneGeometryConstructor {
+    new (width?: number, height?: number, widthSegments?: number, heightSegments?: number): PlaneGeometry;
+    prototype: PlaneGeometry;
+}
+
 export { PlaneGeometry as PlaneBufferGeometry };

--- a/types/three/src/geometries/PolyhedronGeometry.d.ts
+++ b/types/three/src/geometries/PolyhedronGeometry.d.ts
@@ -24,4 +24,9 @@ export class PolyhedronGeometry extends BufferGeometry {
     static fromJSON(data: any): PolyhedronGeometry;
 }
 
+export interface PolyhedronGeometryConstructor {
+    new (vertices?: number[], indices?: number[], radius?: number, detail?: number): PolyhedronGeometry;
+    prototype: PolyhedronGeometry;
+}
+
 export { PolyhedronGeometry as PolyhedronBufferGeometry };

--- a/types/three/src/geometries/RingGeometry.d.ts
+++ b/types/three/src/geometries/RingGeometry.d.ts
@@ -35,4 +35,16 @@ export class RingGeometry extends BufferGeometry {
     static fromJSON(data: any): RingGeometry;
 }
 
+export interface RingGeometryConstructor {
+    new (
+        innerRadius?: number,
+        outerRadius?: number,
+        thetaSegments?: number,
+        phiSegments?: number,
+        thetaStart?: number,
+        thetaLength?: number,
+    ): RingGeometry;
+    prototype: RingGeometry;
+}
+
 export { RingGeometry as RingBufferGeometry };

--- a/types/three/src/geometries/ShapeGeometry.d.ts
+++ b/types/three/src/geometries/ShapeGeometry.d.ts
@@ -12,4 +12,9 @@ export class ShapeGeometry extends BufferGeometry {
     static fromJSON(data: any): ShapeGeometry;
 }
 
+export interface ShapeGeometryConstructor {
+    new (shapes?: Shape | Shape[], curveSegments?: number): ShapeGeometry;
+    prototype: ShapeGeometry;
+}
+
 export { ShapeGeometry as ShapeBufferGeometry };

--- a/types/three/src/geometries/SphereGeometry.d.ts
+++ b/types/three/src/geometries/SphereGeometry.d.ts
@@ -38,4 +38,17 @@ export class SphereGeometry extends BufferGeometry {
     static fromJSON(data: any): SphereGeometry;
 }
 
+export interface SphereGeometryConstructor {
+    new (
+        radius?: number,
+        widthSegments?: number,
+        heightSegments?: number,
+        phiStart?: number,
+        phiLength?: number,
+        thetaStart?: number,
+        thetaLength?: number,
+    ): SphereGeometry;
+    prototype: SphereGeometry;
+}
+
 export { SphereGeometry as SphereBufferGeometry };

--- a/types/three/src/geometries/TetrahedronGeometry.d.ts
+++ b/types/three/src/geometries/TetrahedronGeometry.d.ts
@@ -15,4 +15,9 @@ export class TetrahedronGeometry extends PolyhedronGeometry {
     static fromJSON(data: any): TetrahedronGeometry;
 }
 
+export interface TetrahedronGeometryConstructor {
+    new (radius?: number, detail?: number): TetrahedronGeometry;
+    prototype: TetrahedronGeometry;
+}
+
 export { TetrahedronGeometry as TetrahedronBufferGeometry };

--- a/types/three/src/geometries/TorusGeometry.d.ts
+++ b/types/three/src/geometries/TorusGeometry.d.ts
@@ -26,4 +26,15 @@ export class TorusGeometry extends BufferGeometry {
     static fromJSON(data: any): TorusGeometry;
 }
 
+export interface TorusGeometryConstructor {
+    new (
+        radius?: number,
+        tube?: number,
+        radialSegments?: number,
+        tubularSegments?: number,
+        arc?: number,
+    ): TorusGeometry;
+    prototype: TorusGeometry;
+}
+
 export { TorusGeometry as TorusBufferGeometry };

--- a/types/three/src/geometries/TorusKnotGeometry.d.ts
+++ b/types/three/src/geometries/TorusKnotGeometry.d.ts
@@ -35,4 +35,16 @@ export class TorusKnotGeometry extends BufferGeometry {
     static fromJSON(data: any): TorusKnotGeometry;
 }
 
+export interface TorusKnotGeometryConstructor {
+    new (
+        radius?: number,
+        tube?: number,
+        tubularSegments?: number,
+        radialSegments?: number,
+        p?: number,
+        q?: number,
+    ): TorusKnotGeometry;
+    prototype: TorusKnotGeometry;
+}
+
 export { TorusKnotGeometry as TorusKnotBufferGeometry };

--- a/types/three/src/geometries/TubeGeometry.d.ts
+++ b/types/three/src/geometries/TubeGeometry.d.ts
@@ -37,4 +37,15 @@ export class TubeGeometry extends BufferGeometry {
     static fromJSON(data: any): TubeGeometry;
 }
 
+export interface TubeGeometryConstructor {
+    new (
+        path?: Curve<Vector3>,
+        tubularSegments?: number,
+        radius?: number,
+        radiusSegments?: number,
+        closed?: boolean,
+    ): TubeGeometry;
+    prototype: TubeGeometry;
+}
+
 export { TubeGeometry as TubeBufferGeometry };

--- a/types/three/src/geometries/WireframeGeometry.d.ts
+++ b/types/three/src/geometries/WireframeGeometry.d.ts
@@ -12,3 +12,8 @@ export class WireframeGeometry<TBufferGeometry extends BufferGeometry = BufferGe
         geometry: TBufferGeometry;
     };
 }
+
+export interface WireframeGeometryConstructor<TBufferGeometry extends BufferGeometry = BufferGeometry> {
+    new (geometry?: TBufferGeometry): WireframeGeometry<TBufferGeometry>;
+    prototype: WireframeGeometry<TBufferGeometry>;
+}

--- a/types/three/src/helpers/ArrowHelper.d.ts
+++ b/types/three/src/helpers/ArrowHelper.d.ts
@@ -56,3 +56,15 @@ export class ArrowHelper extends Object3D {
      */
     setColor(color: ColorRepresentation): void;
 }
+
+export interface ArrowHelperConstructor {
+    new (
+        dir?: Vector3,
+        origin?: Vector3,
+        length?: number,
+        color?: ColorRepresentation,
+        headLength?: number,
+        headWidth?: number,
+    ): ArrowHelper;
+    prototype: ArrowHelper;
+}

--- a/types/three/src/helpers/AxesHelper.d.ts
+++ b/types/three/src/helpers/AxesHelper.d.ts
@@ -16,3 +16,8 @@ export class AxesHelper extends LineSegments {
 
     dispose(): void;
 }
+
+export interface AxesHelperConstructor {
+    new (size?: number): AxesHelper;
+    prototype: AxesHelper;
+}

--- a/types/three/src/helpers/Box3Helper.d.ts
+++ b/types/three/src/helpers/Box3Helper.d.ts
@@ -16,3 +16,8 @@ export class Box3Helper extends LineSegments {
 
     box: Box3;
 }
+
+export interface Box3HelperConstructor {
+    new (box: Box3, color?: Color): Box3Helper;
+    prototype: Box3Helper;
+}

--- a/types/three/src/helpers/BoxHelper.d.ts
+++ b/types/three/src/helpers/BoxHelper.d.ts
@@ -18,3 +18,8 @@ export class BoxHelper extends LineSegments {
 
     setFromObject(object: Object3D): this;
 }
+
+export interface BoxHelperConstructor {
+    new (object: Object3D, color?: ColorRepresentation): BoxHelper;
+    prototype: BoxHelper;
+}

--- a/types/three/src/helpers/CameraHelper.d.ts
+++ b/types/three/src/helpers/CameraHelper.d.ts
@@ -16,3 +16,8 @@ export class CameraHelper extends LineSegments {
 
     dispose(): void;
 }
+
+export interface CameraHelperConstructor {
+    new (camera: Camera): CameraHelper;
+    prototype: CameraHelper;
+}

--- a/types/three/src/helpers/DirectionalLightHelper.d.ts
+++ b/types/three/src/helpers/DirectionalLightHelper.d.ts
@@ -30,3 +30,8 @@ export class DirectionalLightHelper extends Object3D {
     dispose(): void;
     update(): void;
 }
+
+export interface DirectionalLightHelperConstructor {
+    new (light: DirectionalLight, size?: number, color?: ColorRepresentation): DirectionalLightHelper;
+    prototype: DirectionalLightHelper;
+}

--- a/types/three/src/helpers/GridHelper.d.ts
+++ b/types/three/src/helpers/GridHelper.d.ts
@@ -20,3 +20,8 @@ export class GridHelper extends LineSegments {
      */
     setColors(color1?: ColorRepresentation, color2?: ColorRepresentation): void;
 }
+
+export interface GridHelperConstructor {
+    new (size?: number, divisions?: number, color1?: ColorRepresentation, color2?: ColorRepresentation): GridHelper;
+    prototype: GridHelper;
+}

--- a/types/three/src/helpers/HemisphereLightHelper.d.ts
+++ b/types/three/src/helpers/HemisphereLightHelper.d.ts
@@ -18,3 +18,8 @@ export class HemisphereLightHelper extends Object3D {
     dispose(): void;
     update(): void;
 }
+
+export interface HemisphereLightHelperConstructor {
+    new (light: HemisphereLight, size: number, color?: ColorRepresentation): HemisphereLightHelper;
+    prototype: HemisphereLightHelper;
+}

--- a/types/three/src/helpers/PlaneHelper.d.ts
+++ b/types/three/src/helpers/PlaneHelper.d.ts
@@ -23,3 +23,8 @@ export class PlaneHelper extends LineSegments {
 
     updateMatrixWorld(force?: boolean): void;
 }
+
+export interface PlaneHelperConstructor {
+    new (plane: Plane, size?: number, hex?: number): PlaneHelper;
+    prototype: PlaneHelper;
+}

--- a/types/three/src/helpers/PointLightHelper.d.ts
+++ b/types/three/src/helpers/PointLightHelper.d.ts
@@ -23,3 +23,8 @@ export class PointLightHelper extends Object3D {
     dispose(): void;
     update(): void;
 }
+
+export interface PointLightHelperConstructor {
+    new (light: PointLight, sphereSize?: number, color?: ColorRepresentation): PointLightHelper;
+    prototype: PointLightHelper;
+}

--- a/types/three/src/helpers/PolarGridHelper.d.ts
+++ b/types/three/src/helpers/PolarGridHelper.d.ts
@@ -24,3 +24,15 @@ export class PolarGridHelper extends LineSegments {
      */
     type: string;
 }
+
+export interface PolarGridHelperConstructor {
+    new (
+        radius?: number,
+        radials?: number,
+        circles?: number,
+        divisions?: number,
+        color1?: ColorRepresentation,
+        color2?: ColorRepresentation,
+    ): PolarGridHelper;
+    prototype: PolarGridHelper;
+}

--- a/types/three/src/helpers/SkeletonHelper.d.ts
+++ b/types/three/src/helpers/SkeletonHelper.d.ts
@@ -26,3 +26,8 @@ export class SkeletonHelper extends LineSegments {
     getBoneList(object: Object3D): Bone[];
     update(): void;
 }
+
+export interface SkeletonHelperConstructor {
+    new (object: Object3D): SkeletonHelper;
+    prototype: SkeletonHelper;
+}

--- a/types/three/src/helpers/SpotLightHelper.d.ts
+++ b/types/three/src/helpers/SpotLightHelper.d.ts
@@ -20,3 +20,8 @@ export class SpotLightHelper extends Object3D {
     dispose(): void;
     update(): void;
 }
+
+export interface SpotLightHelperConstructor {
+    new (light: Light, color?: ColorRepresentation): SpotLightHelper;
+    prototype: SpotLightHelper;
+}

--- a/types/three/src/lights/AmbientLight.d.ts
+++ b/types/three/src/lights/AmbientLight.d.ts
@@ -21,3 +21,8 @@ export class AmbientLight extends Light {
 
     readonly isAmbientLight: true;
 }
+
+export interface AmbientLightConstructor {
+    new (color?: ColorRepresentation, intensity?: number): AmbientLight;
+    prototype: AmbientLight;
+}

--- a/types/three/src/lights/AmbientLightProbe.d.ts
+++ b/types/three/src/lights/AmbientLightProbe.d.ts
@@ -6,3 +6,8 @@ export class AmbientLightProbe extends LightProbe {
 
     readonly isAmbientLightProbe: true;
 }
+
+export interface AmbientLightProbeConstructor {
+    new (color?: ColorRepresentation, intensity?: number): AmbientLightProbe;
+    prototype: AmbientLightProbe;
+}

--- a/types/three/src/lights/DirectionalLight.d.ts
+++ b/types/three/src/lights/DirectionalLight.d.ts
@@ -44,3 +44,8 @@ export class DirectionalLight extends Light {
     shadow: DirectionalLightShadow;
     readonly isDirectionalLight: true;
 }
+
+export interface DirectionalLightConstructor {
+    new (color?: ColorRepresentation, intensity?: number): DirectionalLight;
+    prototype: DirectionalLight;
+}

--- a/types/three/src/lights/HemisphereLight.d.ts
+++ b/types/three/src/lights/HemisphereLight.d.ts
@@ -25,3 +25,8 @@ export class HemisphereLight extends Light {
 
     readonly isHemisphereLight: true;
 }
+
+export interface HemisphereLightConstructor {
+    new (skyColor?: ColorRepresentation, groundColor?: ColorRepresentation, intensity?: number): HemisphereLight;
+    prototype: HemisphereLight;
+}

--- a/types/three/src/lights/HemisphereLightProbe.d.ts
+++ b/types/three/src/lights/HemisphereLightProbe.d.ts
@@ -6,3 +6,8 @@ export class HemisphereLightProbe extends LightProbe {
 
     readonly isHemisphereLightProbe: true;
 }
+
+export interface HemisphereLightProbeConstructor {
+    new (skyColor?: ColorRepresentation, groundColor?: ColorRepresentation, intensity?: number): HemisphereLightProbe;
+    prototype: HemisphereLightProbe;
+}

--- a/types/three/src/lights/Light.d.ts
+++ b/types/three/src/lights/Light.d.ts
@@ -67,3 +67,8 @@ export class Light extends Object3D {
 
     dispose(): void;
 }
+
+export interface LightConstructor {
+    new (hex?: number | string, intensity?: number): Light;
+    prototype: Light;
+}

--- a/types/three/src/lights/LightProbe.d.ts
+++ b/types/three/src/lights/LightProbe.d.ts
@@ -18,3 +18,8 @@ export class LightProbe extends Light {
 
     fromJSON(json: object): LightProbe;
 }
+
+export interface LightProbeConstructor {
+    new (sh?: SphericalHarmonics3, intensity?: number): LightProbe;
+    prototype: LightProbe;
+}

--- a/types/three/src/lights/LightShadow.d.ts
+++ b/types/three/src/lights/LightShadow.d.ts
@@ -69,3 +69,8 @@ export class LightShadow {
     getFrameExtents(): Vector2;
     dispose(): void;
 }
+
+export interface LightShadowConstructor {
+    new (camera: Camera): LightShadow;
+    prototype: LightShadow;
+}

--- a/types/three/src/lights/PointLight.d.ts
+++ b/types/three/src/lights/PointLight.d.ts
@@ -40,3 +40,8 @@ export class PointLight extends Light {
 
     power: number;
 }
+
+export interface PointLightConstructor {
+    new (color?: ColorRepresentation, intensity?: number, distance?: number, decay?: number): PointLight;
+    prototype: PointLight;
+}

--- a/types/three/src/lights/RectAreaLight.d.ts
+++ b/types/three/src/lights/RectAreaLight.d.ts
@@ -28,3 +28,8 @@ export class RectAreaLight extends Light {
 
     readonly isRectAreaLight: true;
 }
+
+export interface RectAreaLightConstructor {
+    new (color?: ColorRepresentation, intensity?: number, width?: number, height?: number): RectAreaLight;
+    prototype: RectAreaLight;
+}

--- a/types/three/src/lights/SpotLight.d.ts
+++ b/types/three/src/lights/SpotLight.d.ts
@@ -70,3 +70,15 @@ export class SpotLight extends Light {
 
     readonly isSpotLight: true;
 }
+
+export interface SpotLightConstructor {
+    new (
+        color?: ColorRepresentation,
+        intensity?: number,
+        distance?: number,
+        angle?: number,
+        penumbra?: number,
+        decay?: number,
+    ): SpotLight;
+    prototype: SpotLight;
+}

--- a/types/three/src/loaders/AnimationLoader.d.ts
+++ b/types/three/src/loaders/AnimationLoader.d.ts
@@ -14,3 +14,8 @@ export class AnimationLoader extends Loader {
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<AnimationClip[]>;
     parse(json: any): AnimationClip[];
 }
+
+export interface AnimationLoaderConstructor {
+    new (manager?: LoadingManager): AnimationLoader;
+    prototype: AnimationLoader;
+}

--- a/types/three/src/loaders/AudioLoader.d.ts
+++ b/types/three/src/loaders/AudioLoader.d.ts
@@ -13,3 +13,8 @@ export class AudioLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<AudioBuffer>;
 }
+
+export interface AudioLoaderConstructor {
+    new (manager?: LoadingManager): AudioLoader;
+    prototype: AudioLoader;
+}

--- a/types/three/src/loaders/BufferGeometryLoader.d.ts
+++ b/types/three/src/loaders/BufferGeometryLoader.d.ts
@@ -18,3 +18,8 @@ export class BufferGeometryLoader extends Loader {
     ): Promise<InstancedBufferGeometry | BufferGeometry>;
     parse(json: any): InstancedBufferGeometry | BufferGeometry;
 }
+
+export interface BufferGeometryLoaderConstructor {
+    new (manager?: LoadingManager): BufferGeometryLoader;
+    prototype: BufferGeometryLoader;
+}

--- a/types/three/src/loaders/CompressedTextureLoader.d.ts
+++ b/types/three/src/loaders/CompressedTextureLoader.d.ts
@@ -14,3 +14,8 @@ export class CompressedTextureLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<CompressedTexture>;
 }
+
+export interface CompressedTextureLoaderConstructor {
+    new (manager?: LoadingManager): CompressedTextureLoader;
+    prototype: CompressedTextureLoader;
+}

--- a/types/three/src/loaders/CubeTextureLoader.d.ts
+++ b/types/three/src/loaders/CubeTextureLoader.d.ts
@@ -14,3 +14,8 @@ export class CubeTextureLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<CubeTexture>;
 }
+
+export interface CubeTextureLoaderConstructor {
+    new (manager?: LoadingManager): CubeTextureLoader;
+    prototype: CubeTextureLoader;
+}

--- a/types/three/src/loaders/DataTextureLoader.d.ts
+++ b/types/three/src/loaders/DataTextureLoader.d.ts
@@ -14,3 +14,8 @@ export class DataTextureLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<DataTexture>;
 }
+
+export interface DataTextureLoaderConstructor {
+    new (manager?: LoadingManager): DataTextureLoader;
+    prototype: DataTextureLoader;
+}

--- a/types/three/src/loaders/FileLoader.d.ts
+++ b/types/three/src/loaders/FileLoader.d.ts
@@ -17,3 +17,8 @@ export class FileLoader extends Loader {
     setMimeType(mimeType: MimeType): FileLoader;
     setResponseType(responseType: string): FileLoader;
 }
+
+export interface FileLoaderConstructor {
+    new (manager?: LoadingManager): FileLoader;
+    prototype: FileLoader;
+}

--- a/types/three/src/loaders/ImageBitmapLoader.d.ts
+++ b/types/three/src/loaders/ImageBitmapLoader.d.ts
@@ -21,3 +21,8 @@ export class ImageBitmapLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<ImageBitmap>;
 }
+
+export interface ImageBitmapLoaderConstructor {
+    new (manager?: LoadingManager): ImageBitmapLoader;
+    prototype: ImageBitmapLoader;
+}

--- a/types/three/src/loaders/ImageLoader.d.ts
+++ b/types/three/src/loaders/ImageLoader.d.ts
@@ -17,3 +17,8 @@ export class ImageLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<HTMLImageElement>;
 }
+
+export interface ImageLoaderConstructor {
+    new (manager?: LoadingManager): ImageLoader;
+    prototype: ImageLoader;
+}

--- a/types/three/src/loaders/Loader.d.ts
+++ b/types/three/src/loaders/Loader.d.ts
@@ -45,3 +45,8 @@ export class Loader {
     setResourcePath(resourcePath: string): this;
     setRequestHeader(requestHeader: { [header: string]: string }): this;
 }
+
+export interface LoaderConstructor {
+    new (manager?: LoadingManager): Loader;
+    prototype: Loader;
+}

--- a/types/three/src/loaders/LoadingManager.d.ts
+++ b/types/three/src/loaders/LoadingManager.d.ts
@@ -67,3 +67,12 @@ export class LoadingManager {
     removeHandler(regex: RegExp): this;
     getHandler(file: string): Loader | null;
 }
+
+export interface LoadingManagerConstructor {
+    new (
+        onLoad?: () => void,
+        onProgress?: (url: string, loaded: number, total: number) => void,
+        onError?: (url: string) => void,
+    ): LoadingManager;
+    prototype: LoadingManager;
+}

--- a/types/three/src/loaders/MaterialLoader.d.ts
+++ b/types/three/src/loaders/MaterialLoader.d.ts
@@ -21,3 +21,8 @@ export class MaterialLoader extends Loader {
     setTextures(textures: { [key: string]: Texture }): this;
     parse(json: any): Material;
 }
+
+export interface MaterialLoaderConstructor {
+    new (manager?: LoadingManager): MaterialLoader;
+    prototype: MaterialLoader;
+}

--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -40,3 +40,8 @@ export class ObjectLoader extends Loader {
     ): // tslint:disable-next-line:no-unnecessary-generics
     T;
 }
+
+export interface ObjectLoaderConstructor {
+    new (manager?: LoadingManager): ObjectLoader;
+    prototype: ObjectLoader;
+}

--- a/types/three/src/loaders/TextureLoader.d.ts
+++ b/types/three/src/loaders/TextureLoader.d.ts
@@ -18,3 +18,8 @@ export class TextureLoader extends Loader {
 
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Texture>;
 }
+
+export interface TextureLoaderConstructor {
+    new (manager?: LoadingManager): TextureLoader;
+    prototype: TextureLoader;
+}

--- a/types/three/src/materials/LineBasicMaterial.d.ts
+++ b/types/three/src/materials/LineBasicMaterial.d.ts
@@ -39,3 +39,8 @@ export class LineBasicMaterial extends Material {
 
     setValues(parameters: LineBasicMaterialParameters): void;
 }
+
+export interface LineBasicMaterialConstructor {
+    new (parameters?: LineBasicMaterialParameters): LineBasicMaterial;
+    prototype: LineBasicMaterial;
+}

--- a/types/three/src/materials/LineDashedMaterial.d.ts
+++ b/types/three/src/materials/LineDashedMaterial.d.ts
@@ -32,3 +32,8 @@ export class LineDashedMaterial extends LineBasicMaterial {
 
     setValues(parameters: LineDashedMaterialParameters): void;
 }
+
+export interface LineDashedMaterialConstructor {
+    new (parameters?: LineDashedMaterialParameters): LineDashedMaterial;
+    prototype: LineDashedMaterial;
+}

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -405,3 +405,8 @@ export class Material extends EventDispatcher {
      */
     toJSON(meta?: any): any;
 }
+
+export interface MaterialConstructor {
+    new (): Material;
+    prototype: Material;
+}

--- a/types/three/src/materials/MeshBasicMaterial.d.ts
+++ b/types/three/src/materials/MeshBasicMaterial.d.ts
@@ -116,3 +116,8 @@ export class MeshBasicMaterial extends Material {
 
     setValues(parameters: MeshBasicMaterialParameters): void;
 }
+
+export interface MeshBasicMaterialConstructor {
+    new (parameters?: MeshBasicMaterialParameters): MeshBasicMaterial;
+    prototype: MeshBasicMaterial;
+}

--- a/types/three/src/materials/MeshDepthMaterial.d.ts
+++ b/types/three/src/materials/MeshDepthMaterial.d.ts
@@ -68,3 +68,8 @@ export class MeshDepthMaterial extends Material {
 
     setValues(parameters: MeshDepthMaterialParameters): void;
 }
+
+export interface MeshDepthMaterialConstructor {
+    new (parameters?: MeshDepthMaterialParameters): MeshDepthMaterial;
+    prototype: MeshDepthMaterial;
+}

--- a/types/three/src/materials/MeshDistanceMaterial.d.ts
+++ b/types/three/src/materials/MeshDistanceMaterial.d.ts
@@ -68,3 +68,8 @@ export class MeshDistanceMaterial extends Material {
 
     setValues(parameters: MeshDistanceMaterialParameters): void;
 }
+
+export interface MeshDistanceMaterialConstructor {
+    new (parameters?: MeshDistanceMaterialParameters): MeshDistanceMaterial;
+    prototype: MeshDistanceMaterial;
+}

--- a/types/three/src/materials/MeshLambertMaterial.d.ts
+++ b/types/three/src/materials/MeshLambertMaterial.d.ts
@@ -131,3 +131,8 @@ export class MeshLambertMaterial extends Material {
 
     setValues(parameters: MeshLambertMaterialParameters): void;
 }
+
+export interface MeshLambertMaterialConstructor {
+    new (parameters?: MeshLambertMaterialParameters): MeshLambertMaterial;
+    prototype: MeshLambertMaterial;
+}

--- a/types/three/src/materials/MeshMatcapMaterial.d.ts
+++ b/types/three/src/materials/MeshMatcapMaterial.d.ts
@@ -103,3 +103,8 @@ export class MeshMatcapMaterial extends Material {
 
     setValues(parameters: MeshMatcapMaterialParameters): void;
 }
+
+export interface MeshMatcapMaterialConstructor {
+    new (parameters?: MeshMatcapMaterialParameters): MeshMatcapMaterial;
+    prototype: MeshMatcapMaterial;
+}

--- a/types/three/src/materials/MeshNormalMaterial.d.ts
+++ b/types/three/src/materials/MeshNormalMaterial.d.ts
@@ -84,3 +84,8 @@ export class MeshNormalMaterial extends Material {
 
     setValues(parameters: MeshNormalMaterialParameters): void;
 }
+
+export interface MeshNormalMaterialConstructor {
+    new (parameters?: MeshNormalMaterialParameters): MeshNormalMaterial;
+    prototype: MeshNormalMaterial;
+}

--- a/types/three/src/materials/MeshPhongMaterial.d.ts
+++ b/types/three/src/materials/MeshPhongMaterial.d.ts
@@ -207,3 +207,8 @@ export class MeshPhongMaterial extends Material {
 
     setValues(parameters: MeshPhongMaterialParameters): void;
 }
+
+export interface MeshPhongMaterialConstructor {
+    new (parameters?: MeshPhongMaterialParameters): MeshPhongMaterial;
+    prototype: MeshPhongMaterial;
+}

--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -157,3 +157,8 @@ export class MeshPhysicalMaterial extends MeshStandardMaterial {
      */
     specularColorMap: Texture | null;
 }
+
+export interface MeshPhysicalMaterialConstructor {
+    new (parameters?: MeshPhysicalMaterialParameters): MeshPhysicalMaterial;
+    prototype: MeshPhysicalMaterial;
+}

--- a/types/three/src/materials/MeshStandardMaterial.d.ts
+++ b/types/three/src/materials/MeshStandardMaterial.d.ts
@@ -199,3 +199,8 @@ export class MeshStandardMaterial extends Material {
 
     setValues(parameters: MeshStandardMaterialParameters): void;
 }
+
+export interface MeshStandardMaterialConstructor {
+    new (parameters?: MeshStandardMaterialParameters): MeshStandardMaterial;
+    prototype: MeshStandardMaterial;
+}

--- a/types/three/src/materials/MeshToonMaterial.d.ts
+++ b/types/three/src/materials/MeshToonMaterial.d.ts
@@ -163,3 +163,8 @@ export class MeshToonMaterial extends Material {
 
     setValues(parameters: MeshToonMaterialParameters): void;
 }
+
+export interface MeshToonMaterialConstructor {
+    new (parameters?: MeshToonMaterialParameters): MeshToonMaterial;
+    prototype: MeshToonMaterial;
+}

--- a/types/three/src/materials/PointsMaterial.d.ts
+++ b/types/three/src/materials/PointsMaterial.d.ts
@@ -46,3 +46,8 @@ export class PointsMaterial extends Material {
 
     setValues(parameters: PointsMaterialParameters): void;
 }
+
+export interface PointsMaterialConstructor {
+    new (parameters?: PointsMaterialParameters): PointsMaterial;
+    prototype: PointsMaterial;
+}

--- a/types/three/src/materials/RawShaderMaterial.d.ts
+++ b/types/three/src/materials/RawShaderMaterial.d.ts
@@ -3,3 +3,8 @@ import { ShaderMaterialParameters, ShaderMaterial } from './ShaderMaterial';
 export class RawShaderMaterial extends ShaderMaterial {
     constructor(parameters?: ShaderMaterialParameters);
 }
+
+export interface RawShaderMaterialConstructor {
+    new (parameters?: ShaderMaterialParameters): RawShaderMaterial;
+    prototype: RawShaderMaterial;
+}

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -113,3 +113,8 @@ export class ShaderMaterial extends Material {
     setValues(parameters: ShaderMaterialParameters): void;
     toJSON(meta: any): any;
 }
+
+export interface ShaderMaterialConstructor {
+    new (parameters?: ShaderMaterialParameters): ShaderMaterial;
+    prototype: ShaderMaterial;
+}

--- a/types/three/src/materials/ShadowMaterial.d.ts
+++ b/types/three/src/materials/ShadowMaterial.d.ts
@@ -24,3 +24,8 @@ export class ShadowMaterial extends Material {
      */
     transparent: boolean;
 }
+
+export interface ShadowMaterialConstructor {
+    new (parameters?: ShadowMaterialParameters): ShadowMaterial;
+    prototype: ShadowMaterial;
+}

--- a/types/three/src/materials/SpriteMaterial.d.ts
+++ b/types/three/src/materials/SpriteMaterial.d.ts
@@ -53,3 +53,8 @@ export class SpriteMaterial extends Material {
     setValues(parameters: SpriteMaterialParameters): void;
     copy(source: SpriteMaterial): this;
 }
+
+export interface SpriteMaterialConstructor {
+    new (parameters?: SpriteMaterialParameters): SpriteMaterial;
+    prototype: SpriteMaterial;
+}

--- a/types/three/src/math/Box2.d.ts
+++ b/types/three/src/math/Box2.d.ts
@@ -46,3 +46,8 @@ export class Box2 {
      */
     isIntersectionBox(b: any): any;
 }
+
+export interface Box2Constructor {
+    new (min?: Vector2, max?: Vector2): Box2;
+    prototype: Box2;
+}

--- a/types/three/src/math/Box3.d.ts
+++ b/types/three/src/math/Box3.d.ts
@@ -64,3 +64,8 @@ export class Box3 {
      */
     isIntersectionSphere(s: any): any;
 }
+
+export interface Box3Constructor {
+    new (min?: Vector3, max?: Vector3): Box3;
+    prototype: Box3;
+}

--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -180,3 +180,9 @@ export class Color {
      */
     static NAMES: Record<string, number>;
 }
+
+export interface ColorConstructor {
+    new (color?: ColorRepresentation): Color;
+    new (r: number, g: number, b: number): Color;
+    prototype: Color;
+}

--- a/types/three/src/math/Cylindrical.d.ts
+++ b/types/three/src/math/Cylindrical.d.ts
@@ -24,3 +24,8 @@ export class Cylindrical {
     setFromVector3(vec3: Vector3): this;
     setFromCartesianCoords(x: number, y: number, z: number): this;
 }
+
+export interface CylindricalConstructor {
+    new (radius?: number, theta?: number, y?: number): Cylindrical;
+    prototype: Cylindrical;
+}

--- a/types/three/src/math/Euler.d.ts
+++ b/types/three/src/math/Euler.d.ts
@@ -43,3 +43,8 @@ export class Euler {
     static RotationOrders: string[];
     static DefaultOrder: string;
 }
+
+export interface EulerConstructor {
+    new (x?: number, y?: number, z?: number, order?: string): Euler;
+    prototype: Euler;
+}

--- a/types/three/src/math/Frustum.d.ts
+++ b/types/three/src/math/Frustum.d.ts
@@ -27,3 +27,8 @@ export class Frustum {
     intersectsBox(box: Box3): boolean;
     containsPoint(point: Vector3): boolean;
 }
+
+export interface FrustumConstructor {
+    new (p0?: Plane, p1?: Plane, p2?: Plane, p3?: Plane, p4?: Plane, p5?: Plane): Frustum;
+    prototype: Frustum;
+}

--- a/types/three/src/math/Line3.d.ts
+++ b/types/three/src/math/Line3.d.ts
@@ -27,3 +27,8 @@ export class Line3 {
     applyMatrix4(matrix: Matrix4): Line3;
     equals(line: Line3): boolean;
 }
+
+export interface Line3Constructor {
+    new (start?: Vector3, end?: Vector3): Line3;
+    prototype: Line3;
+}

--- a/types/three/src/math/Matrix3.d.ts
+++ b/types/three/src/math/Matrix3.d.ts
@@ -162,3 +162,8 @@ export class Matrix3 implements Matrix {
      */
     flattenToArrayOffset(array: number[], offset: number): number[];
 }
+
+export interface Matrix3Constructor {
+    new (): Matrix3;
+    prototype: Matrix3;
+}

--- a/types/three/src/math/Matrix4.d.ts
+++ b/types/three/src/math/Matrix4.d.ts
@@ -289,3 +289,8 @@ export class Matrix4 implements Matrix {
      */
     getInverse(matrix: Matrix): Matrix;
 }
+
+export interface Matrix4Constructor {
+    new (): Matrix4;
+    prototype: Matrix4;
+}

--- a/types/three/src/math/Plane.d.ts
+++ b/types/three/src/math/Plane.d.ts
@@ -45,3 +45,8 @@ export class Plane {
      */
     isIntersectionLine(l: any): any;
 }
+
+export interface PlaneConstructor {
+    new (normal?: Vector3, constant?: number): Plane;
+    prototype: Plane;
+}

--- a/types/three/src/math/Quaternion.d.ts
+++ b/types/three/src/math/Quaternion.d.ts
@@ -175,3 +175,8 @@ export class Quaternion {
 
     random(): Quaternion;
 }
+
+export interface QuaternionConstructor {
+    new (x?: number, y?: number, z?: number, w?: number): Quaternion;
+    prototype: Quaternion;
+}

--- a/types/three/src/math/Ray.d.ts
+++ b/types/three/src/math/Ray.d.ts
@@ -58,3 +58,8 @@ export class Ray {
      */
     isIntersectionSphere(s: any): any;
 }
+
+export interface RayConstructor {
+    new (origin?: Vector3, direction?: Vector3): Ray;
+    prototype: Ray;
+}

--- a/types/three/src/math/Sphere.d.ts
+++ b/types/three/src/math/Sphere.d.ts
@@ -40,3 +40,8 @@ export class Sphere {
      */
     empty(): any;
 }
+
+export interface SphereConstructor {
+    new (center?: Vector3, radius?: number): Sphere;
+    prototype: Sphere;
+}

--- a/types/three/src/math/Spherical.d.ts
+++ b/types/three/src/math/Spherical.d.ts
@@ -25,3 +25,8 @@ export class Spherical {
     setFromVector3(v: Vector3): this;
     setFromCartesianCoords(x: number, y: number, z: number): this;
 }
+
+export interface SphericalConstructor {
+    new (radius?: number, phi?: number, theta?: number): Spherical;
+    prototype: Spherical;
+}

--- a/types/three/src/math/SphericalHarmonics3.d.ts
+++ b/types/three/src/math/SphericalHarmonics3.d.ts
@@ -48,3 +48,8 @@ export class SphericalHarmonics3 {
 
     static getBasisAt(normal: Vector3, shBasis: number[]): void;
 }
+
+export interface SphericalHarmonics3Constructor {
+    new (): SphericalHarmonics3;
+    prototype: SphericalHarmonics3;
+}

--- a/types/three/src/math/Triangle.d.ts
+++ b/types/three/src/math/Triangle.d.ts
@@ -61,3 +61,8 @@ export class Triangle {
     ): Vector2;
     static isFrontFacing(a: Vector3, b: Vector3, c: Vector3, direction: Vector3): boolean;
 }
+
+export interface TriangleConstructor {
+    new (a?: Vector3, b?: Vector3, c?: Vector3): Triangle;
+    prototype: Triangle;
+}

--- a/types/three/src/math/Vector2.d.ts
+++ b/types/three/src/math/Vector2.d.ts
@@ -444,3 +444,8 @@ export class Vector2 implements Vector {
      */
     random(): this;
 }
+
+export interface Vector2Constructor {
+    new (x?: number, y?: number): Vector2;
+    prototype: Vector2;
+}

--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -295,3 +295,8 @@ export class Vector3 implements Vector {
 
     randomDirection(): this;
 }
+
+export interface Vector3Constructor {
+    new (x?: number, y?: number, z?: number): Vector3;
+    prototype: Vector3;
+}

--- a/types/three/src/math/Vector4.d.ts
+++ b/types/three/src/math/Vector4.d.ts
@@ -221,3 +221,8 @@ export class Vector4 implements Vector {
      */
     random(): this;
 }
+
+export interface Vector4Constructor {
+    new (x?: number, y?: number, z?: number, w?: number): Vector4;
+    prototype: Vector4;
+}

--- a/types/three/src/math/interpolants/CubicInterpolant.d.ts
+++ b/types/three/src/math/interpolants/CubicInterpolant.d.ts
@@ -5,3 +5,8 @@ export class CubicInterpolant extends Interpolant {
 
     interpolate_(i1: number, t0: number, t: number, t1: number): any;
 }
+
+export interface CubicInterpolantConstructor {
+    new (parameterPositions: any, samplesValues: any, sampleSize: number, resultBuffer?: any): CubicInterpolant;
+    prototype: CubicInterpolant;
+}

--- a/types/three/src/math/interpolants/DiscreteInterpolant.d.ts
+++ b/types/three/src/math/interpolants/DiscreteInterpolant.d.ts
@@ -5,3 +5,8 @@ export class DiscreteInterpolant extends Interpolant {
 
     interpolate_(i1: number, t0: number, t: number, t1: number): any;
 }
+
+export interface DiscreteInterpolantConstructor {
+    new (parameterPositions: any, samplesValues: any, sampleSize: number, resultBuffer?: any): DiscreteInterpolant;
+    prototype: DiscreteInterpolant;
+}

--- a/types/three/src/math/interpolants/LinearInterpolant.d.ts
+++ b/types/three/src/math/interpolants/LinearInterpolant.d.ts
@@ -5,3 +5,8 @@ export class LinearInterpolant extends Interpolant {
 
     interpolate_(i1: number, t0: number, t: number, t1: number): any;
 }
+
+export interface LinearInterpolantConstructor {
+    new (parameterPositions: any, samplesValues: any, sampleSize: number, resultBuffer?: any): LinearInterpolant;
+    prototype: LinearInterpolant;
+}

--- a/types/three/src/math/interpolants/QuaternionLinearInterpolant.d.ts
+++ b/types/three/src/math/interpolants/QuaternionLinearInterpolant.d.ts
@@ -5,3 +5,13 @@ export class QuaternionLinearInterpolant extends Interpolant {
 
     interpolate_(i1: number, t0: number, t: number, t1: number): any;
 }
+
+export interface QuaternionLinearInterpolantConstructor {
+    new (
+        parameterPositions: any,
+        samplesValues: any,
+        sampleSize: number,
+        resultBuffer?: any,
+    ): QuaternionLinearInterpolant;
+    prototype: QuaternionLinearInterpolant;
+}

--- a/types/three/src/objects/Bone.d.ts
+++ b/types/three/src/objects/Bone.d.ts
@@ -7,3 +7,8 @@ export class Bone extends Object3D {
     readonly isBone: true;
     type: 'Bone';
 }
+
+export interface BoneConstructor {
+    new (): Bone;
+    prototype: Bone;
+}

--- a/types/three/src/objects/Group.d.ts
+++ b/types/three/src/objects/Group.d.ts
@@ -5,3 +5,8 @@ export class Group extends Object3D {
     type: 'Group';
     readonly isGroup: true;
 }
+
+export interface GroupConstructor {
+    new (): Group;
+    prototype: Group;
+}

--- a/types/three/src/objects/InstancedMesh.d.ts
+++ b/types/three/src/objects/InstancedMesh.d.ts
@@ -23,3 +23,14 @@ export class InstancedMesh<
     setMatrixAt(index: number, matrix: Matrix4): void;
     dispose(): void;
 }
+
+export interface InstancedMeshConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry: TGeometry | undefined, material: TMaterial | undefined, count: number): InstancedMesh<
+        TGeometry,
+        TMaterial
+    >;
+    prototype: InstancedMesh<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/LOD.d.ts
+++ b/types/three/src/objects/LOD.d.ts
@@ -24,3 +24,8 @@ export class LOD extends Object3D {
      */
     objects: any[];
 }
+
+export interface LODConstructor {
+    new (): LOD;
+    prototype: LOD;
+}

--- a/types/three/src/objects/Line.d.ts
+++ b/types/three/src/objects/Line.d.ts
@@ -23,3 +23,11 @@ export class Line<
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     updateMorphTargets(): void;
 }
+
+export interface LineConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry?: TGeometry, material?: TMaterial): Line<TGeometry, TMaterial>;
+    prototype: Line<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/LineLoop.d.ts
+++ b/types/three/src/objects/LineLoop.d.ts
@@ -11,3 +11,11 @@ export class LineLoop<
     type: 'LineLoop';
     readonly isLineLoop: true;
 }
+
+export interface LineLoopConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry?: TGeometry, material?: TMaterial): LineLoop<TGeometry, TMaterial>;
+    prototype: LineLoop<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/LineSegments.d.ts
+++ b/types/three/src/objects/LineSegments.d.ts
@@ -23,3 +23,11 @@ export class LineSegments<
     type: 'LineSegments' | string;
     readonly isLineSegments: true;
 }
+
+export interface LineSegmentsConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry?: TGeometry, material?: TMaterial): LineSegments<TGeometry, TMaterial>;
+    prototype: LineSegments<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -20,3 +20,11 @@ export class Mesh<
     updateMorphTargets(): void;
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
 }
+
+export interface MeshConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry?: TGeometry, material?: TMaterial): Mesh<TGeometry, TMaterial>;
+    prototype: Mesh<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/Points.d.ts
+++ b/types/three/src/objects/Points.d.ts
@@ -35,3 +35,11 @@ export class Points<
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     updateMorphTargets(): void;
 }
+
+export interface PointsConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry?: TGeometry, material?: TMaterial): Points<TGeometry, TMaterial>;
+    prototype: Points<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/Skeleton.d.ts
+++ b/types/three/src/objects/Skeleton.d.ts
@@ -27,3 +27,8 @@ export class Skeleton {
      */
     useVertexTexture: boolean;
 }
+
+export interface SkeletonConstructor {
+    new (bones: Bone[], boneInverses?: Matrix4[]): Skeleton;
+    prototype: Skeleton;
+}

--- a/types/three/src/objects/SkinnedMesh.d.ts
+++ b/types/three/src/objects/SkinnedMesh.d.ts
@@ -23,3 +23,11 @@ export class SkinnedMesh<
     updateMatrixWorld(force?: boolean): void;
     boneTransform(index: number, target: Vector3): Vector3;
 }
+
+export interface SkinnedMeshConstructor<
+    TGeometry extends BufferGeometry = BufferGeometry,
+    TMaterial extends Material | Material[] = Material | Material[],
+> {
+    new (geometry?: TGeometry, material?: TMaterial, useVertexTexture?: boolean): SkinnedMesh<TGeometry, TMaterial>;
+    prototype: SkinnedMesh<TGeometry, TMaterial>;
+}

--- a/types/three/src/objects/Sprite.d.ts
+++ b/types/three/src/objects/Sprite.d.ts
@@ -18,3 +18,8 @@ export class Sprite extends Object3D {
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
     copy(source: this): this;
 }
+
+export interface SpriteConstructor {
+    new (material?: SpriteMaterial): Sprite;
+    prototype: Sprite;
+}

--- a/types/three/src/renderers/WebGL1Renderer.d.ts
+++ b/types/three/src/renderers/WebGL1Renderer.d.ts
@@ -4,3 +4,8 @@ export class WebGL1Renderer extends WebGLRenderer {
     constructor(parameters?: WebGLRendererParameters);
     readonly isWebGL1Renderer: true;
 }
+
+export interface WebGL1RendererConstructor {
+    new (parameters?: WebGLRendererParameters): WebGL1Renderer;
+    prototype: WebGL1Renderer;
+}

--- a/types/three/src/renderers/WebGL3DRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGL3DRenderTarget.d.ts
@@ -26,3 +26,8 @@ export class WebGL3DRenderTarget extends WebGLRenderTarget {
 
     readonly isWebGL3DRenderTarget: true;
 }
+
+export interface WebGL3DRenderTargetConstructor {
+    new (width: number, height: number, depth: number): WebGL3DRenderTarget;
+    prototype: WebGL3DRenderTarget;
+}

--- a/types/three/src/renderers/WebGLArrayRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLArrayRenderTarget.d.ts
@@ -26,3 +26,8 @@ export class WebGLArrayRenderTarget extends WebGLRenderTarget {
 
     readonly isWebGLArrayRenderTarget: true;
 }
+
+export interface WebGLArrayRenderTargetConstructor {
+    new (width: number, height: number, depth: number): WebGLArrayRenderTarget;
+    prototype: WebGLArrayRenderTarget;
+}

--- a/types/three/src/renderers/WebGLCubeRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLCubeRenderTarget.d.ts
@@ -12,3 +12,8 @@ export class WebGLCubeRenderTarget extends WebGLRenderTarget {
 
     clear(renderer: WebGLRenderer, color: boolean, depth: boolean, stencil: boolean): void;
 }
+
+export interface WebGLCubeRenderTargetConstructor {
+    new (size: number, options?: WebGLRenderTargetOptions): WebGLCubeRenderTarget;
+    prototype: WebGLCubeRenderTarget;
+}

--- a/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
+++ b/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
@@ -27,3 +27,8 @@ export class WebGLMultipleRenderTargets extends EventDispatcher {
     // This is an available method, however it will break the code see https://github.com/mrdoob/three.js/issues/21930
     setTexture(texture: Texture): void;
 }
+
+export interface WebGLMultipleRenderTargetsConstructor {
+    new (width: number, height: number, count: number, options?: WebGLRenderTargetOptions): WebGLMultipleRenderTargets;
+    prototype: WebGLMultipleRenderTargets;
+}

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -103,3 +103,8 @@ export class WebGLRenderTarget extends EventDispatcher {
     copy(source: WebGLRenderTarget): this;
     dispose(): void;
 }
+
+export interface WebGLRenderTargetConstructor {
+    new (width: number, height: number, options?: WebGLRenderTargetOptions): WebGLRenderTarget;
+    prototype: WebGLRenderTarget;
+}

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -517,3 +517,8 @@ export class WebGLRenderer implements Renderer {
      */
     enableScissorTest(boolean: any): any;
 }
+
+export interface WebGLRendererConstructor {
+    new (parameters?: WebGLRendererParameters): WebGLRenderer;
+    prototype: WebGLRenderer;
+}

--- a/types/three/src/renderers/webgl/WebGLAttributes.d.ts
+++ b/types/three/src/renderers/webgl/WebGLAttributes.d.ts
@@ -16,3 +16,8 @@ export class WebGLAttributes {
 
     update(attribute: BufferAttribute | InterleavedBufferAttribute, bufferType: number): void;
 }
+
+export interface WebGLAttributesConstructor {
+    new (gl: WebGLRenderingContext | WebGL2RenderingContext, capabilities: WebGLCapabilities): WebGLAttributes;
+    prototype: WebGLAttributes;
+}

--- a/types/three/src/renderers/webgl/WebGLBindingStates.d.ts
+++ b/types/three/src/renderers/webgl/WebGLBindingStates.d.ts
@@ -31,3 +31,13 @@ export class WebGLBindingStates {
     enableAttribute(attribute: number): void;
     disableUnusedAttributes(): void;
 }
+
+export interface WebGLBindingStatesConstructor {
+    new (
+        gl: WebGLRenderingContext,
+        extensions: WebGLExtensions,
+        attributes: WebGLAttributes,
+        capabilities: WebGLCapabilities,
+    ): WebGLBindingStates;
+    prototype: WebGLBindingStates;
+}

--- a/types/three/src/renderers/webgl/WebGLBufferRenderer.d.ts
+++ b/types/three/src/renderers/webgl/WebGLBufferRenderer.d.ts
@@ -15,3 +15,13 @@ export class WebGLBufferRenderer {
     render(start: any, count: number): void;
     renderInstances(start: any, count: number, primcount: number): void;
 }
+
+export interface WebGLBufferRendererConstructor {
+    new (
+        gl: WebGLRenderingContext,
+        extensions: WebGLExtensions,
+        info: WebGLInfo,
+        capabilities: WebGLCapabilities,
+    ): WebGLBufferRenderer;
+    prototype: WebGLBufferRenderer;
+}

--- a/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
+++ b/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
@@ -24,3 +24,8 @@ export class WebGLCapabilities {
     getMaxAnisotropy(): number;
     getMaxPrecision(precision: string): string;
 }
+
+export interface WebGLCapabilitiesConstructor {
+    new (gl: WebGLRenderingContext, extensions: any, parameters: WebGLCapabilitiesParameters): WebGLCapabilities;
+    prototype: WebGLCapabilities;
+}

--- a/types/three/src/renderers/webgl/WebGLClipping.d.ts
+++ b/types/three/src/renderers/webgl/WebGLClipping.d.ts
@@ -22,3 +22,8 @@ export class WebGLClipping {
     endShadows(): void;
     setState(material: Material, camera: Camera, useCache: boolean): void;
 }
+
+export interface WebGLClippingConstructor {
+    new (properties: WebGLProperties): WebGLClipping;
+    prototype: WebGLClipping;
+}

--- a/types/three/src/renderers/webgl/WebGLCubeMaps.d.ts
+++ b/types/three/src/renderers/webgl/WebGLCubeMaps.d.ts
@@ -6,3 +6,8 @@ export class WebGLCubeMaps {
     get(texture: any): any;
     dispose(): void;
 }
+
+export interface WebGLCubeMapsConstructor {
+    new (renderer: WebGLRenderer): WebGLCubeMaps;
+    prototype: WebGLCubeMaps;
+}

--- a/types/three/src/renderers/webgl/WebGLCubeUVMaps.d.ts
+++ b/types/three/src/renderers/webgl/WebGLCubeUVMaps.d.ts
@@ -6,3 +6,8 @@ export class WebGLCubeUVMaps {
     get<T>(texture: T): T extends Texture ? Texture : T;
     dispose(): void;
 }
+
+export interface WebGLCubeUVMapsConstructor {
+    new (renderer: WebGLRenderer): WebGLCubeUVMaps;
+    prototype: WebGLCubeUVMaps;
+}

--- a/types/three/src/renderers/webgl/WebGLExtensions.d.ts
+++ b/types/three/src/renderers/webgl/WebGLExtensions.d.ts
@@ -7,3 +7,8 @@ export class WebGLExtensions {
     init(capabilities: WebGLCapabilities): void;
     get(name: string): any;
 }
+
+export interface WebGLExtensionsConstructor {
+    new (gl: WebGLRenderingContext): WebGLExtensions;
+    prototype: WebGLExtensions;
+}

--- a/types/three/src/renderers/webgl/WebGLGeometries.d.ts
+++ b/types/three/src/renderers/webgl/WebGLGeometries.d.ts
@@ -11,3 +11,8 @@ export class WebGLGeometries {
     update(geometry: BufferGeometry): void;
     getWireframeAttribute(geometry: BufferGeometry): BufferAttribute;
 }
+
+export interface WebGLGeometriesConstructor {
+    new (gl: WebGLRenderingContext, attributes: WebGLAttributes, info: WebGLInfo): WebGLGeometries;
+    prototype: WebGLGeometries;
+}

--- a/types/three/src/renderers/webgl/WebGLIndexedBufferRenderer.d.ts
+++ b/types/three/src/renderers/webgl/WebGLIndexedBufferRenderer.d.ts
@@ -6,3 +6,8 @@ export class WebGLIndexedBufferRenderer {
     render(start: any, count: number): void;
     renderInstances(start: any, count: number, primcount: number): void;
 }
+
+export interface WebGLIndexedBufferRendererConstructor {
+    new (gl: WebGLRenderingContext, extensions: any, info: any, capabilities: any): WebGLIndexedBufferRenderer;
+    prototype: WebGLIndexedBufferRenderer;
+}

--- a/types/three/src/renderers/webgl/WebGLInfo.d.ts
+++ b/types/three/src/renderers/webgl/WebGLInfo.d.ts
@@ -37,3 +37,8 @@ export class WebGLInfo {
     update(count: number, mode: number, instanceCount: number): void;
     reset(): void;
 }
+
+export interface WebGLInfoConstructor {
+    new (gl: WebGLRenderingContext): WebGLInfo;
+    prototype: WebGLInfo;
+}

--- a/types/three/src/renderers/webgl/WebGLLights.d.ts
+++ b/types/three/src/renderers/webgl/WebGLLights.d.ts
@@ -41,3 +41,8 @@ export class WebGLLights {
     setup(lights: any): void;
     setupView(lights: any, camera: any): void;
 }
+
+export interface WebGLLightsConstructor {
+    new (extensions: WebGLExtensions, capabilities: WebGLCapabilities): WebGLLights;
+    prototype: WebGLLights;
+}

--- a/types/three/src/renderers/webgl/WebGLObjects.d.ts
+++ b/types/three/src/renderers/webgl/WebGLObjects.d.ts
@@ -4,3 +4,8 @@ export class WebGLObjects {
     update(object: any): any;
     dispose(): void;
 }
+
+export interface WebGLObjectsConstructor {
+    new (gl: WebGLRenderingContext, geometries: any, attributes: any, info: any): WebGLObjects;
+    prototype: WebGLObjects;
+}

--- a/types/three/src/renderers/webgl/WebGLProgram.d.ts
+++ b/types/three/src/renderers/webgl/WebGLProgram.d.ts
@@ -29,3 +29,8 @@ export class WebGLProgram {
     getAttributes(): any;
     destroy(): void;
 }
+
+export interface WebGLProgramConstructor {
+    new (renderer: WebGLRenderer, cacheKey: string, parameters: object): WebGLProgram;
+    prototype: WebGLProgram;
+}

--- a/types/three/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/types/three/src/renderers/webgl/WebGLPrograms.d.ts
@@ -26,3 +26,15 @@ export class WebGLPrograms {
     acquireProgram(parameters: any, cacheKey: string): WebGLProgram;
     releaseProgram(program: WebGLProgram): void;
 }
+
+export interface WebGLProgramsConstructor {
+    new (
+        renderer: WebGLRenderer,
+        cubemaps: WebGLCubeMaps,
+        extensions: WebGLExtensions,
+        capabilities: WebGLCapabilities,
+        bindingStates: WebGLBindingStates,
+        clipping: WebGLClipping,
+    ): WebGLPrograms;
+    prototype: WebGLPrograms;
+}

--- a/types/three/src/renderers/webgl/WebGLProperties.d.ts
+++ b/types/three/src/renderers/webgl/WebGLProperties.d.ts
@@ -6,3 +6,8 @@ export class WebGLProperties {
     update(object: any, key: any, value: any): any;
     dispose(): void;
 }
+
+export interface WebGLPropertiesConstructor {
+    new (): WebGLProperties;
+    prototype: WebGLProperties;
+}

--- a/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
+++ b/types/three/src/renderers/webgl/WebGLRenderLists.d.ts
@@ -58,9 +58,19 @@ export class WebGLRenderList {
     finish(): void;
 }
 
+export interface WebGLRenderListConstructor {
+    new (properties: WebGLProperties): WebGLRenderList;
+    prototype: WebGLRenderList;
+}
+
 export class WebGLRenderLists {
     constructor(properties: WebGLProperties);
 
     dispose(): void;
     get(scene: Scene, renderCallDepth: number): WebGLRenderList;
+}
+
+export interface WebGLRenderListsConstructor {
+    new (properties: WebGLProperties): WebGLRenderLists;
+    prototype: WebGLRenderLists;
 }

--- a/types/three/src/renderers/webgl/WebGLShadowMap.d.ts
+++ b/types/three/src/renderers/webgl/WebGLShadowMap.d.ts
@@ -36,3 +36,8 @@ export class WebGLShadowMap {
      */
     cullFace: any;
 }
+
+export interface WebGLShadowMapConstructor {
+    new (_renderer: WebGLRenderer, _objects: WebGLObjects, _capabilities: WebGLCapabilities): WebGLShadowMap;
+    prototype: WebGLShadowMap;
+}

--- a/types/three/src/renderers/webgl/WebGLState.d.ts
+++ b/types/three/src/renderers/webgl/WebGLState.d.ts
@@ -20,6 +20,11 @@ export class WebGLColorBuffer {
     reset(): void;
 }
 
+export interface WebGLColorBufferConstructor {
+    new (): WebGLColorBuffer;
+    prototype: WebGLColorBuffer;
+}
+
 export class WebGLDepthBuffer {
     constructor();
 
@@ -29,6 +34,11 @@ export class WebGLDepthBuffer {
     setLocked(lock: boolean): void;
     setClear(depth: number): void;
     reset(): void;
+}
+
+export interface WebGLDepthBufferConstructor {
+    new (): WebGLDepthBuffer;
+    prototype: WebGLDepthBuffer;
 }
 
 export class WebGLStencilBuffer {
@@ -41,6 +51,11 @@ export class WebGLStencilBuffer {
     setLocked(lock: boolean): void;
     setClear(stencil: number): void;
     reset(): void;
+}
+
+export interface WebGLStencilBufferConstructor {
+    new (): WebGLStencilBuffer;
+    prototype: WebGLStencilBuffer;
 }
 
 export class WebGLState {
@@ -126,4 +141,9 @@ export class WebGLState {
     scissor(scissor: Vector4): void;
     viewport(viewport: Vector4): void;
     reset(): void;
+}
+
+export interface WebGLStateConstructor {
+    new (gl: WebGLRenderingContext, extensions: WebGLExtensions, capabilities: WebGLCapabilities): WebGLState;
+    prototype: WebGLState;
 }

--- a/types/three/src/renderers/webgl/WebGLTextures.d.ts
+++ b/types/three/src/renderers/webgl/WebGLTextures.d.ts
@@ -28,3 +28,16 @@ export class WebGLTextures {
     safeSetTexture2D(texture: any, slot: number): void;
     safeSetTextureCube(texture: any, slot: number): void;
 }
+
+export interface WebGLTexturesConstructor {
+    new (
+        gl: WebGLRenderingContext,
+        extensions: WebGLExtensions,
+        state: WebGLState,
+        properties: WebGLProperties,
+        capabilities: WebGLCapabilities,
+        utils: WebGLUtils,
+        info: WebGLInfo,
+    ): WebGLTextures;
+    prototype: WebGLTextures;
+}

--- a/types/three/src/renderers/webgl/WebGLUniforms.d.ts
+++ b/types/three/src/renderers/webgl/WebGLUniforms.d.ts
@@ -10,3 +10,8 @@ export class WebGLUniforms {
     static upload(gl: WebGLRenderingContext, seq: any, values: any[], textures: WebGLTextures): void;
     static seqWithValue(seq: any, values: any[]): any[];
 }
+
+export interface WebGLUniformsConstructor {
+    new (gl: WebGLRenderingContext, program: WebGLProgram): WebGLUniforms;
+    prototype: WebGLUniforms;
+}

--- a/types/three/src/renderers/webgl/WebGLUtils.d.ts
+++ b/types/three/src/renderers/webgl/WebGLUtils.d.ts
@@ -5,3 +5,8 @@ export class WebGLUtils {
 
     convert(p: PixelFormat | CompressedPixelFormat | TextureDataType, encoding?: TextureEncoding | null): number | null;
 }
+
+export interface WebGLUtilsConstructor {
+    new (gl: WebGLRenderingContext | WebGL2RenderingContext, extensions: any, capabilities: any): WebGLUtils;
+    prototype: WebGLUtils;
+}

--- a/types/three/src/renderers/webxr/WebXR.d.ts
+++ b/types/three/src/renderers/webxr/WebXR.d.ts
@@ -181,6 +181,11 @@ export class XRWebGLLayer {
     getViewport(view: XRView): XRViewport;
 }
 
+export interface XRWebGLLayerConstructor {
+    new (session: XRSession, gl: WebGLRenderingContext | undefined, options?: XRWebGLLayerInit): XRWebGLLayer;
+    prototype: XRWebGLLayer;
+}
+
 export interface DOMPointInit {
     w?: number | undefined;
     x?: number | undefined;
@@ -194,6 +199,11 @@ export class XRRigidTransform {
     orientation: DOMPointReadOnly;
     matrix: Float32Array;
     inverse: XRRigidTransform;
+}
+
+export interface XRRigidTransformConstructor {
+    new (matrix: Float32Array | DOMPointInit, direction?: DOMPointInit): XRRigidTransform;
+    prototype: XRRigidTransform;
 }
 
 export interface XRView {
@@ -216,6 +226,11 @@ export class XRRay {
     matrix: Float32Array;
 
     constructor(transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: XRRayDirectionInit);
+}
+
+export interface XRRayConstructor {
+    new (transformOrOrigin: XRRigidTransform | DOMPointInit, direction?: XRRayDirectionInit): XRRay;
+    prototype: XRRay;
 }
 
 export enum XRHitTestTrackableType {

--- a/types/three/src/renderers/webxr/WebXRController.d.ts
+++ b/types/three/src/renderers/webxr/WebXRController.d.ts
@@ -12,3 +12,8 @@ export class WebXRController {
     disconnect(inputSource: XRInputSource): this;
     update(inputSource: XRInputSource, frame: XRFrame, referenceSpace: XRReferenceSpace): this;
 }
+
+export interface WebXRControllerConstructor {
+    new (): WebXRController;
+    prototype: WebXRController;
+}

--- a/types/three/src/renderers/webxr/WebXRManager.d.ts
+++ b/types/three/src/renderers/webxr/WebXRManager.d.ts
@@ -30,3 +30,8 @@ export class WebXRManager extends EventDispatcher {
     setFoveation(foveation: number): void;
     dispose(): void;
 }
+
+export interface WebXRManagerConstructor {
+    new (renderer: any, gl: WebGLRenderingContext): WebXRManager;
+    prototype: WebXRManager;
+}

--- a/types/three/src/scenes/Fog.d.ts
+++ b/types/three/src/scenes/Fog.d.ts
@@ -41,3 +41,8 @@ export class Fog implements FogBase {
     clone(): Fog;
     toJSON(): any;
 }
+
+export interface FogConstructor {
+    new (color: ColorRepresentation, near?: number, far?: number): Fog;
+    prototype: Fog;
+}

--- a/types/three/src/scenes/FogExp2.d.ts
+++ b/types/three/src/scenes/FogExp2.d.ts
@@ -24,3 +24,8 @@ export class FogExp2 implements FogBase {
     clone(): FogExp2;
     toJSON(): any;
 }
+
+export interface FogExp2Constructor {
+    new (hex: number | string, density?: number): FogExp2;
+    prototype: FogExp2;
+}

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -47,3 +47,8 @@ export class Scene extends Object3D {
 
     toJSON(meta?: any): any;
 }
+
+export interface SceneConstructor {
+    new (): Scene;
+    prototype: Scene;
+}

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -28,3 +28,18 @@ export class CanvasTexture extends Texture {
 
     readonly isCanvasTexture: true;
 }
+
+export interface CanvasTextureConstructor {
+    new (
+        canvas: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        format?: PixelFormat,
+        type?: TextureDataType,
+        anisotropy?: number,
+    ): CanvasTexture;
+    prototype: CanvasTexture;
+}

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -55,3 +55,21 @@ export class CompressedTexture extends Texture {
 
     readonly isCompressedTexture: true;
 }
+
+export interface CompressedTextureConstructor {
+    new (
+        mipmaps: ImageData[],
+        width: number,
+        height: number,
+        format?: CompressedPixelFormat,
+        type?: TextureDataType,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        anisotropy?: number,
+        encoding?: TextureEncoding,
+    ): CompressedTexture;
+    prototype: CompressedTexture;
+}

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -36,3 +36,19 @@ export class CubeTexture extends Texture {
 
     readonly isCubeTexture: true;
 }
+
+export interface CubeTextureConstructor {
+    new (
+        images?: any[], // HTMLImageElement or HTMLCanvasElement
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        format?: PixelFormat,
+        type?: TextureDataType,
+        anisotropy?: number,
+        encoding?: TextureEncoding,
+    ): CubeTexture;
+    prototype: CubeTexture;
+}

--- a/types/three/src/textures/Data3DTexture.d.ts
+++ b/types/three/src/textures/Data3DTexture.d.ts
@@ -31,3 +31,8 @@ export class Data3DTexture extends Texture {
 
     readonly isData3DTexture: true;
 }
+
+export interface Data3DTextureConstructor {
+    new (data: BufferSource, width: number, height: number, depth: number): Data3DTexture;
+    prototype: Data3DTexture;
+}

--- a/types/three/src/textures/DataArrayTexture.d.ts
+++ b/types/three/src/textures/DataArrayTexture.d.ts
@@ -31,3 +31,8 @@ export class DataArrayTexture extends Texture {
 
     readonly isDataArrayTexture: true;
 }
+
+export interface DataArrayTextureConstructor {
+    new (data?: BufferSource, width?: number, height?: number, depth?: number): DataArrayTexture;
+    prototype: DataArrayTexture;
+}

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -56,3 +56,21 @@ export class DataTexture extends Texture {
 
     readonly isDataTexture: true;
 }
+
+export interface DataTextureConstructor {
+    new (
+        data?: BufferSource | null,
+        width?: number,
+        height?: number,
+        format?: PixelFormat,
+        type?: TextureDataType,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        anisotropy?: number,
+        encoding?: TextureEncoding,
+    ): DataTexture;
+    prototype: DataTexture;
+}

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -40,3 +40,18 @@ export class DepthTexture extends Texture {
 
     readonly isDepthTexture: true;
 }
+
+export interface DepthTextureConstructor {
+    new (
+        width: number,
+        height: number,
+        type?: TextureDataType,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        anisotropy?: number,
+    ): DepthTexture;
+    prototype: DepthTexture;
+}

--- a/types/three/src/textures/FramebufferTexture.d.ts
+++ b/types/three/src/textures/FramebufferTexture.d.ts
@@ -6,3 +6,8 @@ export class FramebufferTexture extends Texture {
 
     constructor(width: number, height: number, format: PixelFormat);
 }
+
+export interface FramebufferTextureConstructor {
+    new (width: number, height: number, format: PixelFormat): FramebufferTexture;
+    prototype: FramebufferTexture;
+}

--- a/types/three/src/textures/Source.d.ts
+++ b/types/three/src/textures/Source.d.ts
@@ -37,3 +37,8 @@ export class Source {
 
     readonly isTexture: true;
 }
+
+export interface SourceConstructor {
+    new (data: any): Source;
+    prototype: Source;
+}

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -209,3 +209,19 @@ export class Texture extends EventDispatcher {
     transformUv(uv: Vector2): Vector2;
     updateMatrix(): void;
 }
+
+export interface TextureConstructor {
+    new (
+        image?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        format?: PixelFormat,
+        type?: TextureDataType,
+        anisotropy?: number,
+        encoding?: TextureEncoding,
+    ): Texture;
+    prototype: Texture;
+}

--- a/types/three/src/textures/VideoTexture.d.ts
+++ b/types/three/src/textures/VideoTexture.d.ts
@@ -32,3 +32,18 @@ export class VideoTexture extends Texture {
      */
     generateMipmaps: boolean;
 }
+
+export interface VideoTextureConstructor {
+    new (
+        video: HTMLVideoElement,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: TextureFilter,
+        minFilter?: TextureFilter,
+        format?: PixelFormat,
+        type?: TextureDataType,
+        anisotropy?: number,
+    ): VideoTexture;
+    prototype: VideoTexture;
+}


### PR DESCRIPTION
### Why

In TypeScript, the parameters to a constructor can be retrieved with a utility type called `ConstructorParameters<Type>`: https://www.typescriptlang.org/docs/handbook/utility-types.html#constructorparameterstype

The Type parameter to ConstructorParameters expects a Constructor interface type, which is an interface with a `new` member and a `prototype` member.

By defining these *Constructor interfaces, Three.js class types can now be used with ConstructorParameters.

### What

I wrote a C# program to scan all the .d.ts files for class exports, extract an interface definition for the constructors, and insert the constructor interfaces after each class definition. My program correctly handles generic classes, multiple class definitions per file, and multiple constructor overloads. You can see that program here: https://github.com/capnmidnight/Juniper/blob/master/etc/GenerateConstructorTypes/Program.cs

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
