### PR TITLE
fix: Remove url argument from PCDLoader.parse signature

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -386,6 +386,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "grschafer",
+      "name": "Greg Schafer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/694225?v=4",
+      "profile": "https://github.com/grschafer",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/cosformula"><img src="https://avatars.githubusercontent.com/u/18232501?v=4?s=100" width="100px;" alt=""/><br /><sub><b>cosformula</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=cosformula" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/miko3k"><img src="https://avatars.githubusercontent.com/u/8658482?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Peter Hanula</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=miko3k" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/MysteryBlokHed"><img src="https://avatars.githubusercontent.com/u/13910387?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Adam Thompson-Sharpe</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=MysteryBlokHed" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/grschafer"><img src="https://avatars.githubusercontent.com/u/694225?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Greg Schafer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=grschafer" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/examples/jsm/loaders/PCDLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PCDLoader.d.ts
@@ -11,5 +11,5 @@ export class PCDLoader extends Loader {
         onError?: (event: ErrorEvent) => void,
     ): void;
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<Points>;
-    parse(data: ArrayBuffer | string, url: string): Points;
+    parse(data: ArrayBuffer | string): Points;
 }

--- a/types/three/test/loaders/loaders-pcdloader.ts
+++ b/types/three/test/loaders/loaders-pcdloader.ts
@@ -1,0 +1,100 @@
+import * as THREE from 'three';
+
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { PCDLoader } from 'three/examples/jsm/loaders/PCDLoader.js';
+
+let camera: THREE.PerspectiveCamera;
+let scene: THREE.Scene;
+let renderer: THREE.WebGLRenderer;
+
+init();
+render();
+
+function init() {
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    scene = new THREE.Scene();
+
+    camera = new THREE.PerspectiveCamera(30, window.innerWidth / window.innerHeight, 0.01, 40);
+    camera.position.set(0, 0, 1);
+    scene.add(camera);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.addEventListener('change', render); // use if there is no animation loop
+    controls.minDistance = 0.5;
+    controls.maxDistance = 10;
+
+    // scene.add( new THREE.AxesHelper( 1 ) );
+
+    const loader = new PCDLoader();
+    loader.load('./models/pcd/binary/Zaghetto.pcd', points => {
+        points.geometry.center();
+        points.geometry.rotateX(Math.PI);
+        points.name = 'Zaghetto.pcd';
+        scene.add(points);
+
+        render();
+    });
+    pcdLoaderLoad(loader, './models/pcd/binary/Zaghetto.pcd', points => {
+        points.geometry.center();
+        points.geometry.rotateX(Math.PI);
+        points.name = 'Zaghetto.pcd';
+        scene.add(points);
+
+        render();
+    });
+
+    const file = './models/pcd/binary/Zaghetto.pcd';
+    const reader = new FileReader();
+
+    window.addEventListener('resize', onWindowResize);
+}
+
+// Mostly copied from PCDLoader.js to exercise the parse() function
+function pcdLoaderLoad(
+    pcdLoader: PCDLoader,
+    url: string,
+    onLoad: (points: THREE.Points) => void,
+    onProgress?: (event: ProgressEvent) => void,
+    onError?: (event: ErrorEvent) => void,
+) {
+    const scope = pcdLoader;
+
+    const loader = new THREE.FileLoader(scope.manager);
+    loader.setPath(scope.path);
+    loader.setResponseType('arraybuffer');
+    loader.setRequestHeader(scope.requestHeader);
+    loader.setWithCredentials(scope.withCredentials);
+    loader.load(
+        url,
+        data => {
+            try {
+                onLoad(scope.parse(data));
+            } catch (e) {
+                if (onError) {
+                    onError(e);
+                } else {
+                    console.error(e);
+                }
+
+                scope.manager.itemError(url);
+            }
+        },
+        onProgress,
+        onError,
+    );
+}
+
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function render() {
+    renderer.render(scene, camera);
+}

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -42,6 +42,7 @@
         "test/loaders/loaders-gltfloader.ts",
         "test/loaders/loaders-svgloader.ts",
         "test/loaders/loaders-tgaloader.ts",
+        "test/loaders/loaders-pcdloader.ts",
         "test/loaders/loaders-mmdanimation.ts",
         "test/loaders/loaders-obj-mtl.ts",
         "test/loaders/loaders-ifc.ts",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The `url` argument to `PCDLoader` was removed from three.js in r141 (May 2022): https://github.com/mrdoob/three.js/commit/eab2a29621b332e0e8a0bac5a0098cfcf1e331e1#diff-d7eb86747ff8ee3e2ab047235419fa6870b9f13e6a0be07a7a35e92064f64b86R56

### What

This PR updates the types to match the current implementation of PCDLoader in three.js.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
