### PR TITLE
Orbital Controls modes of input to accomodate null values

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -42,9 +42,9 @@ export class OrbitControls {
     autoRotate: boolean;
     autoRotateSpeed: number;
 
-    keys: { LEFT: string; UP: string; RIGHT: string; BOTTOM: string };
-    mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
-    touches: { ONE: TOUCH; TWO: TOUCH };
+    keys: { LEFT: string | null; UP: string | null; RIGHT: string | null; BOTTOM: string | null };
+    mouseButtons: { LEFT: MOUSE | null; MIDDLE: MOUSE | null; RIGHT: MOUSE | null };
+    touches: { ONE: TOUCH | null; TWO: TOUCH | null };
 
     target0: Vector3;
     position0: Vector3;


### PR DESCRIPTION
So say I want left click to control nothing.
Right now I have to do this,
```
    controls.mouseButtons = {
      LEFT: null as unknown as THREE.MOUSE,
      MIDDLE: THREE.MOUSE.ROTATE,
      RIGHT: THREE.MOUSE.LEFT,
    };
```
This PR tells typescript to expect null values when the dev wants a specific mode of input not to control anything.
'null' is probably better than making it optional / undefined because it's explicit and fields can unknowingly be left undefined.
