### PR TITLE
fix: add frameid to timenode and shadernodeelements

### DIFF
--- a/types/three/examples/jsm/nodes/shadernode/ShaderNodeElements.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNodeElements.d.ts
@@ -113,6 +113,7 @@ export function spritesheetUV(
 export function timerLocal(timeScale: number, value?: number): Swizzable<TimerNode>;
 export function timerGlobal(timeScale: number, value?: number): Swizzable<TimerNode>;
 export function timerDelta(timeScale: number, value?: number): Swizzable<TimerNode>;
+export const frameId: Swizzable<TimerNode>;
 
 // geometry
 

--- a/types/three/examples/jsm/nodes/utils/TimerNode.d.ts
+++ b/types/three/examples/jsm/nodes/utils/TimerNode.d.ts
@@ -1,11 +1,16 @@
 import UniformNode from '../core/UniformNode';
 
-export type TimerNodeScope = typeof TimerNode.LOCAL | typeof TimerNode.GLOBAL | typeof TimerNode.DELTA;
+export type TimerNodeScope =
+    | typeof TimerNode.LOCAL
+    | typeof TimerNode.GLOBAL
+    | typeof TimerNode.DELTA
+    | typeof TimerNode.FRAME;
 
 export default class TimerNode extends UniformNode {
     static LOCAL: 'local';
     static GLOBAL: 'global';
     static DELTA: 'delta';
+    static FRAME: 'frame';
 
     scope: TimerNodeScope;
     scale: number;


### PR DESCRIPTION

### Why

https://github.com/three-types/three-ts-types/issues/255


### What

Add new "frame" timer type.

### Checklist

-   [ X] Checked the target branch (current goes `master`, next goes `dev`)
-   [ X] Added myself to contributors table
-   [X ] Ready to be merged
