### PR TITLE
fix: allow null for WebXRManager.setSession

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -656,6 +656,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "saitonakamura",
+      "name": "Michael サイトー 中村 Bashurov",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1552189?v=4",
+      "profile": "https://github.com/saitonakamura",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/willstott101"><img src="https://avatars.githubusercontent.com/u/335152?v=4?s=100" width="100px;" alt="Will Stott"/><br /><sub><b>Will Stott</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=willstott101" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/demike"><img src="https://avatars.githubusercontent.com/u/1626922?v=4?s=100" width="100px;" alt="demike"/><br /><sub><b>demike</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=demike" title="Code">💻</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/saitonakamura"><img src="https://avatars.githubusercontent.com/u/1552189?v=4?s=100" width="100px;" alt="Michael サイトー 中村 Bashurov"/><br /><sub><b>Michael サイトー 中村 Bashurov</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=saitonakamura" title="Code">💻</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/types/three/src/renderers/webxr/WebXRManager.d.ts
+++ b/types/three/src/renderers/webxr/WebXRManager.d.ts
@@ -40,7 +40,7 @@ export class WebXRManager extends EventDispatcher {
     getBinding(): XRWebGLBinding;
     getFrame(): XRFrame;
     getSession(): XRSession | null;
-    setSession(value: XRSession): Promise<void>;
+    setSession(value: XRSession | null): Promise<void>;
     getCamera(): WebXRArrayCamera;
     updateCamera(camera: PerspectiveCamera): void;
     setAnimationLoop(callback: XRFrameRequestCallback | null): void;

--- a/types/three/test/renderers/webxr/webxr-vr-cube.ts
+++ b/types/three/test/renderers/webxr/webxr-vr-cube.ts
@@ -23,12 +23,13 @@ async function onSessionStarted(session: XRSession): Promise<void> {
     currentSession = session;
 }
 
-function onSessionEnded(): void {
+async function onSessionEnded(): Promise<void> {
     if (currentSession == null) {
         return;
     }
 
     currentSession.removeEventListener('end', onSessionEnded);
+    await renderer.xr.setSession(null);
     vrButton.innerText = 'Enter VR';
 
     currentSession = null;


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
setting session as null doesn't really do anything, but it's used in this code https://github.com/mrdoob/three.js/blob/312ee7b016c9bb35abe2b9e627829a7d4eb89a2e/editor/js/Viewport.VR.js#L60 so I guess it's fine to allow it

### What

<!-- what have you done, if its a bug, whats your solution? -->
 allow null for WebXRManager.setSession

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
