### PR TITLE
fix issue #124: Texture and MipMap types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -349,10 +349,8 @@
       "profile": "https://github.com/atulrnt",
       "contributions": [
         "code",
-      ],
-        "code"
       ]
-    },
+    }
   ],
   "skipCi": true,
   "contributorsPerLine": 7

--- a/types/three/examples/jsm/loaders/DDSLoader.d.ts
+++ b/types/three/examples/jsm/loaders/DDSLoader.d.ts
@@ -1,7 +1,7 @@
 import { LoadingManager, CompressedTextureLoader, PixelFormat, CompressedPixelFormat } from '../../../src/Three';
 
 export interface DDS {
-    mipmaps: object[];
+    mipmaps: ImageData[];
     width: number;
     height: number;
     format: PixelFormat | CompressedPixelFormat;

--- a/types/three/examples/jsm/loaders/KTXLoader.d.ts
+++ b/types/three/examples/jsm/loaders/KTXLoader.d.ts
@@ -1,7 +1,7 @@
 import { LoadingManager, CompressedTextureLoader, PixelFormat, CompressedPixelFormat } from '../../../src/Three';
 
 export interface KTX {
-    mipmaps: object[];
+    mipmaps: ImageData[];
     width: number;
     height: number;
     format: PixelFormat | CompressedPixelFormat;

--- a/types/three/examples/jsm/loaders/PVRLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PVRLoader.d.ts
@@ -1,7 +1,7 @@
 import { LoadingManager, CompressedTextureLoader, CompressedPixelFormat } from '../../../src/Three';
 
 export interface PVR {
-    mipmaps: object[];
+    mipmaps: ImageData[];
     width: number;
     height: number;
     format: CompressedPixelFormat;

--- a/types/three/src/renderers/WebGL3DRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGL3DRenderTarget.d.ts
@@ -1,10 +1,11 @@
 import { Data3DTexture } from '../textures/Data3DTexture';
+import { DataDimensions3D } from '../textures/Texture';
 import { WebGLRenderTarget } from './WebGLRenderTarget';
 
 /**
  * Represents a three-dimensional render target.
  */
-export class WebGL3DRenderTarget extends WebGLRenderTarget {
+export class WebGL3DRenderTarget extends WebGLRenderTarget<DataDimensions3D, DataDimensions3D, Data3DTexture> {
     /**
      * Creates a new WebGL3DRenderTarget.
      *
@@ -18,11 +19,6 @@ export class WebGL3DRenderTarget extends WebGLRenderTarget {
      * The depth of the render target.
      */
     depth: number;
-
-    /**
-     * The texture property is overwritten with an instance of {@link Data3DTexture}.
-     */
-    texture: Data3DTexture;
 
     readonly isWebGL3DRenderTarget: true;
 }

--- a/types/three/src/renderers/WebGLArrayRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLArrayRenderTarget.d.ts
@@ -1,10 +1,11 @@
 import { DataArrayTexture } from '../textures/DataArrayTexture';
+import { DataDimensions3D } from '../textures/Texture';
 import { WebGLRenderTarget } from './WebGLRenderTarget';
 
 /**
  * This type of render target represents an array of textures.
  */
-export class WebGLArrayRenderTarget extends WebGLRenderTarget {
+export class WebGLArrayRenderTarget extends WebGLRenderTarget<DataDimensions3D, DataDimensions3D, DataArrayTexture> {
     /**
      * Creates a new WebGLArrayRenderTarget.
      *
@@ -18,11 +19,6 @@ export class WebGLArrayRenderTarget extends WebGLRenderTarget {
      * The depth of the render target.
      */
     depth: number;
-
-    /**
-     * The texture property is overwritten with an instance of {@link DataArrayTexture}.
-     */
-    texture: DataArrayTexture;
 
     readonly isWebGLArrayRenderTarget: true;
 }

--- a/types/three/src/renderers/WebGLCubeRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLCubeRenderTarget.d.ts
@@ -1,12 +1,10 @@
 import { WebGLRenderTargetOptions, WebGLRenderTarget } from './WebGLRenderTarget';
 import { WebGLRenderer } from './WebGLRenderer';
-import { Texture } from './../textures/Texture';
+import { BaseTextureImageType, Texture } from './../textures/Texture';
 import { CubeTexture } from './../textures/CubeTexture';
 
-export class WebGLCubeRenderTarget extends WebGLRenderTarget {
+export class WebGLCubeRenderTarget extends WebGLRenderTarget<BaseTextureImageType[], CubeTexture, CubeTexture> {
     constructor(size: number, options?: WebGLRenderTargetOptions);
-
-    texture: CubeTexture;
 
     fromEquirectangularTexture(renderer: WebGLRenderer, texture: Texture): this;
 

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -1,5 +1,5 @@
 import { Vector4 } from './../math/Vector4';
-import { Texture } from './../textures/Texture';
+import { MipMapType, Texture, TextureImageTypes } from './../textures/Texture';
 import { DepthTexture } from './../textures/DepthTexture';
 import { EventDispatcher } from './../core/EventDispatcher';
 import { Wrapping, TextureFilter, TextureDataType, TextureEncoding } from '../constants';
@@ -25,7 +25,11 @@ export interface WebGLRenderTargetOptions {
     samples?: number;
 }
 
-export class WebGLRenderTarget extends EventDispatcher {
+export class WebGLRenderTarget<
+    ImageT extends TextureImageTypes = TextureImageTypes,
+    MipMapT extends MipMapType = MipMapType,
+    TextureT extends Texture<ImageT, MipMapT> = Texture<ImageT, MipMapT>,
+> extends EventDispatcher {
     constructor(width: number, height: number, options?: WebGLRenderTargetOptions);
 
     width: number;
@@ -38,7 +42,7 @@ export class WebGLRenderTarget extends EventDispatcher {
      */
     scissorTest: boolean;
     viewport: Vector4;
-    texture: Texture;
+    texture: TextureT;
 
     /**
      * @default true

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -1,7 +1,8 @@
 import { Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
+import { OffscreenCanvas } from '../renderers/WebGLRenderer';
 
-export class CanvasTexture extends Texture {
+export class CanvasTexture extends Texture<HTMLCanvasElement> {
     /**
      * @param canvas
      * @param [format=THREE.RGBAFormat]
@@ -15,7 +16,7 @@ export class CanvasTexture extends Texture {
      * @param [encoding=THREE.LinearEncoding]
      */
     constructor(
-        canvas: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap,
+        canvas: HTMLCanvasElement | OffscreenCanvas,
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -1,4 +1,4 @@
-import { Texture } from './Texture';
+import { Dimensions2D, Texture } from './Texture';
 import {
     Mapping,
     Wrapping,
@@ -8,7 +8,7 @@ import {
     TextureEncoding,
 } from '../constants';
 
-export class CompressedTexture extends Texture {
+export class CompressedTexture extends Texture<Dimensions2D> {
     /**
      * @param mipmaps
      * @param width
@@ -37,9 +37,6 @@ export class CompressedTexture extends Texture {
         anisotropy?: number,
         encoding?: TextureEncoding,
     );
-
-    get image(): { width: number; height: number };
-    set image(value: { width: number; height: number });
 
     mipmaps: ImageData[];
 

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -1,7 +1,7 @@
-import { Texture } from './Texture';
+import { BaseTextureImageType, Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding } from '../constants';
 
-export class CubeTexture extends Texture {
+export class CubeTexture extends Texture<BaseTextureImageType[], CubeTexture> {
     /**
      * @param [images=[]]
      * @param [mapping=THREE.CubeReflectionMapping]
@@ -15,7 +15,7 @@ export class CubeTexture extends Texture {
      * @param [encoding=THREE.LinearEncoding]
      */
     constructor(
-        images?: any[], // HTMLImageElement or HTMLCanvasElement
+        images?: BaseTextureImageType[],
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,

--- a/types/three/src/textures/Data3DTexture.d.ts
+++ b/types/three/src/textures/Data3DTexture.d.ts
@@ -1,7 +1,7 @@
-import { Texture } from './Texture';
+import { DataDimensions3D, Texture } from './Texture';
 import { TextureFilter } from '../constants';
 
-export class Data3DTexture extends Texture {
+export class Data3DTexture extends Texture<DataDimensions3D, DataDimensions3D> {
     constructor(data: BufferSource, width: number, height: number, depth: number);
 
     /**

--- a/types/three/src/textures/DataArrayTexture.d.ts
+++ b/types/three/src/textures/DataArrayTexture.d.ts
@@ -1,7 +1,7 @@
-import { Texture } from './Texture';
+import { DataDimensions3D, Texture } from './Texture';
 import { TextureFilter } from '../constants';
 
-export class DataArrayTexture extends Texture {
+export class DataArrayTexture extends Texture<DataDimensions3D, DataDimensions3D> {
     constructor(data?: BufferSource, width?: number, height?: number, depth?: number);
 
     /**

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -1,7 +1,7 @@
 import { Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding } from '../constants';
 
-export class DataTexture extends Texture {
+export class DataTexture extends Texture<ImageData> {
     /**
      * @param data
      * @param width

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -1,7 +1,7 @@
-import { Texture } from './Texture';
+import { Dimensions2D, Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, TextureDataType } from '../constants';
 
-export class DepthTexture extends Texture {
+export class DepthTexture extends Texture<Dimensions2D> {
     /**
      * @param width
      * @param height
@@ -24,9 +24,6 @@ export class DepthTexture extends Texture {
         minFilter?: TextureFilter,
         anisotropy?: number,
     );
-
-    get image(): { width: number; height: number };
-    set image(value: { width: number; height: number });
 
     /**
      * @default false

--- a/types/three/src/textures/FramebufferTexture.d.ts
+++ b/types/three/src/textures/FramebufferTexture.d.ts
@@ -1,7 +1,7 @@
-import { Texture } from './Texture';
+import { Dimensions2D, Texture } from './Texture';
 import { PixelFormat } from '../constants';
 
-export class FramebufferTexture extends Texture {
+export class FramebufferTexture extends Texture<Dimensions2D> {
     readonly isFramebufferTexture: true;
 
     constructor(width: number, height: number, format: PixelFormat);

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -11,8 +11,32 @@ import {
     TextureDataType,
     TextureEncoding,
 } from '../constants';
+import { CubeTexture } from './CubeTexture';
+import { OffscreenCanvas } from '../renderers/WebGLRenderer';
 
-export class Texture extends EventDispatcher {
+export interface Dimensions2D {
+    width: number;
+    height: number;
+}
+
+export interface DataDimensions3D extends ImageData {
+    depth: number;
+}
+
+export type BaseTextureImageType = TexImageSource | OffscreenCanvas | DataDimensions3D | Dimensions2D;
+
+export type TextureImageTypes = BaseTextureImageType | BaseTextureImageType[];
+
+export interface ManualMipMapType<ImageSource extends TexImageSource = TexImageSource> extends Dimensions2D {
+    data: ImageSource;
+}
+
+export type MipMapType = ImageData | ManualMipMapType | CubeTexture;
+
+export class Texture<
+    ImageT extends TextureImageTypes = TextureImageTypes,
+    MipMapT extends MipMapType = MipMapType,
+> extends EventDispatcher {
     /**
      * @param [image]
      * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
@@ -26,7 +50,7 @@ export class Texture extends EventDispatcher {
      * @param [encoding=THREE.LinearEncoding]
      */
     constructor(
-        image?: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
+        image?: ImageT,
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
@@ -61,7 +85,7 @@ export class Texture extends EventDispatcher {
      * video element as a source for your texture image and continuously update this texture
      * as long as video is playing - the {@link VideoTexture} class handles this automatically.
      */
-    get image(): any;
+    get image(): ImageT;
 
     /**
      * An image object, typically created using the {@link TextureLoader.load} method.
@@ -71,12 +95,12 @@ export class Texture extends EventDispatcher {
      * video element as a source for your texture image and continuously update this texture
      * as long as video is playing - the {@link VideoTexture} class handles this automatically.
      */
-    set image(data: any);
+    set image(data: ImageT);
 
     /**
      * @default []
      */
-    mipmaps: any[]; // ImageData[] for 2D textures and CubeTexture[] for cube textures;
+    mipmaps: MipMapT[]; // ImageData[] for 2D textures and CubeTexture[] for cube textures;
 
     /**
      * @default THREE.Texture.DEFAULT_MAPPING

--- a/types/three/src/textures/VideoTexture.d.ts
+++ b/types/three/src/textures/VideoTexture.d.ts
@@ -1,7 +1,7 @@
 import { Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
 
-export class VideoTexture extends Texture {
+export class VideoTexture extends Texture<HTMLVideoElement> {
     /**
      * @param video
      * @param [mapping=THREE.Texture.DEFAULT_MAPPING]

--- a/types/three/test/postprocessing/postprocessing-savepass.ts
+++ b/types/three/test/postprocessing/postprocessing-savepass.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { SavePass } from 'three/examples/jsm/postprocessing/SavePass';
 
 let pass = new SavePass(); // $ExpectType SavePass
-let rt = pass.renderTarget; // $ExpectType WebGLRenderTarget
+let rt = pass.renderTarget; // $ExpectType WebGLRenderTarget<TextureImageTypes, MipMapType, Texture<TextureImageTypes, MipMapType>>
 
 pass = new SavePass(new THREE.WebGLRenderTarget(128, 128)); // $ExpectType SavePass
-rt = pass.renderTarget; // $ExpectType WebGLRenderTarget
+rt = pass.renderTarget; // $ExpectType WebGLRenderTarget<TextureImageTypes, MipMapType, Texture<TextureImageTypes, MipMapType>>

--- a/types/three/test/textures/textures-source.ts
+++ b/types/three/test/textures/textures-source.ts
@@ -11,3 +11,57 @@ imageLoader.load('/path/to/image.png', image => {
     material.map.source = source;
     material.map.offset.x = 0.5;
 });
+
+function assertNever(_: never): void {
+    throw new Error('Assertion failed');
+}
+
+(function testTextureFromImage() {
+    const image = document.createElement('img');
+    const imageTex = new THREE.Texture(image);
+    const img = imageTex.image; // $ExpectType HTMLImageElement
+    if (!(img instanceof HTMLImageElement)) {
+        assertNever(img);
+    }
+})();
+
+(function testTextureFromCanvas() {
+    const canvas = document.createElement('canvas');
+    const canvasTex = new THREE.Texture(canvas);
+    const canv = canvasTex.image; // $ExpectType HTMLCanvasElement
+    if (!(canv instanceof HTMLCanvasElement)) {
+        assertNever(canv);
+    }
+})();
+
+(function testTextureFromVideo() {
+    const video = document.createElement('video');
+    const videoTex = new THREE.VideoTexture(video);
+    const vid = videoTex.image; // $ExpectType HTMLVideoElement
+    if (!(vid instanceof HTMLVideoElement)) {
+        assertNever(vid);
+    }
+})();
+
+(function testCanvasTexture() {
+    const canvas = makeCanvas();
+    const canvTex = new THREE.CanvasTexture(canvas);
+    const img = canvTex.image; // $ExpectType HTMLCanvasElement
+    if (!(img instanceof HTMLCanvasElement)) {
+        assertNever(img);
+    }
+})();
+
+function makeCanvas() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 1024;
+    canvas.height = 1024;
+    const g = canvas.getContext('2d');
+    if (g) {
+        g.fillStyle = 'red';
+        g.fillRect(0, 0, 512, 512);
+        g.fillStyle = 'blue';
+        g.fillRect(512, 512, 512, 512);
+    }
+    return canvas;
+}


### PR DESCRIPTION
### Why

Issue #124 discusses a desire to have concrete types for the `image` and `mipmaps` fields of `THREE.Texture`.

This is made difficult by the fact that Three.js appears to occasionally use the `images` field not as an actual source of image data, but as a metadata field to store width/height information about composite texture types like `THREE.CubeTexture`.

For the `mipmaps` field, all of the loaders in the examples code end up returning an `ImageData` structure, but in some cases like `THREE.VideoTexture`, the `mipmaps` field could contain an `HTMLVideoElement`. In general, Three.js does some checking on the type of the `THREE.Texture` before choosing whether to use the `image` field or one of the `mipmaps` array elements for a call to various texture loading functions in WebGL, some of which are capable of loading any `TexImageSource`. Indeed, it appears it's kept as such to also support manually generating mipmaps, e.g. by resizing images via rendering to a Canvas.

### What

For all of the Loader types in the examples folder, I've updated their returned mipmaps fields to be `ImageData[]` instead of `object[]`.

For the base `THREE.Texture` type, I started by defining a number of utility types that describe all the extant ways that the `image` field appears to be used in Three.js. I then used these to create optional type parameters to `THREE.Texture`. Subclasses of `THREE.Texture` can then specify values for those type parameters, e.g. `THREE.VideoTexture` specifies that the image type is `HTMLVideoElement`.

One curious thing is that there actually aren't a lot of restrictions on the types of images you put in `THREE.Texture`s. For example, `THREE.VideoTexture` *could* contain an `HTMLCanvasElement`. All `THREE.VideoTexture` does is run an animation loop to set `needsUpdate` without the user having to do so in their own code. You could conceivably use `THREE.VideoTexture` with a canvas object that you intend to draw to continuously, saving you from having to write an animation loop to update the texture. Similarly, `THREE.CanvasTexture` doesn't really care if you give it a canvas or not, all it does is set `needsUpdate` to true. 

But in those cases, I opted to be explicit in the typing of the textures. If someone were to want to do some shenanigans like that, they can always just cast to `any`.

Finally, I also updated the type signatures for `THREE.WebGLRenderTarget` and its subclasses, so that their `texture` fields could also be typed more explicitly.

I'm submitting this as a draft PR because I'm not really sure of the ergonomics of this. The tests pass, I even managed to write a few that prove out the general concept in type checking. But I'm not really sure how useful the generic `THREE.Texture` type with the default type parameters will be when dealing with textures loaded from model loaders. Well, at the very least, it gives you more guidance on how to go about type filtering on those values, but I'm curious to see what others think.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [ ] Ready to be merged