### PR TITLE
Fix GLTFExporter setPlugins return type

### DIFF
--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -91,7 +91,7 @@ export class GLTFExporter {
 export class GLTFWriter {
     constructor();
 
-    setPlugins(plugins: GLTFExporterPlugin[]);
+    setPlugins(plugins: GLTFExporterPlugin[]): void;
 
     /**
      * Parse scenes and generate GLTF output


### PR DESCRIPTION
### Why

`setPlugins()` currently has no return type, which is an implicit `any` type. In our environment implicit any is disabled and we are typechecking libraries at the moment. The following error occurs with v140 https://github.com/matrix-org/thirdroom/runs/6284942291?check_suite_focus=true#step:5:6

### What

Make `setPlugins()` return type `void`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
