### PR TITLE
fix: add fog to LineBasicMaterial

### DIFF
--- a/types/three/src/materials/LineBasicMaterial.d.ts
+++ b/types/three/src/materials/LineBasicMaterial.d.ts
@@ -4,6 +4,7 @@ import { MaterialParameters, Material } from './Material';
 
 export interface LineBasicMaterialParameters extends MaterialParameters {
     color?: ColorRepresentation | undefined;
+    fog?: boolean | undefined;
     linewidth?: number | undefined;
     linecap?: string | undefined;
     linejoin?: string | undefined;
@@ -21,6 +22,12 @@ export class LineBasicMaterial extends Material {
      * @default 0xffffff
      */
     color: Color;
+
+    /**
+     * Whether the material is affected by fog. Default is true.
+     * @default true
+     */
+    fog: boolean;
 
     /**
      * @default 1


### PR DESCRIPTION
### Why

Missed in https://github.com/three-types/three-ts-types/commit/cbe19672007481857d7d6f9fb863eca62d438eb9.

### What

Add `fog` property back to [LineBasicMaterial](https://threejs.org/docs/index.html#api/en/materials/LineBasicMaterial).

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
