### PR TITLE
refactor: Object3D.matrixWorldAutoUpdate, deprecate Scene.autoUpdate

### DIFF
--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -110,6 +110,13 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
     matrixAutoUpdate: boolean;
 
     /**
+     * When this is set, the renderer checks every frame if the object and its children need matrix updates.
+     * Otherwise, you have to maintain all matrices in the object and its children yourself.
+     * @default THREE.Object3D.DefaultMatrixWorldAutoUpdate
+     */
+    matrixWorldAutoUpdate: boolean;
+
+    /**
      * When this is set, it calculates the matrixWorld in that frame and resets this property to false.
      * @default false
      */
@@ -210,6 +217,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
 
     static DefaultUp: Vector3;
     static DefaultMatrixAutoUpdate: boolean;
+    static DefaultMatrixWorldAutoUpdate: boolean;
 
     /**
      * Applies the matrix transform to the object and updates the object's position, rotation and scale.

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -29,12 +29,6 @@ export class Scene extends Object3D {
     overrideMaterial: Material | null;
 
     /**
-     * @deprecated Use {@link THREE.Object3D.matrixWorldAutoUpdate} instead.
-     * @default true
-     */
-    autoUpdate: boolean;
-
-    /**
      * @default null
      */
     background: null | Color | Texture;

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -29,6 +29,7 @@ export class Scene extends Object3D {
     overrideMaterial: Material | null;
 
     /**
+     * @deprecated Use {@link THREE.Object3D.matrixWorldAutoUpdate} instead.
      * @default true
      */
     autoUpdate: boolean;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Follow-up to https://github.com/mrdoob/three.js/pull/24028 where `Scene.autoUpdate` is moved to `Object3D.matrixWorldAutoUpdate` for granular control of matrices on render and via matrix methods.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

I've added the new `Object3D` properties and deprecated `Scene.autoUpdate`. They added the latter to `Three.Legacy` which will be removed entirely in 10 releases (should this info be inlined?).

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
