### PR TITLE
fix: Adding proper type in `fsQuad` instances inside `jsm/postprocessing`.

### DIFF
--- a/types/three/examples/jsm/loaders/PLYLoader.d.ts
+++ b/types/three/examples/jsm/loaders/PLYLoader.d.ts
@@ -3,6 +3,7 @@ import { BufferGeometry, Loader, LoadingManager } from '../../../src/Three';
 export class PLYLoader extends Loader {
     constructor(manager?: LoadingManager);
     propertyNameMapping: object;
+    customPropertyMapping: Record<string, any>;
 
     load(
         url: string,
@@ -12,5 +13,6 @@ export class PLYLoader extends Loader {
     ): void;
     loadAsync(url: string, onProgress?: (event: ProgressEvent) => void): Promise<BufferGeometry>;
     setPropertyNameMapping(mapping: object): void;
+    setCustomPropertyNameMapping(mapping: Record<string, any>): void;
     parse(data: ArrayBuffer | string): BufferGeometry;
 }

--- a/types/three/examples/jsm/nodes/Nodes.d.ts
+++ b/types/three/examples/jsm/nodes/Nodes.d.ts
@@ -61,6 +61,7 @@ import FrontFacingNode from './display/FrontFacingNode';
 import NormalMapNode from './display/NormalMapNode';
 import PosterizeNode from './display/PosterizeNode';
 import ToneMappingNode from './display/ToneMappingNode';
+import ViewportNode from './display/ViewportNode';
 
 // math
 import MathNode, { MathNodeMethod1, MathNodeMethod2, MathNodeMethod3, MathNodeMethod } from './math/MathNode';
@@ -186,6 +187,7 @@ export {
     NormalMapNode,
     PosterizeNode,
     ToneMappingNode,
+    ViewportNode,
     // math
     MathNode,
     MathNodeMethod1,

--- a/types/three/examples/jsm/nodes/core/NodeBuilder.d.ts
+++ b/types/three/examples/jsm/nodes/core/NodeBuilder.d.ts
@@ -74,6 +74,10 @@ export default abstract class NodeBuilder {
 
     abstract getFrontFacing(): string;
 
+    abstract getFragCoord(): string;
+
+    isFlipY(): boolean;
+
     abstract getTexture(textureProperty: string, uvSnippet: string): string;
 
     abstract getTextureLevel(textureProperty: string, uvSnippet: string, levelSnippet: string): string;

--- a/types/three/examples/jsm/nodes/display/ViewportNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/ViewportNode.d.ts
@@ -1,0 +1,23 @@
+import Node from '../core/Node';
+
+export type ViewportNodeScope =
+    | typeof ViewportNode.COORDINATE
+    | typeof ViewportNode.RESOLUTION
+    | typeof ViewportNode.TOP_LEFT
+    | typeof ViewportNode.BOTTOM_LEFT
+    | typeof ViewportNode.TOP_RIGHT
+    | typeof ViewportNode.BOTTOM_RIGHT;
+
+export default class ViewportNode extends Node {
+    static COORDINATE: 'coordinate';
+    static RESOLUTION: 'resolution';
+    static TOP_LEFT: 'topLeft';
+    static BOTTOM_LEFT: 'bottomLeft';
+    static TOP_RIGHT: 'topRight';
+    static BOTTOM_RIGHT: 'bottomRight';
+
+    scope: ViewportNodeScope;
+    isViewportNode: true;
+
+    constructor(scope: ViewportNodeScope);
+}

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNodeElements.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNodeElements.d.ts
@@ -35,6 +35,7 @@ import {
     TimerNode,
     ToneMappingNode,
     TriplanarTexturesNode,
+    ViewportNode,
 } from '../Nodes';
 
 //
@@ -98,6 +99,13 @@ export function toneMapping(
 ): Swizzable<ToneMappingNode>;
 
 export function posterize(sourceNode: NodeRepresentation, stepsNode: NodeRepresentation): Swizzable<PosterizeNode>;
+
+export const viewportCoordinate: Swizzable<ViewportNode>;
+export const viewportResolution: Swizzable<ViewportNode>;
+export const viewportTopLeft: Swizzable<ViewportNode>;
+export const viewportBottomLeft: Swizzable<ViewportNode>;
+export const viewportTopRight: Swizzable<ViewportNode>;
+export const viewportBottomRight: Swizzable<ViewportNode>;
 
 // lighting
 

--- a/types/three/examples/jsm/postprocessing/AdaptiveToneMappingPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/AdaptiveToneMappingPass.d.ts
@@ -1,6 +1,6 @@
 import { WebGLRenderTarget, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class AdaptiveToneMappingPass extends Pass {
     constructor(adaptive?: boolean, resolution?: number);
@@ -16,7 +16,7 @@ export class AdaptiveToneMappingPass extends Pass {
     adaptLuminanceShader: object;
     materialAdaptiveLum: ShaderMaterial;
     materialToneMap: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 
     reset(): void;
     setAdaptive(adaptive: boolean): void;

--- a/types/three/examples/jsm/postprocessing/AfterimagePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/AfterimagePass.d.ts
@@ -1,6 +1,6 @@
 import { WebGLRenderTarget, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class AfterimagePass extends Pass {
     constructor(damp?: number);
@@ -9,6 +9,6 @@ export class AfterimagePass extends Pass {
     textureComp: WebGLRenderTarget;
     textureOld: WebGLRenderTarget;
     shaderMaterial: ShaderMaterial;
-    compFsQuad: object;
-    copyFsQuad: object;
+    compFsQuad: FullScreenQuad;
+    copyFsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/BloomPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/BloomPass.d.ts
@@ -1,6 +1,6 @@
 import { WebGLRenderTarget, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class BloomPass extends Pass {
     constructor(strength?: number, kernelSize?: number, sigma?: number);
@@ -10,5 +10,5 @@ export class BloomPass extends Pass {
     materialCopy: ShaderMaterial;
     convolutionUniforms: object;
     materialConvolution: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/BokehPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/BokehPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera, ShaderMaterial, WebGLRenderTarget, MeshDepthMaterial, Color } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export interface BokehPassParamters {
     focus?: number;
@@ -18,6 +18,6 @@ export class BokehPass extends Pass {
     materialDepth: MeshDepthMaterial;
     materialBokeh: ShaderMaterial;
     uniforms: object;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     oldClearColor: Color;
 }

--- a/types/three/examples/jsm/postprocessing/ClearPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ClearPass.d.ts
@@ -1,6 +1,6 @@
 import { ColorRepresentation } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class ClearPass extends Pass {
     constructor(clearColor?: ColorRepresentation, clearAlpha?: number);

--- a/types/three/examples/jsm/postprocessing/CubeTexturePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/CubeTexturePass.d.ts
@@ -1,6 +1,6 @@
 import { PerspectiveCamera, CubeTexture, Mesh, Scene } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class CubeTexturePass extends Pass {
     constructor(camera: PerspectiveCamera, envMap?: CubeTexture, opacity?: number);

--- a/types/three/examples/jsm/postprocessing/DotScreenPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/DotScreenPass.d.ts
@@ -1,10 +1,10 @@
 import { Vector2, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class DotScreenPass extends Pass {
     constructor(center?: Vector2, angle?: number, scale?: number);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/EffectComposer.d.ts
+++ b/types/three/examples/jsm/postprocessing/EffectComposer.d.ts
@@ -1,6 +1,6 @@
 import { Clock, WebGLRenderer, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 import { ShaderPass } from './ShaderPass';
 
 export { FullScreenQuad } from './Pass';

--- a/types/three/examples/jsm/postprocessing/FilmPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/FilmPass.d.ts
@@ -1,10 +1,10 @@
 import { ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class FilmPass extends Pass {
     constructor(noiseIntensity?: number, scanlinesIntensity?: number, scanlinesCount?: number, grayscale?: number);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/GlitchPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/GlitchPass.d.ts
@@ -1,12 +1,12 @@
 import { ShaderMaterial, DataTexture } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class GlitchPass extends Pass {
     constructor(dt_size?: number);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     goWild: boolean;
     curF: number;
     randX: number;

--- a/types/three/examples/jsm/postprocessing/HalftonePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/HalftonePass.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export interface HalftonePassParameters {
     shape?: number;
@@ -19,5 +19,5 @@ export class HalftonePass extends Pass {
     constructor(width: number, height: number, params: HalftonePassParameters);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/MaskPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/MaskPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class MaskPass extends Pass {
     constructor(scene: Scene, camera: Camera);

--- a/types/three/examples/jsm/postprocessing/OutlinePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/OutlinePass.d.ts
@@ -12,7 +12,7 @@ import {
     Texture,
 } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class OutlinePass extends Pass {
     constructor(resolution: Vector2, scene: Scene, camera: Camera, selectedObjects?: Object3D[]);
@@ -48,7 +48,7 @@ export class OutlinePass extends Pass {
     materialCopy: ShaderMaterial;
     oldClearColor: Color;
     oldClearAlpha: number;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     tempPulseColor1: Color;
     tempPulseColor2: Color;
     textureMatrix: Matrix4;

--- a/types/three/examples/jsm/postprocessing/RenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/RenderPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera, Material, Color } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class RenderPass extends Pass {
     constructor(scene: Scene, camera: Camera, overrideMaterial?: Material, clearColor?: Color, clearAlpha?: number);

--- a/types/three/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SAOPass.d.ts
@@ -12,7 +12,7 @@ import {
     ColorRepresentation,
 } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export enum OUTPUT {
     Beauty,
@@ -57,7 +57,7 @@ export class SAOPass extends Pass {
     hBlurMaterial: ShaderMaterial;
     materialCopy: ShaderMaterial;
     depthCopy: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     params: SAOPassParams;
 
     static OUTPUT: typeof OUTPUT;

--- a/types/three/examples/jsm/postprocessing/SMAAPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SMAAPass.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial, Texture, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class SMAAPass extends Pass {
     constructor(width: number, height: number);
@@ -14,7 +14,7 @@ export class SMAAPass extends Pass {
     materialWeights: ShaderMaterial;
     uniformsBlend: object;
     materialBlend: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 
     getAreaTexture(): string;
     getSearchTexture(): string;

--- a/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera, ColorRepresentation, ShaderMaterial, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class SSAARenderPass extends Pass {
     constructor(scene: Scene, camera: Camera, clearColor?: ColorRepresentation, clearAlpha?: number);
@@ -12,6 +12,6 @@ export class SSAARenderPass extends Pass {
     clearAlpha: number;
     copyUniforms: object;
     copyMaterial: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     sampleRenderTarget: undefined | WebGLRenderTarget;
 }

--- a/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -12,7 +12,7 @@ import {
     ColorRepresentation,
 } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export enum SSAOPassOUTPUT {
     Default,
@@ -46,7 +46,7 @@ export class SSAOPass extends Pass {
     blurMaterial: ShaderMaterial;
     depthRenderMaterial: ShaderMaterial;
     copyMaterial: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     originalClearColor: Color;
 
     static OUTPUT: SSAOPassOUTPUT;

--- a/types/three/examples/jsm/postprocessing/SavePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SavePass.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class SavePass extends Pass {
     constructor(renderTarget?: WebGLRenderTarget);
@@ -8,5 +8,5 @@ export class SavePass extends Pass {
     renderTarget: WebGLRenderTarget;
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
@@ -1,11 +1,11 @@
 import { ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class ShaderPass extends Pass {
     constructor(shader: object, textureID?: string);
     textureID: string;
     uniforms: { [name: string]: { value: any } };
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/TexturePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/TexturePass.d.ts
@@ -1,6 +1,6 @@
 import { Texture, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class TexturePass extends Pass {
     constructor(map: Texture, opacity?: number);
@@ -8,5 +8,5 @@ export class TexturePass extends Pass {
     opacity: number;
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/UnrealBloomPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/UnrealBloomPass.d.ts
@@ -1,6 +1,6 @@
 import { Color, MeshBasicMaterial, ShaderMaterial, Vector2, Vector3, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class UnrealBloomPass extends Pass {
     constructor(resolution: Vector2, strength: number, radius: number, threshold: number);
@@ -23,7 +23,7 @@ export class UnrealBloomPass extends Pass {
     oldClearColor: Color;
     oldClearAlpha: number;
     basic: MeshBasicMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 
     dispose(): void;
     getSeperableBlurMaterial(): ShaderMaterial;

--- a/types/three/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.d.ts
+++ b/types/three/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.d.ts
@@ -1,5 +1,5 @@
 import NodeBuilder from '../../../nodes/core/NodeBuilder';
-import { Texture, TextureEncoding, Renderer, Object3D } from '../../../../../src/Three';
+import { Renderer, Object3D } from '../../../../../src/Three';
 import Node from '../../../nodes/core/Node';
 import SlotNode from './SlotNode';
 import { NodeShaderStageOption } from '../../../nodes/core/constants';
@@ -44,10 +44,11 @@ export class WebGLNodeBuilder extends NodeBuilder {
 
     replaceCode(shaderStage: string, source: string, target: string, scope?: this): void;
     parseInclude(shaderStage: string, ...includes: string[]): void;
-    getTextureEncodingFromMap(map: Texture): TextureEncoding;
 
     getInstanceIndex(): string;
     getFrontFacing(): string;
+    getFragCoord(): 'gl_FragCoord';
+    isFlipY(): true;
 
     buildCode(): void;
     build(): this;

--- a/types/three/examples/jsm/utils/BufferGeometryUtils.d.ts
+++ b/types/three/examples/jsm/utils/BufferGeometryUtils.d.ts
@@ -1,3 +1,5 @@
+// https://threejs.org/docs/?q=buffergeome#examples/en/utils/BufferGeometryUtils
+
 import {
     BufferAttribute,
     BufferGeometry,
@@ -24,3 +26,11 @@ export function computeMikkTSpaceTangents(
 export function mergeGroups(geometry: BufferGeometry): BufferGeometry;
 export function deinterleaveAttribute(geometry: BufferGeometry): void;
 export function deinterleaveGeometry(geometry: BufferGeometry): void;
+
+/**
+ * Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at an angle greater than the crease angle.
+ *
+ * @param geometry The input geometry.
+ * @param creaseAngle The crease angle.
+ */
+export function toCreasedNormals(geometry: BufferGeometry, creaseAngle?: number): BufferGeometry;

--- a/types/three/src/lights/PointLight.d.ts
+++ b/types/three/src/lights/PointLight.d.ts
@@ -18,7 +18,7 @@ export class PointLight extends Light {
 
     /**
      * Light's intensity.
-     * @default 1
+     * @default 2
      */
     intensity: number;
 

--- a/types/three/src/lights/SpotLight.d.ts
+++ b/types/three/src/lights/SpotLight.d.ts
@@ -37,7 +37,7 @@ export class SpotLight extends Light {
 
     /**
      * Light's intensity.
-     * @default 1
+     * @default 2
      */
     intensity: number;
 

--- a/types/three/src/math/Matrix3.d.ts
+++ b/types/three/src/math/Matrix3.d.ts
@@ -1,3 +1,5 @@
+// https://threejs.org/docs/#api/en/math/Matrix3
+
 import { Matrix4 } from './Matrix4';
 import { Vector3 } from './Vector3';
 
@@ -98,6 +100,47 @@ export class Matrix3 implements Matrix {
     setUvTransform(tx: number, ty: number, sx: number, sy: number, rotation: number, cx: number, cy: number): Matrix3;
 
     scale(sx: number, sy: number): Matrix3;
+
+    /**
+     * Sets this matrix as a 2D translation transform:
+     *
+     * ```
+     * 1, 0, x,
+     * 0, 1, y,
+     * 0, 0, 1
+     * ```
+     *
+     * @param x the amount to translate in the X axis.
+     * @param y the amount to translate in the Y axis.
+     */
+    makeTranslation(x: number, y: number): this;
+
+    /**
+     * Sets this matrix as a 2D rotational transformation by theta radians. The resulting matrix will be:
+     *
+     * ```
+     * cos(θ) -sin(θ) 0
+     * sin(θ) cos(θ)  0
+     * 0      0       1
+     * ```
+     *
+     * @param theta Rotation angle in radians. Positive values rotate counterclockwise.
+     */
+    makeRotation(theta: number): this;
+
+    /**
+     * Sets this matrix as a 2D scale transform:
+     *
+     * ```
+     * x, 0, 0,
+     * 0, y, 0,
+     * 0, 0, 1
+     * ```
+     *
+     * @param x the amount to scale in the X axis.
+     * @param y the amount to scale in the Y axis.
+     */
+    makeScale(x: number, y: number): this;
 
     rotate(theta: number): Matrix3;
 

--- a/types/three/src/objects/LOD.d.ts
+++ b/types/three/src/objects/LOD.d.ts
@@ -38,6 +38,7 @@ export class LOD extends Object3D {
     update(camera: Camera): void;
     toJSON(meta: any): any;
 
+    // TODO: Remove this
     /**
      * @deprecated Use {@link LOD#levels .levels} instead.
      */

--- a/types/three/src/objects/LOD.d.ts
+++ b/types/three/src/objects/LOD.d.ts
@@ -8,11 +8,30 @@ export class LOD extends Object3D {
 
     type: 'LOD';
 
-    levels: Array<{ distance: number; object: Object3D }>;
+    /**
+     *
+     * An array of level objects
+     *
+     * Each level is an object with the following properties:
+     *
+     * - object - The Object3D to display at this level.
+     * - distance - The distance at which to display this level of detail.
+     * - hysteresis - Threshold used to avoid flickering at LOD boundaries, as a fraction of distance.
+     */
+    levels: Array<{ distance: number; hysteresis: number; object: Object3D }>;
+
     autoUpdate: boolean;
     readonly isLOD: true;
 
-    addLevel(object: Object3D, distance?: number): this;
+    /**
+     * Adds a mesh that will display at a certain distance and greater. Typically the further away the distance, the lower the detail on the mesh.
+     *
+     * @param object The Object3D to display at this level.
+     * @param distance The distance at which to display this level of detail. Default 0.0.
+     * @param hysteresis Threshold used to avoid flickering at LOD boundaries, as a fraction of distance. Default 0.0.
+     */
+    addLevel(object: Object3D, distance?: number, hysteresis?: number): this;
+
     getCurrentLevel(): number;
     getObjectForDistance(distance: number): Object3D | null;
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;

--- a/types/three/src/renderers/webxr/WebXRController.d.ts
+++ b/types/three/src/renderers/webxr/WebXRController.d.ts
@@ -39,6 +39,7 @@ export class WebXRController {
     getTargetRaySpace(): XRTargetRaySpace;
     getGripSpace(): XRGripSpace;
     dispatchEvent(event: { type: XRControllerEventType; data?: XRInputSource }): this;
+    connect(inputSource: XRInputSource): this;
     disconnect(inputSource: XRInputSource): this;
     update(inputSource: XRInputSource, frame: XRFrame, referenceSpace: XRReferenceSpace): this;
 }

--- a/types/three/src/renderers/webxr/WebXRManager.d.ts
+++ b/types/three/src/renderers/webxr/WebXRManager.d.ts
@@ -1,3 +1,5 @@
+// https://threejs.org/docs/#api/en/renderers/webxr/WebXRManager
+
 /// <reference types="webxr" />
 
 import { Vector4 } from '../../math/Vector4';
@@ -44,5 +46,11 @@ export class WebXRManager extends EventDispatcher {
     setAnimationLoop(callback: XRFrameRequestCallback | null): void;
     getFoveation(): number | undefined;
     setFoveation(foveation: number): void;
+
+    /**
+     * Returns the set of planes detected by WebXR's plane detection API.
+     */
+    getPlanes(): Set<XRPlane>;
+
     dispose(): void;
 }

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -1,3 +1,5 @@
+// https://threejs.org/docs/?q=scene#api/en/scenes/Scene
+
 import { FogBase } from './Fog';
 import { Material } from './../materials/Material';
 import { Object3D } from './../core/Object3D';
@@ -22,7 +24,19 @@ export class Scene extends Object3D {
      */
     fog: FogBase | null;
 
+    /**
+     * Sets the blurriness of the background. Only influences environment maps assigned to Scene.background. Valid input is a float between 0 and 1.
+     *
+     * @default 0
+     */
     backgroundBlurriness: number;
+
+    /**
+     * Attenuates the color of the background. Only applies to background textures.
+     *
+     * @default 1
+     */
+    backgroundIntensity: number;
 
     /**
      * If not null, it will force everything in the scene to be rendered with that material. Default is null.

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -1,3 +1,5 @@
+// https://threejs.org/docs/?q=texture#api/en/textures/Texture
+
 import { Vector2 } from './../math/Vector2';
 import { Matrix3 } from './../math/Matrix3';
 import { Source } from './Source';
@@ -26,7 +28,7 @@ export class Texture extends EventDispatcher {
      * @param [minFilter=THREE.LinearMipmapLinearFilter]
      * @param [format=THREE.RGBAFormat]
      * @param [type=THREE.UnsignedByteType]
-     * @param [anisotropy=1]
+     * @param [anisotropy=THREE.Texture.DEFAULT_ANISOTROPY]
      * @param [encoding=THREE.LinearEncoding]
      */
     constructor(
@@ -203,6 +205,8 @@ export class Texture extends EventDispatcher {
     readonly isTexture: true;
 
     onUpdate: () => void;
+
+    static DEFAULT_ANISOTROPY: number;
     static DEFAULT_IMAGE: any;
     static DEFAULT_MAPPING: any;
 

--- a/types/three/test/nodes/nodes-ShaderNodeElements.ts
+++ b/types/three/test/nodes/nodes-ShaderNodeElements.ts
@@ -14,6 +14,7 @@ import ColorAdjustmentNode from 'three/examples/jsm/nodes/display/ColorAdjustmen
 import ColorSpaceNode from 'three/examples/jsm/nodes/display/ColorSpaceNode';
 import NormalMapNode from 'three/examples/jsm/nodes/display/NormalMapNode';
 import ToneMappingNode from 'three/examples/jsm/nodes/display/ToneMappingNode';
+import ViewportNode from 'three/examples/jsm/nodes/display/ViewportNode';
 
 // lighting
 import LightsNode from 'three/examples/jsm/nodes/lighting/LightsNode';
@@ -70,6 +71,13 @@ export const colorSpace = (node: Node, encoding: TextureEncoding) =>
 export const normalMap = nodeProxy(NormalMapNode);
 export const toneMapping = (mapping: ToneMapping, exposure: Node, color: Node) =>
     nodeObject(new ToneMappingNode(mapping, nodeObject(exposure), nodeObject(color)));
+
+export const viewportCoordinate = nodeImmutable(ViewportNode, ViewportNode.COORDINATE);
+export const viewportResolution = nodeImmutable(ViewportNode, ViewportNode.RESOLUTION);
+export const viewportTopLeft = nodeImmutable(ViewportNode, ViewportNode.TOP_LEFT);
+export const viewportBottomLeft = nodeImmutable(ViewportNode, ViewportNode.BOTTOM_LEFT);
+export const viewportTopRight = nodeImmutable(ViewportNode, ViewportNode.TOP_RIGHT);
+export const viewportBottomRight = nodeImmutable(ViewportNode, ViewportNode.BOTTOM_RIGHT);
 
 // lighting
 


### PR DESCRIPTION
Following https://github.com/three-types/three-ts-types/pull/302#issuecomment-1357833271, this PR simply replaces `fsQuad: object` instances inside the files of `jsm/postprocessing`. Given the `FullScreenQuad` exists, it makes sense using this instead of `object` 😄 .

### Why

It doesn't close an issue, it was mentioned https://github.com/three-types/three-ts-types/pull/302#issuecomment-1357833271. It simply uses proper types in `fsQuad` instances.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

