### PR TITLE
feature: Add `stopListenToKeyEvents` to `OrbitControls`

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -231,6 +231,11 @@ export class OrbitControls {
     listenToKeyEvents(domElement: HTMLElement | Window): void;
 
     /**
+     * Removes the key event listener previously defined with {@link listenToKeyEvents}.
+     */
+    stopListenToKeyEvents(): void;
+
+    /**
      * Save the current state of the controls. This can later be
      * recovered with .reset.
      */


### PR DESCRIPTION
This PR addresses a part of #357

### Why

to catch up with r150

### What

Added `stopListenToKeyEvents` to `OrbitControls`.

- See: https://threejs.org/docs/#examples/en/controls/OrbitControls.stopListenToKeyEvents
- See: https://github.com/mrdoob/three.js/pull/25418

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
