### PR TITLE
fix (WebXRManager): change argument name of `setFoveation`

### DIFF
--- a/types/three/src/renderers/webxr/WebXRManager.d.ts
+++ b/types/three/src/renderers/webxr/WebXRManager.d.ts
@@ -45,7 +45,7 @@ export class WebXRManager extends EventDispatcher {
     updateCamera(camera: PerspectiveCamera): void;
     setAnimationLoop(callback: XRFrameRequestCallback | null): void;
     getFoveation(): number | undefined;
-    setFoveation(foveation: number): void;
+    setFoveation(value: number): void;
 
     /**
      * Returns the set of planes detected by WebXR's plane detection API.


### PR DESCRIPTION
### Why

To catch up with r149

### What

change argument name of `setFoveation`

See: https://github.com/mrdoob/three.js/pull/25282

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
