### PR TITLE
Fixed SavePass constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://twitter.com/ggsimm"><img src="https://avatars.githubusercontent.com/u/1862172?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Gianmarco</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=gsimone" title="Code">💻</a></td>
     <td align="center"><a href="https://davidpeicho.github.io/"><img src="https://avatars.githubusercontent.com/u/8783766?v=4?s=100" width="100px;" alt=""/><br /><sub><b>David Peicho</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=DavidPeicho" title="Code">💻</a></td>
     <td align="center"><a href="https://subho57.github.io"><img src="https://avatars.githubusercontent.com/u/98544661?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Subhankar Pal</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=subhankar-trisetra" title="Code">💻</a> <a href="https://github.com/three-types/three-ts-types/commits?author=subhankar-trisetra" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://synphonyte.com"><img src="https://avatars.githubusercontent.com/u/380881?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Maccesch</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=maccesch" title="Code">💻</a> <a href="https://github.com/three-types/three-ts-types/commits?author=maccesch" title="Tests">⚠️</a></td>
   </tr>
 </table>
 

--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -118,7 +118,6 @@ examples/jsm/postprocessing/OutlinePass.d.ts
 examples/jsm/postprocessing/RenderPass.d.ts
 examples/jsm/postprocessing/BloomPass.d.ts
 examples/jsm/postprocessing/SAOPass.d.ts
-examples/jsm/postprocessing/SavePass.d.ts
 examples/jsm/postprocessing/SMAAPass.d.ts
 examples/jsm/postprocessing/SSAARenderPass.d.ts
 examples/jsm/postprocessing/SSAOPass.d.ts

--- a/types/three/examples/jsm/postprocessing/SavePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SavePass.d.ts
@@ -3,7 +3,7 @@ import { ShaderMaterial, WebGLRenderTarget } from '../../../src/Three';
 import { Pass } from './Pass';
 
 export class SavePass extends Pass {
-    constructor(renderTarget: WebGLRenderTarget);
+    constructor(renderTarget?: WebGLRenderTarget);
     textureID: string;
     renderTarget: WebGLRenderTarget;
     uniforms: object;

--- a/types/three/test/postprocessing/postprocessing-savepass.ts
+++ b/types/three/test/postprocessing/postprocessing-savepass.ts
@@ -1,0 +1,8 @@
+import * as THREE from 'three';
+import { SavePass } from 'three/examples/jsm/postprocessing/SavePass';
+
+let pass = new SavePass(); // $ExpectType SavePass
+let rt = pass.renderTarget; // $ExpectType WebGLRenderTarget
+
+pass = new SavePass(new THREE.WebGLRenderTarget(128, 128)); // $ExpectType SavePass
+rt = pass.renderTarget; // $ExpectType WebGLRenderTarget

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -56,6 +56,7 @@
         "test/misc/misc-gpucomputationrender.ts",
         "test/postprocessing/postprocessing-ssr.ts",
         "test/postprocessing/postprocessing-effectcomposer-pass.ts",
+        "test/postprocessing/postprocessing-savepass.ts",
         "test/renderers/renderers-renderTarget-multiple.ts",
         "test/renderers/renderers-renderTarget-texture2DArray.ts",
         "test/renderers/webxr/webxr-vr-cube.ts",


### PR DESCRIPTION
Parameter `renderTarget` is optional in the constructor of `SavePass`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table 
  - feels a bit prentenious to add myself there because I added literally just one single character. But it's in the checklist, so I did 😄 
-   [x] Ready to be merged