### PR TITLE
Add exports field to package.json

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -1,3 +1,5 @@
+build/three.d.ts
+build/three.module.d.ts
 examples/jsm/animation/AnimationClipCreator.d.ts
 examples/jsm/csm/CSMShader.d.ts
 examples/jsm/curves/NURBSCurve.d.ts

--- a/types/three/build/three.d.ts
+++ b/types/three/build/three.d.ts
@@ -1,0 +1,2 @@
+export * from '../src/Three';
+export as namespace THREE;

--- a/types/three/build/three.module.d.ts
+++ b/types/three/build/three.module.d.ts
@@ -1,0 +1,2 @@
+export * from '../src/Three';
+export as namespace THREE;

--- a/types/three/package.json
+++ b/types/three/package.json
@@ -10,8 +10,5 @@
         "./addons/*": "./examples/jsm/*",
         "./src/*": "./src/*",
         "./nodes": "./examples/jsm/nodes/Nodes.js"
-    },
-    "dependencies": {
-        "@types/webxr": "*"
     }
 }

--- a/types/three/package.json
+++ b/types/three/package.json
@@ -1,6 +1,5 @@
 {
     "private": true,
-    "license": "MIT",
     "exports": {
         ".": {
             "import": "./build/three.module.js",

--- a/types/three/package.json
+++ b/types/three/package.json
@@ -1,0 +1,18 @@
+{
+    "private": true,
+    "license": "MIT",
+    "exports": {
+        ".": {
+            "import": "./build/three.module.js",
+            "require": "./build/three.cjs"
+        },
+        "./examples/fonts/*": "./examples/fonts/*",
+        "./examples/jsm/*": "./examples/jsm/*",
+        "./addons/*": "./examples/jsm/*",
+        "./src/*": "./src/*",
+        "./nodes": "./examples/jsm/nodes/Nodes.js"
+    },
+    "dependencies": {
+        "@types/webxr": "*"
+    }
+}

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -13,8 +13,6 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
-        "build/three.d.ts",
-        "build/three.module.d.ts",
         "index.d.ts",
         "three-tests.ts",
         "test/audio/audio-context.ts",

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -13,6 +13,8 @@
         "forceConsistentCasingInFileNames": true
     },
     "files": [
+        "build/three.d.ts",
+        "build/three.module.d.ts",
         "index.d.ts",
         "three-tests.ts",
         "test/audio/audio-context.ts",


### PR DESCRIPTION
### Why

Resolves #336.

### What

Added the `exports` field to `package.json` to match three's [`exports` field](https://github.com/mrdoob/three.js/blob/dev/package.json#L8-L18). Also added `build/three.d.ts` and `build/three.module.d.ts` so that those paths would resolve correctly.

I tested this locally and importing `three/addons/controls/OrbitControls.js` seems to resolve correctly. Hopefully DefinitelyTyped preserves this field when publishing the types. The only way to know for sure is to try it out.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
