### PR TITLE
Update webXR hand profile names

### DIFF
--- a/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
+++ b/types/three/examples/jsm/webxr/XRHandModelFactory.d.ts
@@ -19,7 +19,7 @@ export class XRHandModelFactory {
 
     createHandModel(
         controller: Group,
-        profile?: 'spheres' | 'boxes' | 'oculus',
+        profile?: 'spheres' | 'boxes' | 'mesh',
         options?: XRHandPrimitiveModelOptions,
     ): XRHandModel;
 }


### PR DESCRIPTION
### Why

The hand tracking profile name "mesh" is not considered valid because the type definitions still use the old name "oculus".
The hand profile names were changed in THREE.js r129 ([commit 571347f](https://github.com/mrdoob/three.js/commit/571347f504dec332f6905bb3d8ef43f1b405d45c)). Since this repo is supposed to correspond to revision r140, this was probably an omission and should be updated.

### What

Updated the profile name to reflect the new one

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged
