### PR TITLE
[feat] allow GLBufferAttribute as an attribute type

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -504,6 +504,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "mikkom",
+      "name": "Mikko Matilainen",
+      "avatar_url": "https://avatars.githubusercontent.com/u/77391?v=4",
+      "profile": "https://github.com/mikkom",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/LuchoTurtle"><img src="https://avatars.githubusercontent.com/u/17494745?v=4?s=100" width="100px;" alt=""/><br /><sub><b>LuchoTurtle</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=LuchoTurtle" title="Code">💻</a></td>
     <td align="center"><a href="https://www.needle.tools"><img src="https://avatars.githubusercontent.com/u/5083203?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Marcel Wiessler</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=marwie" title="Code">💻</a></td>
     <td align="center"><a href="https://s2n.tech/"><img src="https://avatars.githubusercontent.com/u/37236438?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Shuntaro Nishizawa</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/issues?q=author%3Ashun-shobon" title="Bug reports">🐛</a> <a href="https://github.com/three-types/three-ts-types/commits?author=shun-shobon" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/mikkom"><img src="https://avatars.githubusercontent.com/u/77391?v=4?s=100" width="100px;" alt=""/><br /><sub><b>Mikko Matilainen</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=mikkom" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -1,4 +1,6 @@
 import { BufferAttribute } from './BufferAttribute';
+import { InterleavedBufferAttribute } from './InterleavedBufferAttribute';
+import { GLBufferAttribute } from './GLBufferAttribute';
 import { Box3 } from './../math/Box3';
 import { Sphere } from './../math/Sphere';
 import { Matrix4 } from './../math/Matrix4';
@@ -6,7 +8,6 @@ import { Quaternion } from './../math/Quaternion';
 import { Vector2 } from './../math/Vector2';
 import { Vector3 } from './../math/Vector3';
 import { EventDispatcher } from './EventDispatcher';
-import { InterleavedBufferAttribute } from './InterleavedBufferAttribute';
 import { BuiltinShaderAttributeName } from '../constants';
 
 /**
@@ -47,7 +48,7 @@ export class BufferGeometry extends EventDispatcher {
      * @default {}
      */
     attributes: {
-        [name: string]: BufferAttribute | InterleavedBufferAttribute;
+        [name: string]: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute;
     };
 
     /**
@@ -93,9 +94,11 @@ export class BufferGeometry extends EventDispatcher {
 
     setAttribute(
         name: BuiltinShaderAttributeName | (string & {}),
-        attribute: BufferAttribute | InterleavedBufferAttribute,
+        attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute,
     ): BufferGeometry;
-    getAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferAttribute | InterleavedBufferAttribute;
+    getAttribute(
+        name: BuiltinShaderAttributeName | (string & {}),
+    ): BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute;
     deleteAttribute(name: BuiltinShaderAttributeName | (string & {})): BufferGeometry;
     hasAttribute(name: BuiltinShaderAttributeName | (string & {})): boolean;
 

--- a/types/three/src/core/GLBufferAttribute.d.ts
+++ b/types/three/src/core/GLBufferAttribute.d.ts
@@ -5,6 +5,10 @@
 export class GLBufferAttribute {
     constructor(buffer: WebGLBuffer, type: number, itemSize: number, elementSize: 1 | 2 | 4, count: number);
 
+    /**
+     * @default ''
+     */
+    name: string;
     buffer: WebGLBuffer;
     type: number;
     itemSize: number;

--- a/types/three/src/renderers/webgl/WebGLAttributes.d.ts
+++ b/types/three/src/renderers/webgl/WebGLAttributes.d.ts
@@ -1,18 +1,19 @@
 import { WebGLCapabilities } from './WebGLCapabilities';
 import { BufferAttribute } from '../../core/BufferAttribute';
 import { InterleavedBufferAttribute } from '../../core/InterleavedBufferAttribute';
+import { GLBufferAttribute } from '../../core/GLBufferAttribute';
 
 export class WebGLAttributes {
     constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, capabilities: WebGLCapabilities);
 
-    get(attribute: BufferAttribute | InterleavedBufferAttribute): {
+    get(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute): {
         buffer: WebGLBuffer;
         type: number;
         bytesPerElement: number;
         version: number;
     };
 
-    remove(attribute: BufferAttribute | InterleavedBufferAttribute): void;
+    remove(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute): void;
 
-    update(attribute: BufferAttribute | InterleavedBufferAttribute, bufferType: number): void;
+    update(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute, bufferType: number): void;
 }

--- a/types/three/test/controls/controls-pointercontrols.ts
+++ b/types/three/test/controls/controls-pointercontrols.ts
@@ -126,14 +126,16 @@ function init() {
 
     let position = floorGeometry.attributes.position;
 
-    for (let i = 0, l = position.count; i < l; i++) {
-        vertex.fromBufferAttribute(position, i);
+    if (!(position instanceof THREE.GLBufferAttribute)) {
+        for (let i = 0, l = position.count; i < l; i++) {
+            vertex.fromBufferAttribute(position, i);
 
-        vertex.x += Math.random() * 20 - 10;
-        vertex.y += Math.random() * 2;
-        vertex.z += Math.random() * 20 - 10;
+            vertex.x += Math.random() * 20 - 10;
+            vertex.y += Math.random() * 2;
+            vertex.z += Math.random() * 20 - 10;
 
-        position.setXYZ(i, vertex.x, vertex.y, vertex.z);
+            position.setXYZ(i, vertex.x, vertex.y, vertex.z);
+        }
     }
 
     const indexedGeometry = floorGeometry.toNonIndexed(); // ensure each face has unique vertices


### PR DESCRIPTION
This is the same change as https://github.com/three-types/three-ts-types/pull/295, just retargeted against dev branch.

### Why

The current typings don't allow setting `GLBufferAttribute` as an attribute in `BufferGeometry`. This functionality has been in Three.js for quite some time (originally introduced in https://github.com/mrdoob/three.js/pull/13196 back in 2020).

Three.js master continues to support this feature in `BufferGeometry` (see e.g. https://github.com/mrdoob/three.js/blob/master/src/core/BufferGeometry.js#L371), documents the attribute type in https://threejs.org/docs/#api/en/core/GLBufferAttribute and has a usage example in https://github.com/mrdoob/three.js/blob/master/examples/webgl_buffergeometry_glbufferattribute.html#L115-L117.

### What

This change adds `GLBufferAttribute` as a valid type for `setAttribute` and `getAttribute` methods in `BufferGeometry`. The type for `GLBufferAttribute` had already been defined and exported but it was not used anywhere else in the typings.

Note that the change can break consumers of the typings as `GLBufferAttribute` does not implement the same interface as `BufferAttribute`. The way to fix these issues is to use the boolean flags (`isBufferAttribute`, `isInterleavedBufferAttribute`, or `isGLBufferAttribute`) to discriminate between the different options (or alternatively by resorting to type assertions). Despite the potential breakage, I believe these typings are more correct.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged