### PR TITLE
fix: SAOPass.OUTPUT type

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -348,11 +348,18 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/894203?v=4",
       "profile": "https://github.com/atulrnt",
       "contributions": [
-        "code",
-      ],
         "code"
       ]
     },
+    {
+      "login": "serenayl",
+      "name": "Serena Li",
+      "avatar_url": "https://avatars.githubusercontent.com/u/12814119?v=4",
+      "profile": "https://github.com/serenayl",
+      "contributions": [
+        "code"
+      ]
+    }
   ],
   "skipCi": true,
   "contributorsPerLine": 7

--- a/types/three/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SAOPass.d.ts
@@ -60,7 +60,7 @@ export class SAOPass extends Pass {
     fsQuad: object;
     params: SAOPassParams;
 
-    static OUTPUT: OUTPUT;
+    static OUTPUT: typeof OUTPUT;
 
     renderPass(
         renderer: WebGLRenderer,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

When attempting to refer to an enum such as `SAOPass.OUTPUT.Beauty`, I get this warning: "Property 'Beauty' does not exist on type 'OUTPUT'." The type should be the object/value per the JS code:
```
SAOPass.OUTPUT = {
	'Beauty': 1,
	'Default': 0,
	'SAO': 2,
	'Depth': 3,
	'Normal': 4
};
```

### What

<!-- what have you done, if its a bug, whats your solution? -->

Uses `typeof` to resolve this TS error.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
