### PR TITLE
chore: remove deprecated codes

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -179,7 +179,6 @@ export * from './objects/Group';
 /**
  * Renderers
  */
-export * from './renderers/WebGLMultisampleRenderTarget';
 export * from './renderers/WebGLCubeRenderTarget';
 export * from './renderers/WebGLMultipleRenderTargets';
 export * from './renderers/WebGLRenderTarget';
@@ -226,8 +225,6 @@ export * from './scenes/Scene';
 export * from './textures/VideoTexture';
 export * from './textures/CompressedArrayTexture';
 export * from './textures/DataTexture';
-export * from './textures/DataTexture2DArray';
-export * from './textures/DataTexture3D';
 export * from './textures/CompressedTexture';
 export * from './textures/CubeTexture';
 export * from './textures/Data3DTexture';

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -154,7 +154,6 @@ export const UnsignedInt248Type: TextureDataType;
 // Pixel formats
 export enum PixelFormat {}
 export const AlphaFormat: PixelFormat;
-export const RGBFormat: PixelFormat;
 export const RGBAFormat: PixelFormat;
 export const LuminanceFormat: PixelFormat;
 export const LuminanceAlphaFormat: PixelFormat;

--- a/types/three/src/renderers/WebGLMultisampleRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLMultisampleRenderTarget.d.ts
@@ -1,6 +1,0 @@
-import { WebGLRenderTarget } from './WebGLRenderTarget';
-
-/**
- * @deprecated THREE.WebGLMultisampleRenderTarget has been removed. Use a normal {@link WebGLRenderTarget render target} and set the "samples" property to greater 0 to enable multisampling.
- */
-export class WebGLMultisampleRenderTarget extends WebGLRenderTarget {}

--- a/types/three/src/textures/DataTexture2DArray.d.ts
+++ b/types/three/src/textures/DataTexture2DArray.d.ts
@@ -1,6 +1,0 @@
-import { DataArrayTexture } from './DataArrayTexture';
-
-/**
- * @deprecated THREE.DataTexture2DArray has been renamed to DataArrayTexture.
- */
-export class DataTexture2DArray extends DataArrayTexture {}

--- a/types/three/src/textures/DataTexture3D.d.ts
+++ b/types/three/src/textures/DataTexture3D.d.ts
@@ -1,6 +1,0 @@
-import { Data3DTexture } from './Data3DTexture';
-
-/**
- * @deprecated THREE.DataTexture3D has been renamed to Data3DTexture.
- */
-export class DataTexture3D extends Data3DTexture {}


### PR DESCRIPTION
### Why

To catch up with r149

### What

Remove deprecated codes.

- Remove `RGBFormat`
- Remove `WebGLMultisampleRenderTarget`, `DataTexture2DArray`, and `DataTexture3D`

See: https://github.com/mrdoob/three.js/pull/25279

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
