### PR TITLE
Fix usage with "module": "nodenext"

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -1,3 +1,4 @@
+build/three.d.cts
 build/three.d.ts
 build/three.module.d.ts
 examples/jsm/animation/AnimationClipCreator.d.ts

--- a/types/three/build/three.d.cts
+++ b/types/three/build/three.d.cts
@@ -1,0 +1,2 @@
+export * from '../src/Three';
+export as namespace THREE;

--- a/types/three/package.json
+++ b/types/three/package.json
@@ -1,6 +1,5 @@
 {
     "private": true,
-    "type": "module",
     "exports": {
         ".": {
             "import": "./build/three.module.js",


### PR DESCRIPTION
### Why

I was a little too hasty with https://github.com/three-types/three-ts-types/pull/352 and didn't test it with `"module": "nodenext"`. Turns out if you specify `"type": "module"` it expects all the imports to have extensions. DefinitelyTyped doesn't currently support this, but they are working on it. Until then, we should remove `"type": "module"`.

This also resolves https://github.com/three-types/three-ts-types/issues/336, since the `exports` field works when using `"module": "nodenext"`.

### What

Remove `"type": "module"` (reverting https://github.com/three-types/three-ts-types/pull/352). Also add `build/three.d.cts` to match `build/three.cjs`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
