### PR TITLE
fix: back-port TypeScript fix

### DIFF
--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -82,10 +82,10 @@ type FilterConstructorsByScope<T extends AnyConstructors, S> = {
  * "flattens" the tuple into an union type
  */
 type ConstructorUnion<T extends AnyConstructors> =
-    | (T['a'] extends undefined ? never : T['a'])
-    | (T['b'] extends undefined ? never : T['b'])
-    | (T['c'] extends undefined ? never : T['c'])
-    | (T['d'] extends undefined ? never : T['d']);
+    | Exclude<T['a'], undefined>
+    | Exclude<T['b'], undefined>
+    | Exclude<T['c'], undefined>
+    | Exclude<T['d'], undefined>;
 
 /**
  * Extract list of possible scopes - union of the first paramter


### PR DESCRIPTION
### Why

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62011 was applied in DefinitelyTyped, but not here.

### What

Apply fix from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62011.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
