### PR TITLE
Remove Earcut export

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -67,7 +67,6 @@ export * from './extras/core/ShapePath';
 export * from './extras/core/CurvePath';
 export * from './extras/core/Curve';
 export * as DataUtils from './extras/DataUtils';
-export * from './extras/Earcut';
 export * from './extras/ImageUtils';
 export * from './extras/ShapeUtils';
 export * from './extras/PMREMGenerator';

--- a/types/three/test/extra/Earcut.ts
+++ b/types/three/test/extra/Earcut.ts
@@ -1,3 +1,3 @@
-import * as THREE from 'three';
+import { Earcut } from 'three/src/extras/Earcut';
 
-const triangles = THREE.Earcut.triangulate([0, 0, 1, 0, 1, 1, 0, 1]); // $ExpectType number[]
+const triangles = Earcut.triangulate([0, 0, 1, 0, 1, 1, 0, 1]); // $ExpectType number[]


### PR DESCRIPTION
### Why

Earcut is not exported from [Three.js](https://github.com/mrdoob/three.js/blob/dev/src/Three.js).

### What

Remove Earcut export from Three.d.ts.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
