### PR TITLE
fix: MeshLambertMaterial.dispalcementScale typo to .displacementScale

### DIFF
--- a/types/three/src/materials/MeshLambertMaterial.d.ts
+++ b/types/three/src/materials/MeshLambertMaterial.d.ts
@@ -67,7 +67,7 @@ export class MeshLambertMaterial extends Material {
     /**
      * @default 1
      */
-    dispalcementScale: number;
+    displacementScale: number;
 
     /**
      * @default 0


### PR DESCRIPTION


### Why

typo in MeshLambertMaterial, where displacementScale was misspelled as dispalcementScale

### What

renamed dispalcementScale to displacementScale

### Checklist

<!-- Have you done all of these things?  -->



-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
