### PR TITLE
fix: correct type for XRHandJoints

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -440,6 +440,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "mz8i",
+      "name": "Maciej Ziarkowski",
+      "avatar_url": "https://avatars.githubusercontent.com/u/36160844?v=4",
+      "profile": "https://github.com/mz8i",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center"><a href="https://github.com/mattrossman"><img src="https://avatars.githubusercontent.com/u/22670878?v=4?s=100" width="100px;" alt="Matt Rossman"/><br /><sub><b>Matt Rossman</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=mattrossman" title="Code">💻</a></td>
       <td align="center"><a href="https://github.com/imbateam-gg/titan-reactor"><img src="https://avatars.githubusercontent.com/u/586716?v=4?s=100" width="100px;" alt="Alex Pineda"/><br /><sub><b>Alex Pineda</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=alexpineda" title="Code">💻</a></td>
       <td align="center"><a href="https://github.com/Draichi"><img src="https://avatars.githubusercontent.com/u/19378148?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Lucas</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Draichi" title="Documentation">📖</a></td>
+      <td align="center"><a href="https://github.com/mz8i"><img src="https://avatars.githubusercontent.com/u/36160844?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Maciej Ziarkowski</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=mz8i" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/types/three/src/renderers/webxr/WebXRController.d.ts
+++ b/types/three/src/renderers/webxr/WebXRController.d.ts
@@ -3,7 +3,11 @@ import { Vector3 } from '../../math/Vector3';
 
 export type XRControllerEventType = XRSessionEventType | XRInputSourceEventType | 'disconnected' | 'connected';
 
-export type XRHandJoints = Record<XRHandJoint, number>;
+export class XRJointSpace extends Group {
+    readonly jointRadius: number | undefined;
+}
+
+export type XRHandJoints = Record<XRHandJoint, XRJointSpace>;
 
 export interface XRHandInputState {
     pinching: boolean;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Corrected typing of `XRHandSpace.joints`. It was typed as a record of numbers, but in fact it's a record of Group instances with an added `inputRadius` field.
See:
- https://github.com/mrdoob/three.js/blob/master/src/renderers/webxr/WebXRController.js#L143
- https://github.com/mrdoob/three.js/blob/master/src/renderers/webxr/WebXRController.js#L158
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Added `XRJointSpace` class. Corrected record value type for `XRHandJoints`.

The naming of the new class is debatable, I called it `XRJointSpace` rather than `XRJointPose` to follow the naming of other classes in the file and to avoid collision with `XRJointPose` from `@types/webxr`.
 
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
