### PR TITLE
chore: HTMLDocument is deprecated, changed to Document

### DIFF
--- a/types/three/examples/jsm/controls/FirstPersonControls.d.ts
+++ b/types/three/examples/jsm/controls/FirstPersonControls.d.ts
@@ -4,7 +4,7 @@ export class FirstPersonControls {
     constructor(object: Camera, domElement?: HTMLElement);
 
     object: Camera;
-    domElement: HTMLElement | HTMLDocument;
+    domElement: HTMLElement | Document;
 
     enabled: boolean;
     movementSpeed: number;

--- a/types/three/examples/jsm/controls/FlyControls.d.ts
+++ b/types/three/examples/jsm/controls/FlyControls.d.ts
@@ -4,7 +4,7 @@ export class FlyControls extends EventDispatcher {
     constructor(object: Camera, domElement?: HTMLElement);
 
     object: Camera;
-    domElement: HTMLElement | HTMLDocument;
+    domElement: HTMLElement | Document;
 
     movementSpeed: number;
     rollSpeed: number;

--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -4,7 +4,7 @@ export class OrbitControls {
     constructor(object: Camera, domElement?: HTMLElement);
 
     object: Camera;
-    domElement: HTMLElement | HTMLDocument;
+    domElement: HTMLElement | Document;
 
     // API
     enabled: boolean;


### PR DESCRIPTION
The type HTMLDocument is deprecated, this PR changes all instances of it to Document
Encountered this,
![image](https://user-images.githubusercontent.com/54670936/173767588-dfc02dd9-d6a5-4e02-9b66-aefa76fa1226.png)

I checked,

![image](https://user-images.githubusercontent.com/54670936/173767786-b0d7d992-b691-47d4-bcb2-923933fc3918.png)

and yes document has the type Document now.
