### PR TITLE
chore(mesh): maintain consistent nomenclature

### DIFF
--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -21,10 +21,10 @@ export class Mesh<
     updateMorphTargets(): void;
 
     /**
-     * Get the current position of the indicated vertex in local space,
+     * Get the local-space position of the vertex at the given index,
      * taking into account the current animation state of both morph targets and skinning.
      */
-    getVertexPosition(vert: number, target: Vector3): Vector3;
+    getVertexPosition(index: number, target: Vector3): Vector3;
 
     raycast(raycaster: Raycaster, intersects: Intersection[]): void;
 }


### PR DESCRIPTION
### Why

To catch up with r149

### What

- Change the first argument of `Mesh.getVertexPosition`, `vert` -> `index`
- Update the doc comment of `Mesh.getVertexPosition`

See: https://github.com/mrdoob/three.js/pull/25178

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
