### PR TITLE
chore: replace `TwoPassDoubleSide` with `material.forceSinglePass`

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -36,15 +36,12 @@ export const VSMShadowMap: ShadowMapType;
 // side
 /**
  * Defines which side of faces will be rendered - front, back or both.
- * Default is FrontSide.
- *
- * TwoPassDoubleSide will renderer double-sided transparent materials in two passes in back-front order to mitigate transparency artifacts.
+ * Default is {@link FrontSide}.
  */
 export enum Side {}
 export const FrontSide: Side;
 export const BackSide: Side;
 export const DoubleSide: Side;
-export const TwoPassDoubleSide: Side;
 
 // blending modes
 export enum Blending {}

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -39,6 +39,7 @@ export interface MaterialParameters {
     polygonOffsetUnits?: number | undefined;
     precision?: 'highp' | 'mediump' | 'lowp' | null | undefined;
     premultipliedAlpha?: boolean | undefined;
+    forceSinglePass?: boolean | undefined;
     dithering?: boolean | undefined;
     side?: Side | undefined;
     shadowSide?: Side | undefined;
@@ -284,6 +285,11 @@ export class Material extends EventDispatcher {
     premultipliedAlpha: boolean;
 
     /**
+     * @default false
+     */
+    forceSinglePass: boolean;
+
+    /**
      * Whether to apply dithering to the color to remove the appearance of banding. Default is false.
      * @default false
      */
@@ -291,8 +297,9 @@ export class Material extends EventDispatcher {
 
     /**
      * Defines which of the face sides will be rendered - front, back or both.
-     * Default is THREE.FrontSide. Other options are THREE.BackSide and THREE.DoubleSide.
-     * @default THREE.FrontSide
+     * Default is {@link THREE.FrontSide}. Other options are {@link THREE.BackSide} and {@link THREE.DoubleSide}.
+     *
+     * @default {@link THREE.FrontSide}
      */
     side: Side;
 


### PR DESCRIPTION
### Why

To catch up with r149

### What

- Remove `TwoPassDoubleSide`.
- Add `material.forceSinglePass`.

See: https://github.com/mrdoob/three.js/pull/25239

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
