### PR TITLE
fix: return type for GLTFLoader's parseAsync method

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -65,7 +65,7 @@ export class GLTFLoader extends Loader {
         onError?: (event: ErrorEvent) => void,
     ): void;
 
-    parseAsync(data: ArrayBuffer | string, path: string): Promise<void>;
+    parseAsync(data: ArrayBuffer | string, path: string): Promise<GLTF>;
 }
 
 export type GLTFReferenceType = 'materials' | 'nodes' | 'textures' | 'meshes';


### PR DESCRIPTION
### Why

`GLTFLoader::parseAsync()` indicates a `Promise<void>` return type, which is incorrect

### What

Change `GLTFLoader::parseAsync()` to return `Promise<GLTF>`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
