### PR TITLE
fix(Mesh): material default is MeshBasicMaterial

### DIFF
--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -2,11 +2,12 @@ import { Material } from './../materials/Material';
 import { Raycaster } from './../core/Raycaster';
 import { Object3D } from './../core/Object3D';
 import { BufferGeometry } from '../core/BufferGeometry';
+import { MeshBasicMaterial } from '../materials/MeshBasicMaterial';
 import { Intersection } from '../core/Raycaster';
 
 export class Mesh<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = MeshBasicMaterial,
 > extends Object3D {
     constructor(geometry?: TGeometry, material?: TMaterial);
 


### PR DESCRIPTION
### Why

`THREE.Mesh` is created with an empty `THREE.BufferGeometry` and `THREE.MeshBasicMaterial` by default, but its material type defaults to `Material | Material[]`.

### What

I've changed `Mesh`'s default material to `MeshBasicMaterial` to better reflect its implementation. This shouldn't change inference when geometry/material are defined as args, but I worry about the case where they are directly mutated and if that's the reason for this discrepancy in the first place.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged