### PR TITLE
fix: remove context field from WebGLRenderer

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -128,11 +128,6 @@ export class WebGLRenderer implements Renderer {
     domElement: HTMLCanvasElement;
 
     /**
-     * The HTML5 Canvas's 'webgl' context obtained from the canvas where the renderer will draw.
-     */
-    context: WebGLRenderingContext;
-
-    /**
      * Defines whether the renderer should automatically clear its output before rendering.
      * @default true
      */


### PR DESCRIPTION
### Why

The context field of WebGLRenderer was removed from Three.js on Jul 10, 2019

https://github.com/mrdoob/three.js/commit/246cf01522a69b500d858ae71a0b69cf24d1808e

### What

Just deleted the field.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged