### PR TITLE
Re-export @types/stats.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,15 +16,14 @@
         "@definitelytyped/dtslint-runner": "latest",
         "@definitelytyped/header-parser": "latest",
         "@definitelytyped/utils": "latest",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
         "all-contributors-cli": "^6.24.0",
         "husky": "^8.0.3",
         "prettier": "2.8.4",
         "pretty-quick": "^3.1.3",
         "source-map-support": "^0.5.21",
         "typescript": "next"
-    },
-    "dependencies": {
-        "@types/webxr": "^0.5.1"
     },
     "packageManager": "yarn@3.4.1"
 }

--- a/types/three/examples/jsm/libs/stats.module.d.ts
+++ b/types/three/examples/jsm/libs/stats.module.d.ts
@@ -1,24 +1,3 @@
-interface Stats {
-    REVISION: number;
-    dom: HTMLDivElement;
-    addPanel(panel: Stats.Panel): Stats.Panel;
-    showPanel(id: number): void;
-    begin(): void;
-    end(): number;
-    update(): void;
-    domElement: HTMLDivElement;
-    setMode(id: number): void;
-}
-
-declare function Stats(): Stats;
-
-declare namespace Stats {
-    interface Panel {
-        dom: HTMLCanvasElement;
-        update(value: number, maxValue: number): void;
-    }
-
-    function Panel(name?: string, fg?: string, bg?: string): Panel;
-}
+import Stats = require('stats.js');
 
 export default Stats;

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,7 +350,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/webxr@npm:^0.5.1":
+"@types/stats.js@npm:*":
+  version: 0.17.0
+  resolution: "@types/stats.js@npm:0.17.0"
+  checksum: ac8dc5e622fa3b7cc37b9e21663193a2f171a4f5896285e4dfc04f2874acbb75edc958f077bffbd85b0ae358daa5bf4ecbc71210386a4300bff05d09435e35f9
+  languageName: node
+  linkType: hard
+
+"@types/webxr@npm:*":
   version: 0.5.1
   resolution: "@types/webxr@npm:0.5.1"
   checksum: a77c6be72623679341526dbec18971db0824d5697626d56decc8bb5b73491582b64d094c168ae8d00861549122ca066d7dc45d9cbb5c608626be7f48a6cd7c43
@@ -3371,7 +3378,8 @@ __metadata:
     "@definitelytyped/dtslint-runner": latest
     "@definitelytyped/header-parser": latest
     "@definitelytyped/utils": latest
-    "@types/webxr": ^0.5.1
+    "@types/stats.js": "*"
+    "@types/webxr": "*"
     all-contributors-cli: ^6.24.0
     husky: ^8.0.3
     prettier: 2.8.4


### PR DESCRIPTION
### Why

We shouldn't have divergent types for stats.js, the source of truth should be `@types/stats.js`.

### What

Replace duplicated types with a re-export of `@types/stats.js`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
