### PR TITLE
Change examples/jsm/libs/stats `end` function return to `number`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -361,14 +361,23 @@
       ]
     },
     {
-            "login": "cosformula",
+      "login": "cosformula",
       "name": "cosformula",
       "avatar_url": "https://avatars.githubusercontent.com/u/18232501?v=4",
       "profile": "https://github.com/cosformula",
-       "contributions": [
+      "contributions": [
         "code"
       ]
-     }
+    },
+    {
+      "login": "MysteryBlokHed",
+      "name": "Adam Thompson-Sharpe",
+      "avatar_url": "https://avatars.githubusercontent.com/u/13910387?v=4",
+      "profile": "https://github.com/MysteryBlokHed",
+      "contributions": [
+        "code"
+      ]
+    }
   ],
   "skipCi": true,
   "contributorsPerLine": 7

--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/atulrnt"><img src="https://avatars.githubusercontent.com/u/894203?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Arthur LAURENT</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=atulrnt" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/serenayl"><img src="https://avatars.githubusercontent.com/u/12814119?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Serena Li</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=serenayl" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/cosformula"><img src="https://avatars.githubusercontent.com/u/18232501?v=4?s=100" width="100px;" alt=""/><br /><sub><b>cosformula</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=cosformula" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/miko3k"><img src="https://avatars.githubusercontent.com/u/8658482?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Peter Hanula</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=miko3k" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/MysteryBlokHed"><img src="https://avatars.githubusercontent.com/u/13910387?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Adam Thompson-Sharpe</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=MysteryBlokHed" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/libs/stats.module.d.ts
+++ b/types/three/examples/jsm/libs/stats.module.d.ts
@@ -4,7 +4,7 @@ interface Stats {
     addPanel(panel: Stats.Panel): Stats.Panel;
     showPanel(id: number): void;
     begin(): void;
-    end(): void;
+    end(): number;
     update(): void;
     domElement: HTMLDivElement;
     setMode(id: number): void;


### PR DESCRIPTION
### Why

DefinitelyTyped/DefinitelyTyped#61861—The `end` function should return `number` instead of `void`

<https://github.com/mrdoob/three.js/blob/d135492cb9cce736c500c9acde39f6f177ab85e2/examples/jsm/libs/stats.module.js#L89>

### What

Changes the `end` function's return type to `number`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

Original PR is DefinitelyTyped/DefinitelyTyped#61869, but was directed here