### PR TITLE
fix: add ViewHelper

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -30,6 +30,7 @@ examples/jsm/helpers/OctreeHelper.d.ts
 examples/jsm/helpers/PositionalAudioHelper.d.ts
 examples/jsm/helpers/VertexNormalsHelper.d.ts
 examples/jsm/helpers/VertexTangentsHelper.d.ts
+examples/jsm/helpers/ViewHelper.d.ts
 examples/jsm/interactive/HTMLMesh.d.ts
 examples/jsm/interactive/InteractiveGroup.d.ts
 examples/jsm/libs/stats.module.d.ts

--- a/types/three/examples/jsm/helpers/ViewHelper.d.ts
+++ b/types/three/examples/jsm/helpers/ViewHelper.d.ts
@@ -1,0 +1,16 @@
+import { Object3D, Vector3, WebGLRenderer } from '../../../src/Three';
+import { Octree } from '../math/Octree';
+
+export class ViewHelper extends Object3D {
+    animating: boolean;
+    center: Vector3;
+
+    readonly isViewHelper: true;
+
+    constructor(camera: Octree, domElement: HTMLElement);
+
+    render(renderer: WebGLRenderer): void;
+    handleClick(event: PointerEvent): boolean;
+    update(delta: number): void;
+    dispose(): void;
+}


### PR DESCRIPTION
### Why

To catch up with r149

### What

Add missing `ViewHelper` definition

This commit refers to the ViewHelper as of https://github.com/mrdoob/three.js/pull/25202 which is going to be included in r149 so I'm targeting the `dev`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
