### PR TITLE
fix: add missing `samples` parameter of WebGLRenderTarget

### DIFF
--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -17,6 +17,12 @@ export interface WebGLRenderTargetOptions {
     generateMipmaps?: boolean | undefined; // true;
     depthTexture?: DepthTexture | undefined;
     encoding?: TextureEncoding | undefined;
+
+    /**
+     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
+     * @default 0
+     */
+    samples?: number;
 }
 
 export class WebGLRenderTarget extends EventDispatcher {


### PR DESCRIPTION
### Why

Obvious

### What

Add a missing parameter `samples` to `WebGLRenderTarget` .

I forgot to add this in my last PR: https://github.com/three-types/three-ts-types/commit/ac2358fbd2cfd8ba9f3660a6cb8bbe769ce580b3

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
