### PR TITLE
Add createInterpolant to KeyframeTrack

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -485,6 +485,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "marwie",
+      "name": "Marcel Wiessler",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5083203?v=4",
+      "profile": "https://www.needle.tools",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/autonomobil"><img src="https://avatars.githubusercontent.com/u/31781343?s=96&v=4?s=100" width="100px;" alt=""/><br /><sub><b>Moritz Cremer</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=autonomobil" title="Code">💻</a></td>
-    <td align="center"><a href="https://github.com/LuchoTurtle"><img src="https://avatars.githubusercontent.com/u/17494745?v=4?s=100" width="100px;" alt=""/><br /><sub><b>LuchoTurtle</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=LuchoTurtle" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/LuchoTurtle"><img src="https://avatars.githubusercontent.com/u/17494745?v=4?s=100" width="100px;" alt=""/><br /><sub><b>LuchoTurtle</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=LuchoTurtle" title="Code">💻</a></td> 
+    <td align="center"><a href="https://github.com/marwie"><img src="https://avatars.githubusercontent.com/u/5083203?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcel Wiessler</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=marwie" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/animation/KeyframeTrack.d.ts
+++ b/types/three/src/animation/KeyframeTrack.d.ts
@@ -1,6 +1,7 @@
 import { DiscreteInterpolant } from './../math/interpolants/DiscreteInterpolant';
 import { LinearInterpolant } from './../math/interpolants/LinearInterpolant';
 import { CubicInterpolant } from './../math/interpolants/CubicInterpolant';
+import { Interpolant } from '../math/Interpolant';
 import { InterpolationModes } from '../constants';
 
 export class KeyframeTrack {
@@ -31,6 +32,7 @@ export class KeyframeTrack {
 
     setInterpolation(interpolation: InterpolationModes): KeyframeTrack;
     getInterpolation(): InterpolationModes;
+    createInterpolant(): Interpolant;
 
     getValueSize(): number;
 


### PR DESCRIPTION

### Why

Keyframetracks were missing ``createInterpolant`` https://threejs.org/docs/#api/en/animation/KeyframeTrack.createInterpolant

### What

https://threejs.org/docs/#api/en/animation/KeyframeTrack.createInterpolant

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
