### PR TITLE
Add "type": "module" to package.json

### DIFF
--- a/types/three/package.json
+++ b/types/three/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "type": "module",
     "exports": {
         ".": {
             "import": "./build/three.module.js",


### PR DESCRIPTION
### Why

[DefinitelyTyped suggests](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64361) adding `"type": "module"` to the `package.json` if the implementation package has it.

### What

Add `"type": "module"` to the `package.json`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
