### PR TITLE
Fix Earcut.triangulate return value

### DIFF
--- a/types/three/src/extras/Earcut.d.ts
+++ b/types/three/src/extras/Earcut.d.ts
@@ -1,4 +1,3 @@
-import { Triangle } from '../Three';
-export namespace Earcut {
-    function triangulate(data: number[], holeIndices: number[], dim: number): Triangle[];
-}
+export const Earcut: {
+    triangulate(data: number[], holeIndices?: number[], dim?: number): number[];
+};

--- a/types/three/test/extra/Earcut.ts
+++ b/types/three/test/extra/Earcut.ts
@@ -1,0 +1,3 @@
+import * as THREE from 'three';
+
+const triangles = THREE.Earcut.triangulate([0, 0, 1, 0, 1, 1, 0, 1]); // $ExpectType number[]

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -27,6 +27,7 @@
         "test/controls/controls-transformcontrols.ts",
         "test/core/core-eventDispatcher.ts",
         "test/core/uniform.ts",
+        "test/extra/Earcut.ts",
         "test/geometries/geometry-buffer.ts",
         "test/geometries/geometry-cube.ts",
         "test/geometries/geometry-parametric.ts",


### PR DESCRIPTION
### Why

Resolves #268.

### What

- Fix return value
  - Not trivial to verify by just reading code, but found [here](https://github.com/mrdoob/three.js/blob/dev/src/extras/Earcut.js#L128-L130)
  - Also tested runtime to verify
- Make the last two parameters optional
  - Verified by [these lines](https://github.com/mrdoob/three.js/blob/dev/src/extras/Earcut.js#L7-L9)
- Export a const instead of using a namespace
- Add test

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
