### PR TITLE
chore: Set Git line endings to LF for Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### Why

This is necessary for Windows contributors since Prettier enforces LF line endings. Suggested at https://prettier.io/docs/en/options.html#end-of-line.

### What

Configure Git to clone using LF line endings.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
