### PR TITLE
Fix stats.js export

### DIFF
--- a/types/three/examples/jsm/libs/stats.module.d.ts
+++ b/types/three/examples/jsm/libs/stats.module.d.ts
@@ -1,3 +1,3 @@
 import Stats = require('stats.js');
 
-export default Stats;
+export = Stats;


### PR DESCRIPTION
### Why

Using `export default` doesn't work when trying to import with `"moduleResolution": "nodenext"` since it thinks that stats.js is CommonJS. It's not trivial to properly declare stats.js as ESM yet (still waiting on some DefinitelyTyped updates for proper support of ESM), but this is the next best thing.

### What

Export stats.js using `export =` instead of `export default`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
