### PR TITLE
fix: class name is now ReflectorForSSRPass

### DIFF
--- a/types/three/examples/jsm/objects/ReflectorForSSRPass.d.ts
+++ b/types/three/examples/jsm/objects/ReflectorForSSRPass.d.ts
@@ -21,7 +21,7 @@ export interface ReflectorShader {
     fragmentShader: string;
 }
 
-export interface ReflectorOptions {
+export interface ReflectorForSSRPassOptions {
     clipBias?: number | undefined;
     textureWidth?: number | undefined;
     textureHeight?: number | undefined;
@@ -30,9 +30,9 @@ export interface ReflectorOptions {
     shader?: ReflectorShader | undefined;
 }
 
-export class Reflector<TGeometry extends BufferGeometry = BufferGeometry> extends Mesh<TGeometry> {
+export class ReflectorForSSRPass<TGeometry extends BufferGeometry = BufferGeometry> extends Mesh<TGeometry> {
     type: 'ReflectorForSSRPass';
-    options: ReflectorOptions;
+    options: ReflectorForSSRPassOptions;
 
     static ReflectorShader: ReflectorShader;
 
@@ -49,7 +49,7 @@ export class Reflector<TGeometry extends BufferGeometry = BufferGeometry> extend
 
     renderTarget: WebGLRenderTarget;
 
-    constructor(geometry: TGeometry, options: ReflectorOptions);
+    constructor(geometry: TGeometry, options: ReflectorForSSRPassOptions);
 
     doRender: (renderer: WebGLRenderer, scene: Scene, camera: Camera) => void;
 

--- a/types/three/examples/jsm/postprocessing/SSRPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSRPass.d.ts
@@ -12,7 +12,7 @@ import {
     ColorRepresentation,
 } from '../../../src/Three';
 import { Pass, FullScreenQuad } from '../postprocessing/Pass';
-import { Reflector } from '../objects/ReflectorForSSRPass';
+import { ReflectorForSSRPass } from '../objects/ReflectorForSSRPass';
 
 export interface SSRPassParams {
     renderer: WebGLRenderer;
@@ -23,7 +23,7 @@ export interface SSRPassParams {
     selects: Mesh[] | null;
     isPerspectiveCamera?: boolean | undefined;
     isBouncing?: boolean | undefined;
-    groundReflector: Reflector | null;
+    groundReflector: ReflectorForSSRPass | null;
 }
 
 export class SSRPass extends Pass {
@@ -33,7 +33,7 @@ export class SSRPass extends Pass {
     renderer: WebGLRenderer;
     scene: Scene;
     camera: Camera;
-    groundReflector: Reflector | null;
+    groundReflector: ReflectorForSSRPass | null;
     opacity: number;
     output: number;
     maxDistance: number;

--- a/types/three/test/postprocessing/postprocessing-ssr.ts
+++ b/types/three/test/postprocessing/postprocessing-ssr.ts
@@ -4,7 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer';
 import { SSRPass } from 'three/examples/jsm/postprocessing/SSRPass';
-import { Reflector } from 'three/examples/jsm/objects/ReflectorForSSRPass';
+import { ReflectorForSSRPass } from 'three/examples/jsm/objects/ReflectorForSSRPass';
 
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader';
 
@@ -22,7 +22,7 @@ let camera: THREE.PerspectiveCamera;
 let scene: THREE.Scene;
 let renderer: THREE.WebGLRenderer;
 const otherMeshes: THREE.Mesh[] = [];
-let groundReflector: Reflector;
+let groundReflector: ReflectorForSSRPass;
 const selects: THREE.Mesh[] = [];
 
 const container = document.querySelector('#container') as Element;
@@ -107,7 +107,7 @@ function init() {
     }
     {
         const geometry = new THREE.PlaneBufferGeometry(8, 8);
-        groundReflector = new Reflector(geometry, {
+        groundReflector = new ReflectorForSSRPass(geometry, {
             clipBias: 0.003,
             textureWidth: window.innerWidth,
             textureHeight: window.innerHeight,


### PR DESCRIPTION
### Why

The class exported from `examples/jsm/objects/ReflectorForSSRPass` was renamed from `Reflector` to `ReflectorForSSRPass` in https://github.com/mrdoob/three.js/pull/21403.

### What

Renamed class to match the [current file](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/objects/ReflectorForSSRPass.js#L18).

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
