### PR TITLE
Fix OctreeHelper constructor

### DIFF
--- a/types/three/examples/jsm/helpers/OctreeHelper.d.ts
+++ b/types/three/examples/jsm/helpers/OctreeHelper.d.ts
@@ -2,7 +2,7 @@ import { ColorRepresentation, LineSegments } from '../../../src/Three';
 import { Octree } from '../math/Octree';
 
 export class OctreeHelper extends LineSegments {
-    constructor(octree: Octree, color: ColorRepresentation);
+    constructor(octree: Octree, color?: ColorRepresentation);
 
     octree: Octree;
     color: ColorRepresentation;


### PR DESCRIPTION
### Why

The second parameter of `OctreeHelper` is optional ([source](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/helpers/OctreeHelper.js#L10)) and is used that way ([source](https://github.com/mrdoob/three.js/blob/dev/examples/games_fps.html#L439)).

### What

Make second parameter of the `OctreeHelper` constructor optional.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
