### PR TITLE
Allow Color to be set from an InterleavedBufferAttribute

### DIFF
--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -2,6 +2,7 @@ import { ColorSpace } from '../constants';
 import { ColorRepresentation } from '../utils';
 
 import { BufferAttribute } from './../core/BufferAttribute';
+import { InterleavedBufferAttribute } from './../core/InterleavedBufferAttribute';
 
 export { SRGBToLinear } from './ColorManagement';
 
@@ -326,7 +327,7 @@ export class Color {
      */
     toArray(xyz: ArrayLike<number>, offset?: number): ArrayLike<number>;
 
-    fromBufferAttribute(attribute: BufferAttribute, index: number): this;
+    fromBufferAttribute(attribute: BufferAttribute | InterleavedBufferAttribute, index: number): this;
 
     [Symbol.iterator](): Generator<number, void>;
 


### PR DESCRIPTION
### Why

A `Color` can also be set from an `InterleavedBufferAttribute` since [the code for that method](https://github.com/mrdoob/three.js/blob/master/src/math/Color.js#L574-L582) is just calling `getX()`/`getY()`/`getZ()`.

### What

Add `InterleavedBufferAttribute` as an allowed type for `Color.fromBufferAttribute`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
