### PR TITLE
feature: add a new constant `DisplayP3ColorSpace`

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -316,10 +316,11 @@ export enum NormalMapTypes {}
 export const TangentSpaceNormalMap: NormalMapTypes;
 export const ObjectSpaceNormalMap: NormalMapTypes;
 
-export type ColorSpace = NoColorSpace | SRGBColorSpace | LinearSRGBColorSpace;
+export type ColorSpace = NoColorSpace | SRGBColorSpace | LinearSRGBColorSpace | DisplayP3ColorSpace;
 export type NoColorSpace = '';
 export type SRGBColorSpace = 'srgb';
 export type LinearSRGBColorSpace = 'srgb-linear';
+export type DisplayP3ColorSpace = 'display-p3';
 
 // Stencil Op types
 export enum StencilOp {}

--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -1,4 +1,4 @@
-import { ColorSpace, LinearSRGBColorSpace, SRGBColorSpace } from '../constants';
+import { ColorSpace, DisplayP3ColorSpace, LinearSRGBColorSpace, SRGBColorSpace } from '../constants';
 import { Color } from './Color';
 
 export function SRGBToLinear(c: number): number;
@@ -18,8 +18,8 @@ export namespace ColorManagement {
 
     function convert(
         color: Color,
-        sourceColorSpace: SRGBColorSpace | LinearSRGBColorSpace,
-        targetColorSpace: SRGBColorSpace | LinearSRGBColorSpace,
+        sourceColorSpace: SRGBColorSpace | LinearSRGBColorSpace | DisplayP3ColorSpace,
+        targetColorSpace: SRGBColorSpace | LinearSRGBColorSpace | DisplayP3ColorSpace,
     ): Color;
 
     function fromWorkingColorSpace(color: Color, targetColorSpace: SRGBColorSpace | LinearSRGBColorSpace): Color;


### PR DESCRIPTION
This PR addresses a part of https://github.com/three-types/three-ts-types/issues/357

### Why

to catch up with r150

### What

Add a new constant `DisplayP3ColorSpace`, and `ColorManagement.convert` now supports the `DisplayP3ColorSpace`

See: https://github.com/mrdoob/three.js/pull/25520

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
