### PR TITLE
feat: Add constants for RGTC compressed textures

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -270,6 +270,12 @@ export const RGBA_ASTC_12x12_Format: CompressedPixelFormat;
 // BPTC compressed texture formats
 export const RGBA_BPTC_Format: CompressedPixelFormat;
 
+// RGTC compressed texture formats
+export const RED_RGTC1_Format: CompressedPixelFormat;
+export const SIGNED_RED_RGTC1_Format: CompressedPixelFormat;
+export const RED_GREEN_RGTC2_Format: CompressedPixelFormat;
+export const SIGNED_RED_GREEN_RGTC2_Format: CompressedPixelFormat;
+
 // Loop styles for AnimationAction
 export enum AnimationActionLoopStyles {}
 export const LoopOnce: AnimationActionLoopStyles;


### PR DESCRIPTION
### Why

To catch up with r149

https://github.com/three-types/three-ts-types/issues/312

### What

Add constants for RGTC compressed textures.

See: https://github.com/mrdoob/three.js/pull/25180

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
