### PR TITLE
fix: Add missing extend to Loader in NRRDLoader

### DIFF
--- a/types/three/examples/jsm/loaders/NRRDLoader.d.ts
+++ b/types/three/examples/jsm/loaders/NRRDLoader.d.ts
@@ -1,8 +1,8 @@
-import { LoadingManager } from '../../../src/Three';
+import { Loader, LoadingManager } from '../../../src/Three';
 
 import { Volume } from '../misc/Volume';
 
-export class NRRDLoader {
+export class NRRDLoader extends Loader {
     constructor(manager?: LoadingManager);
     manager: LoadingManager;
     path: string;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The extend to Loader is missing in the type NRRDLoader which has for effect to be unable to compile TS without errors.

### What

I added the extend to Loader in NRRDLoader the same way all the other loaders extend it.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
