### PR TITLE
fix: Import SphereGeometry instead of SphereBufferGeometry

### DIFF
--- a/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
+++ b/types/three/examples/jsm/webxr/OculusHandPointerModel.d.ts
@@ -7,7 +7,7 @@ import {
     MeshBasicMaterial,
     Object3D,
     Raycaster,
-    SphereBufferGeometry,
+    SphereGeometry,
     Texture,
     Vector3,
 } from '../../../src/Three';
@@ -30,7 +30,7 @@ export class OculusHandPointerModel extends Object3D {
     pinched: boolean;
     attached: boolean;
 
-    cursorObject: Mesh<SphereBufferGeometry, MeshBasicMaterial> | null;
+    cursorObject: Mesh<SphereGeometry, MeshBasicMaterial> | null;
 
     raycaster: Raycaster;
 


### PR DESCRIPTION
### Why
Types specifying wrong import causing tsc error

### What
Replace SphereBufferGeometry with SphereGeometry - see also https://github.com/mrdoob/three.js/blob/309b00afb6dcbc5e6c58e72f10eaa8d2e8888c83/examples/jsm/webxr/OculusHandPointerModel.js#L218

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged


![image](https://user-images.githubusercontent.com/5083203/204869149-efa8fed2-546a-4de5-b832-2a45fc402a84.png)

