### PR TITLE
fix(ColorManagement): export as namespace, add static properties

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -158,6 +158,7 @@ export * from './math/Vector2';
 export * from './math/Quaternion';
 export * from './math/Color';
 export * from './math/SphericalHarmonics3';
+export { ColorManagement } from './math/ColorManagement'
 import * as MathUtils from './math/MathUtils';
 export { MathUtils };
 /**

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -158,7 +158,7 @@ export * from './math/Vector2';
 export * from './math/Quaternion';
 export * from './math/Color';
 export * from './math/SphericalHarmonics3';
-export { ColorManagement } from './math/ColorManagement'
+export { ColorManagement } from './math/ColorManagement';
 import * as MathUtils from './math/MathUtils';
 export { MathUtils };
 /**

--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -9,12 +9,12 @@ export namespace ColorManagement {
     /**
      * @default true
      */
-    var legacyMode: boolean
+    var legacyMode: boolean;
 
     /**
      * @default LinearSRGBColorSpace
      */
-    var workingColorSpace: ColorSpace
+    var workingColorSpace: ColorSpace;
 
     function convert(
         color: Color,

--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -9,12 +9,12 @@ export namespace ColorManagement {
     /**
      * @default true
      */
-    const legacyMode: boolean;
+    let legacyMode: boolean;
 
     /**
      * @default LinearSRGBColorSpace
      */
-    const workingColorSpace: ColorSpace;
+    let workingColorSpace: ColorSpace;
 
     function convert(
         color: Color,

--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -9,12 +9,12 @@ export namespace ColorManagement {
     /**
      * @default true
      */
-    var legacyMode: boolean;
+    const legacyMode: boolean;
 
     /**
      * @default LinearSRGBColorSpace
      */
-    var workingColorSpace: ColorSpace;
+    const workingColorSpace: ColorSpace;
 
     function convert(
         color: Color,

--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -1,4 +1,4 @@
-import { LinearSRGBColorSpace, SRGBColorSpace } from '../constants';
+import { ColorSpace, LinearSRGBColorSpace, SRGBColorSpace } from '../constants';
 import { Color } from './Color';
 
 export function SRGBToLinear(c: number): number;
@@ -6,6 +6,16 @@ export function SRGBToLinear(c: number): number;
 export function LinearToSRGB(c: number): number;
 
 export namespace ColorManagement {
+    /**
+     * @default true
+     */
+    var legacyMode: boolean
+
+    /**
+     * @default LinearSRGBColorSpace
+     */
+    var workingColorSpace: ColorSpace
+
     function convert(
         color: Color,
         sourceColorSpace: SRGBColorSpace | LinearSRGBColorSpace,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Support for globally correct color management was added to r139 with https://github.com/mrdoob/three.js/pull/23392. Background and API usage can be found at https://threejs.org/docs/#manual/en/introduction/Color-management.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

I've added missing static properties and exported `ColorManagement`, its `SRGBToLinear` and `LinearToSRGB` methods are private and not user-facing.

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
