### PR TITLE
fix: Adding proper type in `fsQuad` instances inside `jsm/postprocessing`.

### DIFF
--- a/types/three/examples/jsm/postprocessing/AdaptiveToneMappingPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/AdaptiveToneMappingPass.d.ts
@@ -1,6 +1,6 @@
 import { WebGLRenderTarget, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class AdaptiveToneMappingPass extends Pass {
     constructor(adaptive?: boolean, resolution?: number);
@@ -16,7 +16,7 @@ export class AdaptiveToneMappingPass extends Pass {
     adaptLuminanceShader: object;
     materialAdaptiveLum: ShaderMaterial;
     materialToneMap: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 
     reset(): void;
     setAdaptive(adaptive: boolean): void;

--- a/types/three/examples/jsm/postprocessing/AfterimagePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/AfterimagePass.d.ts
@@ -1,6 +1,6 @@
 import { WebGLRenderTarget, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class AfterimagePass extends Pass {
     constructor(damp?: number);
@@ -9,6 +9,6 @@ export class AfterimagePass extends Pass {
     textureComp: WebGLRenderTarget;
     textureOld: WebGLRenderTarget;
     shaderMaterial: ShaderMaterial;
-    compFsQuad: object;
-    copyFsQuad: object;
+    compFsQuad: FullScreenQuad;
+    copyFsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/BloomPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/BloomPass.d.ts
@@ -1,6 +1,6 @@
 import { WebGLRenderTarget, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class BloomPass extends Pass {
     constructor(strength?: number, kernelSize?: number, sigma?: number);
@@ -10,5 +10,5 @@ export class BloomPass extends Pass {
     materialCopy: ShaderMaterial;
     convolutionUniforms: object;
     materialConvolution: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/BokehPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/BokehPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera, ShaderMaterial, WebGLRenderTarget, MeshDepthMaterial, Color } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export interface BokehPassParamters {
     focus?: number;
@@ -18,6 +18,6 @@ export class BokehPass extends Pass {
     materialDepth: MeshDepthMaterial;
     materialBokeh: ShaderMaterial;
     uniforms: object;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     oldClearColor: Color;
 }

--- a/types/three/examples/jsm/postprocessing/ClearPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ClearPass.d.ts
@@ -1,6 +1,6 @@
 import { ColorRepresentation } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class ClearPass extends Pass {
     constructor(clearColor?: ColorRepresentation, clearAlpha?: number);

--- a/types/three/examples/jsm/postprocessing/CubeTexturePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/CubeTexturePass.d.ts
@@ -1,6 +1,6 @@
 import { PerspectiveCamera, CubeTexture, Mesh, Scene } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class CubeTexturePass extends Pass {
     constructor(camera: PerspectiveCamera, envMap?: CubeTexture, opacity?: number);

--- a/types/three/examples/jsm/postprocessing/DotScreenPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/DotScreenPass.d.ts
@@ -1,10 +1,10 @@
 import { Vector2, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class DotScreenPass extends Pass {
     constructor(center?: Vector2, angle?: number, scale?: number);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/EffectComposer.d.ts
+++ b/types/three/examples/jsm/postprocessing/EffectComposer.d.ts
@@ -1,6 +1,6 @@
 import { Clock, WebGLRenderer, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 import { ShaderPass } from './ShaderPass';
 
 export { FullScreenQuad } from './Pass';

--- a/types/three/examples/jsm/postprocessing/FilmPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/FilmPass.d.ts
@@ -1,10 +1,10 @@
 import { ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class FilmPass extends Pass {
     constructor(noiseIntensity?: number, scanlinesIntensity?: number, scanlinesCount?: number, grayscale?: number);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/GlitchPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/GlitchPass.d.ts
@@ -1,12 +1,12 @@
 import { ShaderMaterial, DataTexture } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class GlitchPass extends Pass {
     constructor(dt_size?: number);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     goWild: boolean;
     curF: number;
     randX: number;

--- a/types/three/examples/jsm/postprocessing/HalftonePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/HalftonePass.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export interface HalftonePassParameters {
     shape?: number;
@@ -19,5 +19,5 @@ export class HalftonePass extends Pass {
     constructor(width: number, height: number, params: HalftonePassParameters);
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/MaskPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/MaskPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class MaskPass extends Pass {
     constructor(scene: Scene, camera: Camera);

--- a/types/three/examples/jsm/postprocessing/OutlinePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/OutlinePass.d.ts
@@ -12,7 +12,7 @@ import {
     Texture,
 } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class OutlinePass extends Pass {
     constructor(resolution: Vector2, scene: Scene, camera: Camera, selectedObjects?: Object3D[]);
@@ -48,7 +48,7 @@ export class OutlinePass extends Pass {
     materialCopy: ShaderMaterial;
     oldClearColor: Color;
     oldClearAlpha: number;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     tempPulseColor1: Color;
     tempPulseColor2: Color;
     textureMatrix: Matrix4;

--- a/types/three/examples/jsm/postprocessing/RenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/RenderPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera, Material, Color } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class RenderPass extends Pass {
     constructor(scene: Scene, camera: Camera, overrideMaterial?: Material, clearColor?: Color, clearAlpha?: number);

--- a/types/three/examples/jsm/postprocessing/SAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SAOPass.d.ts
@@ -12,7 +12,7 @@ import {
     ColorRepresentation,
 } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export enum OUTPUT {
     Beauty,
@@ -57,7 +57,7 @@ export class SAOPass extends Pass {
     hBlurMaterial: ShaderMaterial;
     materialCopy: ShaderMaterial;
     depthCopy: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     params: SAOPassParams;
 
     static OUTPUT: typeof OUTPUT;

--- a/types/three/examples/jsm/postprocessing/SMAAPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SMAAPass.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial, Texture, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class SMAAPass extends Pass {
     constructor(width: number, height: number);
@@ -14,7 +14,7 @@ export class SMAAPass extends Pass {
     materialWeights: ShaderMaterial;
     uniformsBlend: object;
     materialBlend: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 
     getAreaTexture(): string;
     getSearchTexture(): string;

--- a/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAARenderPass.d.ts
@@ -1,6 +1,6 @@
 import { Scene, Camera, ColorRepresentation, ShaderMaterial, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class SSAARenderPass extends Pass {
     constructor(scene: Scene, camera: Camera, clearColor?: ColorRepresentation, clearAlpha?: number);
@@ -12,6 +12,6 @@ export class SSAARenderPass extends Pass {
     clearAlpha: number;
     copyUniforms: object;
     copyMaterial: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     sampleRenderTarget: undefined | WebGLRenderTarget;
 }

--- a/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -12,7 +12,7 @@ import {
     ColorRepresentation,
 } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export enum SSAOPassOUTPUT {
     Default,
@@ -46,7 +46,7 @@ export class SSAOPass extends Pass {
     blurMaterial: ShaderMaterial;
     depthRenderMaterial: ShaderMaterial;
     copyMaterial: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
     originalClearColor: Color;
 
     static OUTPUT: SSAOPassOUTPUT;

--- a/types/three/examples/jsm/postprocessing/SavePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SavePass.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class SavePass extends Pass {
     constructor(renderTarget?: WebGLRenderTarget);
@@ -8,5 +8,5 @@ export class SavePass extends Pass {
     renderTarget: WebGLRenderTarget;
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/ShaderPass.d.ts
@@ -1,11 +1,11 @@
 import { ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class ShaderPass extends Pass {
     constructor(shader: object, textureID?: string);
     textureID: string;
     uniforms: { [name: string]: { value: any } };
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/TexturePass.d.ts
+++ b/types/three/examples/jsm/postprocessing/TexturePass.d.ts
@@ -1,6 +1,6 @@
 import { Texture, ShaderMaterial } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class TexturePass extends Pass {
     constructor(map: Texture, opacity?: number);
@@ -8,5 +8,5 @@ export class TexturePass extends Pass {
     opacity: number;
     uniforms: object;
     material: ShaderMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 }

--- a/types/three/examples/jsm/postprocessing/UnrealBloomPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/UnrealBloomPass.d.ts
@@ -1,6 +1,6 @@
 import { Color, MeshBasicMaterial, ShaderMaterial, Vector2, Vector3, WebGLRenderTarget } from '../../../src/Three';
 
-import { Pass } from './Pass';
+import { Pass, FullScreenQuad } from './Pass';
 
 export class UnrealBloomPass extends Pass {
     constructor(resolution: Vector2, strength: number, radius: number, threshold: number);
@@ -23,7 +23,7 @@ export class UnrealBloomPass extends Pass {
     oldClearColor: Color;
     oldClearAlpha: number;
     basic: MeshBasicMaterial;
-    fsQuad: object;
+    fsQuad: FullScreenQuad;
 
     dispose(): void;
     getSeperableBlurMaterial(): ShaderMaterial;


### PR DESCRIPTION
Following https://github.com/three-types/three-ts-types/pull/302#issuecomment-1357833271, this PR simply replaces `fsQuad: object` instances inside the files of `jsm/postprocessing`. Given the `FullScreenQuad` exists, it makes sense using this instead of `object` 😄 .

### Why

It doesn't close an issue, it was mentioned https://github.com/three-types/three-ts-types/pull/302#issuecomment-1357833271. It simply uses proper types in `fsQuad` instances.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

