### PR TITLE
Remove format from return type

### DIFF
--- a/types/three/examples/jsm/loaders/RGBELoader.d.ts
+++ b/types/three/examples/jsm/loaders/RGBELoader.d.ts
@@ -7,7 +7,6 @@ export interface RGBE {
     header: string;
     gamma: number;
     exposure: number;
-    format: PixelFormat;
     type: TextureDataType;
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

Fixes https://github.com/three-types/three-ts-types/issues/271

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Removes format from the `RGBELoader.parse` return type as this no longer exists. 
See https://github.com/mrdoob/three.js/blob/dev/examples/jsm/loaders/RGBELoader.js#L415
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
