### PR TITLE
fix: r150 renames; ColorManagement.enabled, WebGLRenderer.useLegacyLights

### DIFF
--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -7,9 +7,9 @@ export function LinearToSRGB(c: number): number;
 
 export namespace ColorManagement {
     /**
-     * @default true
+     * @default false
      */
-    let legacyMode: boolean;
+    let enabled: boolean;
 
     /**
      * @default LinearSRGBColorSpace

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -178,9 +178,9 @@ export class WebGLRenderer implements Renderer {
     outputEncoding: TextureEncoding;
 
     /**
-     * @default false
+     * @default true
      */
-    physicallyCorrectLights: boolean;
+    useLegacyLights: boolean;
 
     /**
      * @default THREE.NoToneMapping

--- a/types/three/test/lights/lights-physical.ts
+++ b/types/three/test/lights/lights-physical.ts
@@ -173,7 +173,7 @@ function init() {
     boxMesh3.castShadow = true;
     scene.add(boxMesh3);
 
-    renderer.physicallyCorrectLights = true;
+    renderer.useLegacyLights = false;
     renderer.outputEncoding = THREE.sRGBEncoding;
     renderer.shadowMap.enabled = true;
     renderer.toneMapping = THREE.ReinhardToneMapping;

--- a/types/three/test/loaders/loaders-gltfloader-extensions.ts
+++ b/types/three/test/loaders/loaders-gltfloader-extensions.ts
@@ -154,7 +154,7 @@ function onload() {
     renderer.outputEncoding = THREE.sRGBEncoding;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
     renderer.toneMappingExposure = 1;
-    renderer.physicallyCorrectLights = true;
+    renderer.useLegacyLights = false;
     document.body.appendChild(renderer.domElement);
 
     window.addEventListener('resize', onWindowResize);

--- a/types/three/test/materials/materials-envmaps-hdr.ts
+++ b/types/three/test/materials/materials-envmaps-hdr.ts
@@ -76,7 +76,7 @@ function init() {
     scene.background = new THREE.Color(0x000000);
 
     renderer = new THREE.WebGLRenderer();
-    renderer.physicallyCorrectLights = true;
+    renderer.useLegacyLights = false;
     renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
     //

--- a/types/three/test/webxr/webxr-ar-lighting.ts
+++ b/types/three/test/webxr/webxr-ar-lighting.ts
@@ -31,7 +31,7 @@ function init() {
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(window.innerWidth, window.innerHeight);
     renderer.outputEncoding = THREE.sRGBEncoding;
-    renderer.physicallyCorrectLights = true;
+    renderer.useLegacyLights = false;
     renderer.xr.enabled = true;
     container.appendChild(renderer.domElement);
 


### PR DESCRIPTION
Re-implements #372 and #373. I messed them up when rebasing.