### PR TITLE
Add types for lil-gui

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,14 @@
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/utils": "latest",
+        "@types/webxr": "*",
         "all-contributors-cli": "^6.24.0",
         "husky": "^8.0.3",
+        "lil-gui": "~0.17.0",
         "prettier": "2.8.4",
         "pretty-quick": "^3.1.3",
         "source-map-support": "^0.5.21",
         "typescript": "next"
-    },
-    "dependencies": {
-        "@types/webxr": "^0.5.1"
     },
     "packageManager": "yarn@3.4.1"
 }

--- a/types/three/examples/jsm/libs/lil-gui.module.min.d.ts
+++ b/types/three/examples/jsm/libs/lil-gui.module.min.d.ts
@@ -1,0 +1,1 @@
+export * from 'lil-gui';

--- a/types/three/package.json
+++ b/types/three/package.json
@@ -10,5 +10,8 @@
         "./addons/*": "./examples/jsm/*",
         "./src/*": "./src/*",
         "./nodes": "./examples/jsm/nodes/Nodes.js"
+    },
+    "dependencies": {
+        "lil-gui": "~0.17.0"
     }
 }

--- a/types/three/test/libs/lil-gui.ts
+++ b/types/three/test/libs/lil-gui.ts
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min';
+
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 200);
+
+const layers = {
+    'Toggle Name'() {
+        camera.layers.toggle(0);
+    },
+    'Toggle Mass'() {
+        camera.layers.toggle(1);
+    },
+    'Enable All'() {
+        camera.layers.enableAll();
+    },
+
+    'Disable All'() {
+        camera.layers.disableAll();
+    },
+};
+
+const gui = new GUI();
+
+gui.add(layers, 'Toggle Name');
+gui.add(layers, 'Toggle Mass');
+gui.add(layers, 'Enable All');
+gui.add(layers, 'Disable All');

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -33,6 +33,7 @@
         "test/geometries/geometry-parametric.ts",
         "test/geometries/geometry-shapes.ts",
         "test/helpers/helper-viewHelper.ts",
+        "test/libs/lil-gui.ts",
         "test/lights/lights-hemisphere.ts",
         "test/lights/lights-physical.ts",
         "test/lights/lights-pointlights.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,7 +350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webxr@npm:^0.5.1":
+"@types/webxr@npm:*":
   version: 0.5.1
   resolution: "@types/webxr@npm:0.5.1"
   checksum: a77c6be72623679341526dbec18971db0824d5697626d56decc8bb5b73491582b64d094c168ae8d00861549122ca066d7dc45d9cbb5c608626be7f48a6cd7c43
@@ -2332,6 +2332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lil-gui@npm:~0.17.0":
+  version: 0.17.0
+  resolution: "lil-gui@npm:0.17.0"
+  checksum: a6f33e90748ea98477f1f7af6d6cbdc4a1b38ce9da86d674d73f7b0bbdc7f3e947d81edee04c32f33fb28c69a108ba04c24270a8398064ffcc56ffeabc0a916e
+  languageName: node
+  linkType: hard
+
 "locate-path@npm:^5.0.0":
   version: 5.0.0
   resolution: "locate-path@npm:5.0.0"
@@ -3371,9 +3378,10 @@ __metadata:
     "@definitelytyped/dtslint-runner": latest
     "@definitelytyped/header-parser": latest
     "@definitelytyped/utils": latest
-    "@types/webxr": ^0.5.1
+    "@types/webxr": "*"
     all-contributors-cli: ^6.24.0
     husky: ^8.0.3
+    lil-gui: ~0.17.0
     prettier: 2.8.4
     pretty-quick: ^3.1.3
     source-map-support: ^0.5.21


### PR DESCRIPTION
### Why

I'm working on creating an automated system for testing the types using the HTML examples in the three.js repository. They make use of the lil-gui library, so this PR adds the types for that library.

### What

Add types for lil-gui.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
