### PR TITLE
Draft: sketch out approach to better BufferAttribute typings #35

### DIFF
--- a/types/three/src/core/BufferAttribute.d.ts
+++ b/types/three/src/core/BufferAttribute.d.ts
@@ -5,14 +5,14 @@ import { Matrix4 } from './../math/Matrix4';
 /**
  * see {@link https://github.com/mrdoob/three.js/blob/master/src/core/BufferAttribute.js|src/core/BufferAttribute.js}
  */
-export class BufferAttribute {
-    constructor(array: ArrayLike<number>, itemSize: number, normalized?: boolean); // array parameter should be TypedArray.
+export class BufferAttribute<ArrayType extends ArrayLike<number> = ArrayLike<number>> {
+    constructor(array: ArrayType, itemSize: number, normalized?: boolean); // array parameter should be TypedArray.
 
     /**
      * @default ''
      */
     name: string;
-    array: ArrayLike<number>;
+    array: ArrayType;
     itemSize: number;
 
     /**
@@ -48,9 +48,9 @@ export class BufferAttribute {
     onUpload(callback: () => void): this;
     setUsage(usage: Usage): this;
     clone(): this;
-    copy(source: BufferAttribute): this;
-    copyAt(index1: number, attribute: BufferAttribute, index2: number): this;
-    copyArray(array: ArrayLike<number>): this;
+    copy(source: BufferAttribute<ArrayType>): this;
+    copyAt(index1: number, attribute: BufferAttribute<ArrayType>, index2: number): this;
+    copyArray(array: ArrayType): this;
     copyColorsArray(colors: Array<{ r: number; g: number; b: number }>): this;
     copyVector2sArray(vectors: Array<{ x: number; y: number }>): this;
     copyVector3sArray(vectors: Array<{ x: number; y: number; z: number }>): this;
@@ -59,7 +59,7 @@ export class BufferAttribute {
     applyMatrix4(m: Matrix4): this;
     applyNormalMatrix(m: Matrix3): this;
     transformDirection(m: Matrix4): this;
-    set(value: ArrayLike<number> | ArrayBufferView, offset?: number): this;
+    set(value: ArrayType | ArrayBufferView, offset?: number): this;
     getX(index: number): number;
     setX(index: number, x: number): this;
     getY(index: number): number;
@@ -142,82 +142,23 @@ export class Float64Attribute extends BufferAttribute {
     constructor(array: any, itemSize: number);
 }
 
-export class Int8BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Int8BufferAttribute extends BufferAttribute<Int8Array> {}
 
-export class Uint8BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Uint8BufferAttribute extends BufferAttribute<Uint8Array> {}
 
-export class Uint8ClampedBufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Uint8ClampedBufferAttribute extends BufferAttribute<Uint8ClampedArray> {}
 
-export class Int16BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Int16BufferAttribute extends BufferAttribute<Int16Array> {}
 
-export class Uint16BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Uint16BufferAttribute extends BufferAttribute<Uint16Array> {}
 
-export class Int32BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Int32BufferAttribute extends BufferAttribute<Int32Array> {}
 
-export class Uint32BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Uint32BufferAttribute extends BufferAttribute<Uint32Array> {}
 
-export class Float16BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+// Float 16 arrays don't exist, what to do
+export class Float16BufferAttribute extends BufferAttribute {}
 
-export class Float32BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Float32BufferAttribute extends BufferAttribute<Float32Array> {}
 
-export class Float64BufferAttribute extends BufferAttribute {
-    constructor(
-        array: Iterable<number> | ArrayLike<number> | ArrayBuffer | number,
-        itemSize: number,
-        normalized?: boolean,
-    );
-}
+export class Float64BufferAttribute extends BufferAttribute<Float64Array> {}

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -9,6 +9,17 @@ import { EventDispatcher } from './EventDispatcher';
 import { InterleavedBufferAttribute } from './InterleavedBufferAttribute';
 import { BuiltinShaderAttributeName } from '../constants';
 
+// TODO make the exhaustive
+type TypedArray = Uint8Array | Uint16Array | Int8Array | Int16Array | Float32Array | Float64Array | Uint8ClampedArray;
+interface BufferGeometryAttributeMap {
+    [attributeName: string]: TypedArray,
+}
+
+type AttributesFor<AttrTypeMap extends BufferGeometryAttributeMap> = {
+    // TODO make InterleavedBufferAttribute generic
+    [attributeName in keyof AttrTypeMap]: BufferAttribute<AttrTypeMap[attributeName]> | InterleavedBufferAttribute //<AttrTypeMap[attributeName]>
+}
+
 /**
  * This is a superefficent class for geometries because it saves all data in buffers.
  * It reduces memory costs and cpu cycles. But it is not as easy to work with because of all the necessary buffer calculations.
@@ -16,7 +27,7 @@ import { BuiltinShaderAttributeName } from '../constants';
  *
  * see {@link https://github.com/mrdoob/three.js/blob/master/src/core/BufferGeometry.js|src/core/BufferGeometry.js}
  */
-export class BufferGeometry extends EventDispatcher {
+export class BufferGeometry<AttrTypeMap extends BufferGeometryAttributeMap = Record<BuiltinShaderAttributeName | string, TypedArray>> extends EventDispatcher {
     /**
      * This creates a new BufferGeometry. It also sets several properties to an default value.
      */
@@ -46,9 +57,7 @@ export class BufferGeometry extends EventDispatcher {
     /**
      * @default {}
      */
-    attributes: {
-        [name: string]: BufferAttribute | InterleavedBufferAttribute;
-    };
+    attributes: AttributesFor<AttrTypeMap>;
 
     /**
      * @default {}
@@ -88,13 +97,14 @@ export class BufferGeometry extends EventDispatcher {
     userData: { [key: string]: any };
     readonly isBufferGeometry: true;
 
+    // TODO provide index type
     getIndex(): BufferAttribute | null;
     setIndex(index: BufferAttribute | number[] | null): BufferGeometry;
 
-    setAttribute(
+    setAttribute<AttributeName extends string, T extends TypedArray>(
         name: BuiltinShaderAttributeName | (string & {}),
-        attribute: BufferAttribute | InterleavedBufferAttribute,
-    ): BufferGeometry;
+        attribute: BufferAttribute<T> | InterleavedBufferAttribute,
+    ): BufferGeometry<AttrTypeMap & { [k in AttributeName]: T }>;
     getAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferAttribute | InterleavedBufferAttribute;
     deleteAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferGeometry;
     hasAttribute(name: BuiltinShaderAttributeName | (string & {})): boolean;


### PR DESCRIPTION
This is a draft to collect feedback on the idea of improving specificity of BufferAttribute typings, especially as they relate to BufferGeometry typings

### Why

The current typing of attributes on BufferGeometries is too wide. It's not possible to specify what attributes are actually defined and what "flavor" of TypedArray actually underlies them.

### What

I've made the `BufferAttribute` type generic so that the backing TypedArrays can be specified. I've leveraged this in the definition of `BufferGeometry` to make it possible to specify the attributes and their underlying types.

With this change, the following code works:

```typescript
type geom = BufferGeometry<{ normal: Float32Array,  position: Uint16Array }>
type normal = geom['attributes']['normal'] // InterleavedBufferAttribute | BufferAttribute<Float32Array>
type position = geom['attributes']['position'] // InterleavedBufferAttribute | BufferAttribute<UInt16Array>

// @ts-expect-error Property 'foo' does not exist on type 'AttributesFor<{ normal: Float32Array; position: Uint16Array; }>'
type foo = geom['attributes']['foo'] // type error!
```

Using the previous wide type as default allows backwards compatibility:

```typescript
type geom = BufferGeometry
type foo = geom['attributes']['foo']; // InterleavedBufferAttribute | BufferAttribute<TypedArray>
```

If there's an appetite for this sort of change, I'll button up the PR here with: 
- Handling for all variants of TypedArray
- Handling of all methods of `BufferGeometry`
- Better handling/generic typing of `InterleavedBufferAttribute` in the same vein as the way `BufferAttribute` is handled

### Checklist

-   [ ] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [ ] Ready to be merged
