### PR TITLE
Change KeyframeTrack params type `times` from any[] to number[]

### DIFF
--- a/types/three/src/animation/KeyframeTrack.d.ts
+++ b/types/three/src/animation/KeyframeTrack.d.ts
@@ -10,7 +10,7 @@ export class KeyframeTrack {
      * @param values
      * @param [interpolation=THREE.InterpolateLinear]
      */
-    constructor(name: string, times: ArrayLike<any>, values: ArrayLike<any>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<any>, interpolation?: InterpolationModes);
 
     name: string;
     times: Float32Array;

--- a/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
@@ -1,7 +1,7 @@
 import { KeyframeTrack } from './../KeyframeTrack';
 
 export class BooleanKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: any[], values: any[]);
+    constructor(name: string, times: number[], values: any[]);
 
     /**
      * @default 'bool'

--- a/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
@@ -1,7 +1,7 @@
 import { KeyframeTrack } from './../KeyframeTrack';
 
 export class BooleanKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: number[], values: any[]);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<any>);
 
     /**
      * @default 'bool'

--- a/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class ColorKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: any[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: number[], values: any[], interpolation?: InterpolationModes);
 
     /**
      * @default 'color'

--- a/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class ColorKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: number[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'color'

--- a/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class NumberKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: number[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'number'

--- a/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class NumberKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: any[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: number[], values: any[], interpolation?: InterpolationModes);
 
     /**
      * @default 'number'

--- a/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class QuaternionKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: any[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: number[], values: number[], interpolation?: InterpolationModes);
 
     /**
      * @default 'quaternion'

--- a/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class QuaternionKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: number[], values: number[], interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'quaternion'

--- a/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class StringKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: number[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<any>, interpolation?: InterpolationModes);
 
     /**
      * @default 'string'

--- a/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class StringKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: any[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: number[], values: any[], interpolation?: InterpolationModes);
 
     /**
      * @default 'string'

--- a/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class VectorKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: number[], values: number[], interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'vector'

--- a/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack';
 import { InterpolationModes } from '../../constants';
 
 export class VectorKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: any[], values: any[], interpolation?: InterpolationModes);
+    constructor(name: string, times: number[], values: number[], interpolation?: InterpolationModes);
 
     /**
      * @default 'vector'


### PR DESCRIPTION
Change KeyframeTrack params `times` from `any[]` to `number[]`

By doing this following child of KeyframeTrack, I changed `BooleanKeyframeTrack` , `ColorKeyframeTrack`, `NumberKeyframeTrack ` ,`StringKeyframeTrack ` , `QuaternionKeyframeTrack ` , `VectorKeyframeTrack `.

I changed `times` types of these. And I changed `QuaternionKeyframeTrack ` , `VectorKeyframeTrack ` parameter `values` from `any[]` to `number[]`.

But low confident, I didn't changed other `values` types.
I think it will be good if we can know what others type of the value and change by this PR.

If I know the type of other values, I will add new commit.

-   [x ] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [ x] Ready to be merged

I didn't add my self to contributors table cause it already has.

issue link https://github.com/three-types/three-ts-types/issues/294