### PR TITLE
Update documentation for ThreeJS scenes and textures Classes, with some Typing improvements

### DIFF
--- a/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -9,6 +9,8 @@ import {
     TextureFilter,
     TextureDataType,
     IUniform,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
 } from '../../../src/Three';
 
 export interface Variable {
@@ -43,8 +45,8 @@ export class GPUComputationRenderer {
         sizeYTexture: number,
         wrapS: Wrapping,
         wrapT: number,
-        minFilter: TextureFilter,
-        magFilter: TextureFilter,
+        minFilter: MinificationTextureFilter,
+        magFilter: MagnificationTextureFilter,
     ): WebGLRenderTarget;
     createTexture(): DataTexture;
     renderTexture(input: Texture, output: Texture): void;

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -157,6 +157,9 @@ export type ToneMapping =
  */
 export const UVMapping: 300;
 
+/**
+ * @remarks This is the _default_ value and behaver for Cube Texture Mapping.
+ */
 export const CubeReflectionMapping: 301;
 export const CubeRefractionMapping: 302;
 export const CubeUVReflectionMapping: 306;
@@ -165,19 +168,31 @@ export const EquirectangularReflectionMapping: 303;
 export const EquirectangularRefractionMapping: 304;
 
 /**
- * Texture Mapping Modes
+ * Texture Mapping Modes for non-cube Textures
  * @remarks {@link UVMapping} is the _default_ value and behaver for Texture Mapping.
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
  */
 export type Mapping =
     | typeof UVMapping
-    | typeof CubeReflectionMapping
-    | typeof CubeRefractionMapping
-    | typeof CubeUVReflectionMapping
     | typeof EquirectangularReflectionMapping
     | typeof EquirectangularRefractionMapping;
 
-export type CubeTextureMapping = typeof CubeReflectionMapping | typeof CubeRefractionMapping;
+/**
+ * Texture Mapping Modes for cube Textures
+ * @remarks {@link CubeReflectionMapping} is the _default_ value and behaver for Cube Texture Mapping.
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type CubeTextureMapping =
+    | typeof CubeReflectionMapping
+    | typeof CubeRefractionMapping
+    | typeof CubeUVReflectionMapping;
+
+/**
+ * Texture Mapping Modes for any type of  Textures
+ * @see {@link Mapping} and {@link CubeTextureMapping}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type AnyMapping = Mapping | CubeTextureMapping;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Wrapping modes

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -442,6 +442,13 @@ export type WebGL2PixelFormat =
  */
 export type PixelFormat = WebGL1PixelFormat | WebGL2PixelFormat;
 
+/**
+ * All Texture Pixel Formats Modes for {@link THREE.DeepTexture}.
+ * @see {@link WebGLRenderingContext.texImage2D} for details.
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type DeepTexturePixelFormat = typeof DepthFormat | typeof DepthStencilFormat;
+
 ///////////////////////////////////////////////////////////////////////////////
 // Compressed texture formats
 // DDS / ST3C Compressed texture formats

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -473,39 +473,130 @@ export type DeepTexturePixelFormat = typeof DepthFormat | typeof DepthStencilFor
 ///////////////////////////////////////////////////////////////////////////////
 // Compressed texture formats
 // DDS / ST3C Compressed texture formats
+
+/**
+ * A DXT1-compressed image in an RGB image format.
+ * @remarks Require support for the _WEBGL_compressed_texture_s3tc_ WebGL extension.
+ */
 export const RGB_S3TC_DXT1_Format: 33776;
+/**
+ * A DXT1-compressed image in an RGB image format with a simple on/off alpha value.
+ * @remarks Require support for the _WEBGL_compressed_texture_s3tc_ WebGL extension.
+ */
 export const RGBA_S3TC_DXT1_Format: 33777;
+/**
+ * A DXT3-compressed image in an RGBA image format. Compared to a 32-bit RGBA texture, it offers 4:1 compression.
+ * @remarks Require support for the _WEBGL_compressed_texture_s3tc_ WebGL extension.
+ */
 export const RGBA_S3TC_DXT3_Format: 33778;
+/**
+ * A DXT5-compressed image in an RGBA image format. It also provides a 4:1 compression, but differs to the DXT3 compression in how the alpha compression is done.
+ * @remarks Require support for the _WEBGL_compressed_texture_s3tc_ WebGL extension.
+ */
 export const RGBA_S3TC_DXT5_Format: 33779;
 
 // PVRTC compressed './texture formats
+
+/**
+ * RGB compression in 4-bit mode. One block for each 4×4 pixels.
+ * @remarks Require support for the _WEBGL_compressed_texture_pvrtc_ WebGL extension.
+ */
 export const RGB_PVRTC_4BPPV1_Format: 35840;
+/**
+ * RGB compression in 2-bit mode. One block for each 8×4 pixels.
+ * @remarks Require support for the _WEBGL_compressed_texture_pvrtc_ WebGL extension.
+ */
 export const RGB_PVRTC_2BPPV1_Format: 35841;
+/**
+ * RGBA compression in 4-bit mode. One block for each 4×4 pixels.
+ * @remarks Require support for the _WEBGL_compressed_texture_pvrtc_ WebGL extension.
+ */
 export const RGBA_PVRTC_4BPPV1_Format: 35842;
+/**
+ * RGBA compression in 2-bit mode. One block for each 8×4 pixels.
+ * @remarks Require support for the _WEBGL_compressed_texture_pvrtc_ WebGL extension.
+ */
 export const RGBA_PVRTC_2BPPV1_Format: 35843;
 
 // ETC compressed texture formats
+
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_etc1_ (ETC1) or _WEBGL_compressed_texture_etc_ (ETC2) WebGL extension.
+ */
 export const RGB_ETC1_Format: 36196;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_etc1_ (ETC1) or _WEBGL_compressed_texture_etc_ (ETC2) WebGL extension.
+ */
 export const RGB_ETC2_Format: 37492;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_etc1_ (ETC1) or _WEBGL_compressed_texture_etc_ (ETC2) WebGL extension.
+ */
 export const RGBA_ETC2_EAC_Format: 37496;
 
 // ASTC compressed texture formats
+
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_4x4_Format: 37808;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_5x4_Format: 37809;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_5x5_Format: 37810;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_6x5_Format: 37811;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_6x6_Format: 37812;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_8x5_Format: 37813;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_8x6_Format: 37814;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_8x8_Format: 37815;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_10x5_Format: 37816;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_10x6_Format: 37817;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_10x8_Format: 37818;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_10x10_Format: 37819;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_12x10_Format: 37820;
+/**
+ * @remarks Require support for the _WEBGL_compressed_texture_astc_ WebGL extension.
+ */
 export const RGBA_ASTC_12x12_Format: 37821;
 
 // BPTC compressed texture formats
+
+/**
+ * @remarks Require support for the _EXT_texture_compression_bptc_ WebGL extension.
+ */
 export const RGBA_BPTC_Format: 36492;
 
 // RGTC compressed texture formats
@@ -514,6 +605,10 @@ export const SIGNED_RED_RGTC1_Format: 36284;
 export const RED_GREEN_RGTC2_Format: 36285;
 export const SIGNED_RED_GREEN_RGTC2_Format: 36286;
 
+/**
+ * For use with a {@link THREE.CompressedTexture}'s {@link THREE.CompressedTexture.format | .format} property.
+ * @remarks Compressed Require support for correct WebGL extension.
+ */
 export type CompressedPixelFormat =
     | typeof RGB_S3TC_DXT1_Format
     | typeof RGBA_S3TC_DXT1_Format
@@ -545,6 +640,7 @@ export type CompressedPixelFormat =
     | typeof SIGNED_RED_RGTC1_Format
     | typeof RED_GREEN_RGTC2_Format
     | typeof SIGNED_RED_GREEN_RGTC2_Format;
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /**

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -146,13 +146,25 @@ export type ToneMapping =
     | typeof ACESFilmicToneMapping
     | typeof CustomToneMapping;
 
+///////////////////////////////////////////////////////////////////////////////
 // Mapping modes
+
+/**
+ * Maps the texture using the mesh's UV coordinates.
+ * @remarks This is the _default_ value and behaver for Texture Mapping.
+ */
 export const UVMapping: 300;
 export const CubeReflectionMapping: 301;
 export const CubeRefractionMapping: 302;
 export const EquirectangularReflectionMapping: 303;
 export const EquirectangularRefractionMapping: 304;
 export const CubeUVReflectionMapping: 306;
+
+/**
+ * Texture Mapping Modes
+ * @remarks {@link UVMapping} is the _default_ value and behaver for Texture Mapping.
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
 export type Mapping =
     | typeof UVMapping
     | typeof CubeReflectionMapping
@@ -161,24 +173,105 @@ export type Mapping =
     | typeof EquirectangularRefractionMapping
     | typeof CubeUVReflectionMapping;
 
+///////////////////////////////////////////////////////////////////////////////
 // Wrapping modes
+
+/** With {@link RepeatWrapping} the texture will simply repeat to infinity. */
 export const RepeatWrapping: 1000;
+/**
+ * With {@link ClampToEdgeWrapping} the last pixel of the texture stretches to the edge of the mesh.
+ * @remarks This is the _default_ value and behaver for Wrapping Mapping.
+ */
 export const ClampToEdgeWrapping: 1001;
+/** With {@link MirroredRepeatWrapping} the texture will repeats to infinity, mirroring on each repeat. */
 export const MirroredRepeatWrapping: 1002;
+
+/**
+ * Texture Wrapping Modes
+ * @remarks {@link ClampToEdgeWrapping} is the _default_ value and behaver for Wrapping Mapping.
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
 export type Wrapping = typeof RepeatWrapping | typeof ClampToEdgeWrapping | typeof MirroredRepeatWrapping;
 
+///////////////////////////////////////////////////////////////////////////////
 // Filters
+
+/** {@link NearestFilter} returns the value of the texture element that is nearest (in Manhattan distance) to the specified texture coordinates. */
 export const NearestFilter: 1003;
+
+/**
+ * {@link NearestMipmapNearestFilter} chooses the mipmap that most closely matches the size of the pixel being textured
+ * and uses the {@link NearestFilter} criterion (the texel nearest to the center of the pixel) to produce a texture value.
+ */
 export const NearestMipmapNearestFilter: 1004;
+/**
+ * {@link NearestMipmapNearestFilter} chooses the mipmap that most closely matches the size of the pixel being textured
+ * and uses the {@link NearestFilter} criterion (the texel nearest to the center of the pixel) to produce a texture value.
+ */
 export const NearestMipMapNearestFilter: 1004;
+
+/**
+ * {@link NearestMipmapLinearFilter} chooses the two mipmaps that most closely match the size of the pixel being textured
+ * and uses the {@link NearestFilter} criterion to produce a texture value from each mipmap.
+ * The final texture value is a weighted average of those two values.
+ */
 export const NearestMipmapLinearFilter: 1005;
+/**
+ * {@link NearestMipMapLinearFilter} chooses the two mipmaps that most closely match the size of the pixel being textured
+ * and uses the {@link NearestFilter} criterion to produce a texture value from each mipmap.
+ * The final texture value is a weighted average of those two values.
+ */
 export const NearestMipMapLinearFilter: 1005;
+
+/**
+ * {@link LinearFilter} returns the weighted average of the four texture elements that are closest to the specified texture coordinates,
+ * and can include items wrapped or repeated from other parts of a texture,
+ * depending on the values of {@link THREE.Texture.wrapS | wrapS} and {@link THREE.Texture.wrapT | wrapT}, and on the exact mapping.
+ */
 export const LinearFilter: 1006;
+
+/**
+ * {@link LinearMipmapNearestFilter} chooses the mipmap that most closely matches the size of the pixel being textured and
+ * uses the {@link LinearFilter} criterion (a weighted average of the four texels that are closest to the center of the pixel) to produce a texture value.
+ */
 export const LinearMipmapNearestFilter: 1007;
+/**
+ * {@link LinearMipMapNearestFilter} chooses the mipmap that most closely matches the size of the pixel being textured and
+ * uses the {@link LinearFilter} criterion (a weighted average of the four texels that are closest to the center of the pixel) to produce a texture value.
+ */
 export const LinearMipMapNearestFilter: 1007;
+
+/**
+ * {@link LinearMipmapLinearFilter} is the default and chooses the two mipmaps that most closely match the size of the pixel being textured and
+ * uses the {@link LinearFilter} criterion to produce a texture value from each mipmap.
+ * The final texture value is a weighted average of those two values.
+ */
 export const LinearMipmapLinearFilter: 1008;
+
+/**
+ * {@link LinearMipMapLinearFilter} is the default and chooses the two mipmaps that most closely match the size of the pixel being textured and
+ * uses the {@link LinearFilter} criterion to produce a texture value from each mipmap.
+ * The final texture value is a weighted average of those two values.
+ */
 export const LinearMipMapLinearFilter: 1008;
-export type TextureFilter =
+
+/**
+ * Texture Magnification Filter Modes.
+ * For use with a texture's {@link THREE.Texture.magFilter | magFilter} property,
+ * these define the texture magnification function to be used when the pixel being textured maps to an area less than or equal to one texture element (texel).
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ * @see {@link https://sbcode.net/threejs/mipmaps/ | Texture Mipmaps (non-official)}
+ */
+export type MagnificationTextureFilter = typeof NearestFilter | typeof LinearFilter;
+
+/**
+ * Texture Minification Filter Modes.
+ * For use with a texture's {@link THREE.Texture.minFilter | minFilter} property,
+ * these define the texture minifying function that is used whenever the pixel being textured maps to an area greater than one texture element (texel).
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ * @see {@link https://sbcode.net/threejs/mipmaps/ | Texture Mipmaps (non-official)}
+ */
+export type MinificationTextureFilter =
     | typeof NearestFilter
     | typeof NearestMipmapNearestFilter
     | typeof NearestMipMapNearestFilter
@@ -190,6 +283,15 @@ export type TextureFilter =
     | typeof LinearMipmapLinearFilter
     | typeof LinearMipMapLinearFilter;
 
+/**
+ * Texture all Magnification and Minification Filter Modes.
+ * @see {@link MagnificationTextureFilter} and {@link MinificationTextureFilter}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ * @see {@link https://sbcode.net/threejs/mipmaps/ | Texture Mipmaps (non-official)}
+ */
+export type TextureFilter = MagnificationTextureFilter | MinificationTextureFilter;
+
+///////////////////////////////////////////////////////////////////////////////
 // Data types
 export const UnsignedByteType: 1009;
 export const ByteType: 1010;
@@ -215,19 +317,101 @@ export type TextureDataType =
     | typeof UnsignedShort5551Type
     | typeof UnsignedInt248Type;
 
+///////////////////////////////////////////////////////////////////////////////
 // Pixel formats
+
+/** {@link AlphaFormat} discards the red, green and blue components and reads just the alpha component. */
 export const AlphaFormat: 1021;
+
+/** {@link RGBAFormat} discards the green and blue components and reads just the red component. (Can only be used with a WebGL 2 rendering context). */
 export const RGBAFormat: 1023;
+
+/**
+ * {@link LuminanceFormat} reads each element as a single luminance component.
+ * This is then converted to a floating point, clamped to the range `[0,1]`, and then assembled into an RGBA element by
+ * placing the luminance value in the red, green and blue channels, and attaching `1.0` to the alpha channel.
+ * */
 export const LuminanceFormat: 1024;
+
+/**
+ * {@link LuminanceAlphaFormat} reads each element as a luminance/alpha double.
+ * The same process occurs as for the {@link LuminanceFormat}, except that the alpha channel may have values other than `1.0`.
+ */
 export const LuminanceAlphaFormat: 1025;
+
+/**
+ * {@link DepthFormat} reads each element as a single depth value, converts it to floating point, and clamps to the range `[0,1]`.
+ * @remarks This is the default for {@link THREE.DepthTexture}.
+ */
 export const DepthFormat: 1026;
+
+/**
+ * {@link DepthStencilFormat} reads each element is a pair of depth and stencil values.
+ * The depth component of the pair is interpreted as in {@link DepthFormat}.
+ * The stencil component is interpreted based on the depth + stencil internal format.
+ */
 export const DepthStencilFormat: 1027;
+
+/**
+ * {@link RedFormat} discards the green and blue components and reads just the red component.
+ * @remarks Can only be used with a WebGL 2 rendering context.
+ */
 export const RedFormat: 1028;
+
+/**
+ * {@link RedIntegerFormat} discards the green and blue components and reads just the red component.
+ * The texels are read as integers instead of floating point.
+ * @remarks Can only be used with a WebGL 2 rendering context.
+ */
 export const RedIntegerFormat: 1029;
+
+/**
+ * {@link RGFormat} discards the alpha, and blue components and reads the red, and green components.
+ * @remarks Can only be used with a WebGL 2 rendering context.
+ */
 export const RGFormat: 1030;
+
+/**
+ * {@link RGIntegerFormat} discards the alpha, and blue components and reads the red, and green components.
+ * The texels are read as integers instead of floating point.
+ * @remarks Can only be used with a WebGL 2 rendering context.
+ */
 export const RGIntegerFormat: 1031;
+
+/**
+ * {@link RGBAIntegerFormat} reads the red, green, blue and alpha component
+ * @remarks This is the default for {@link THREE.Texture}.
+ */
 export const RGBAIntegerFormat: 1033;
-export type PixelFormat =
+
+export const _SRGBAFormat = 1035; // fallback for WebGL 1
+
+/**
+ * Texture Pixel Formats Modes. Compatible only with {@link WebGLRenderingContext | WebGL 1 Rendering Context}.
+ * @remarks Note that the texture must have the correct {@link THREE.Texture.type} set, as described in  {@link TextureDataType}.
+ * @see {@link WebGLRenderingContext.texImage2D} for details.
+ * @see {@link WebGL2PixelFormat} and {@link PixelFormat}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type WebGL1PixelFormat =
+    | typeof AlphaFormat
+    | typeof LuminanceFormat
+    | typeof LuminanceAlphaFormat
+    | typeof DepthFormat
+    | typeof DepthStencilFormat
+    | typeof RedFormat
+    | typeof RedIntegerFormat
+    | typeof RGFormat
+    | typeof _SRGBAFormat;
+
+/**
+ * Texture Pixel Formats Modes. Compatible only with {@link WebGL2RenderingContext | WebGL 2 Rendering Context}.
+ * @remarks Note that the texture must have the correct {@link THREE.Texture.type} set, as described in  {@link TextureDataType}.
+ * @see {@link WebGLRenderingContext.texImage2D} for details.
+ * @see {@link WebGL2PixelFormat} and {@link PixelFormat}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type WebGL2PixelFormat =
     | typeof AlphaFormat
     | typeof RGBAFormat
     | typeof LuminanceFormat
@@ -241,6 +425,16 @@ export type PixelFormat =
     | typeof RGBAIntegerFormat
     | typeof _SRGBAFormat;
 
+/**
+ * All Texture Pixel Formats Modes.
+ * @remarks Note that the texture must have the correct {@link THREE.Texture.type} set, as described in  {@link TextureDataType}.
+ * @see {@link WebGLRenderingContext.texImage2D} for details.
+ * @see {@link WebGL1PixelFormat} and {@link WebGL2PixelFormat}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type PixelFormat = WebGL1PixelFormat | WebGL2PixelFormat;
+
+///////////////////////////////////////////////////////////////////////////////
 // Compressed texture formats
 // DDS / ST3C Compressed texture formats
 export const RGB_S3TC_DXT1_Format: 33776;
@@ -428,9 +622,16 @@ export const GLSL1: '100';
 export const GLSL3: '300 es';
 export type GLSLVersion = typeof GLSL1 | typeof GLSL3;
 
-export const _SRGBAFormat = 1035; // fallback for WebGL 1
+///////////////////////////////////////////////////////////////////////////////
+// Texture - Internal Pixel Formats
 
-// Internal Pixel Formats
+/**
+ * For use with a texture's {@link THREE.Texture.internalFormat} property, these define how elements of a {@link THREE.Texture}, or texels, are stored on the GPU.
+ * @remark Note that the texture must have the correct {@link THREE.Texture.type} set, as well as the correct {@link THREE.Texture.format}.
+ * @see {@link WebGLRenderingContext.texImage2D} and {@link WebGLRenderingContext.texImage3D} for more details regarding the possible combination
+ * of {@link THREE.Texture.format}, {@link THREE.Texture.internalFormat}, and {@link THREE.Texture.type}.
+ * @see {@link https://registry.khronos.org/webgl/specs/latest/2.0/ | WebGL2 Specification} and {@link https://registry.khronos.org/OpenGL/specs/es/3.0/es_spec_3.0.pdf | OpenGL ES 3.0 Specification} For more in-depth information regarding internal formats.
+ */
 export type PixelFormatGPU =
     | 'ALPHA'
     | 'RGB'
@@ -493,6 +694,8 @@ export type PixelFormatGPU =
     | 'DEPTH_COMPONENT32F'
     | 'DEPTH24_STENCIL8'
     | 'DEPTH32F_STENCIL8';
+
+///////////////////////////////////////////////////////////////////////////////
 
 export type BuiltinShaderAttributeName =
     | 'position'

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -524,7 +524,18 @@ export type CompressedPixelFormat =
     | typeof SIGNED_RED_RGTC1_Format
     | typeof RED_GREEN_RGTC2_Format
     | typeof SIGNED_RED_GREEN_RGTC2_Format;
+///////////////////////////////////////////////////////////////////////////////
 
+/**
+ * All Possible Texture Pixel Formats Modes. For any Type or SubType of Textures.
+ * @remarks Note that the texture must have the correct {@link THREE.Texture.type} set, as described in {@link TextureDataType}.
+ * @see {@link WebGLRenderingContext.texImage2D} for details.
+ * @see {@link PixelFormat} and {@link DeepTexturePixelFormat} and {@link CompressedPixelFormat}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
+export type AnyPixelFormat = PixelFormat | DeepTexturePixelFormat | CompressedPixelFormat;
+
+///////////////////////////////////////////////////////////////////////////////
 // Loop styles for AnimationAction
 export const LoopOnce: 2200;
 export const LoopRepeat: 2201;

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -147,6 +147,8 @@ export type ToneMapping =
     | typeof CustomToneMapping;
 
 ///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 // Mapping modes
 
 /**
@@ -154,11 +156,13 @@ export type ToneMapping =
  * @remarks This is the _default_ value and behaver for Texture Mapping.
  */
 export const UVMapping: 300;
+
 export const CubeReflectionMapping: 301;
 export const CubeRefractionMapping: 302;
+export const CubeUVReflectionMapping: 306;
+
 export const EquirectangularReflectionMapping: 303;
 export const EquirectangularRefractionMapping: 304;
-export const CubeUVReflectionMapping: 306;
 
 /**
  * Texture Mapping Modes
@@ -169,9 +173,11 @@ export type Mapping =
     | typeof UVMapping
     | typeof CubeReflectionMapping
     | typeof CubeRefractionMapping
+    | typeof CubeUVReflectionMapping
     | typeof EquirectangularReflectionMapping
-    | typeof EquirectangularRefractionMapping
-    | typeof CubeUVReflectionMapping;
+    | typeof EquirectangularRefractionMapping;
+
+export type CubeTextureMapping = typeof CubeReflectionMapping | typeof CubeRefractionMapping;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Wrapping modes
@@ -570,7 +576,6 @@ export type TrianglesDrawModes = typeof TrianglesDrawMode | typeof TriangleStrip
 
 export const LinearEncoding: 3000;
 export const sRGBEncoding: 3001;
-
 /**
  * Texture Encodings.
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
@@ -579,12 +584,14 @@ export type TextureEncoding = typeof LinearEncoding | typeof sRGBEncoding;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Depth packing strategies
+
 export const BasicDepthPacking: 3200;
 export const RGBADepthPacking: 3201;
 export type DepthPackingStrategies = typeof BasicDepthPacking | typeof RGBADepthPacking;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Normal Map types
+
 export const TangentSpaceNormalMap: 0;
 export const ObjectSpaceNormalMap: 1;
 export type NormalMapTypes = typeof TangentSpaceNormalMap | typeof ObjectSpaceNormalMap;

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -293,6 +293,7 @@ export type TextureFilter = MagnificationTextureFilter | MinificationTextureFilt
 
 ///////////////////////////////////////////////////////////////////////////////
 // Data types
+
 export const UnsignedByteType: 1009;
 export const ByteType: 1010;
 export const ShortType: 1011;
@@ -304,6 +305,13 @@ export const HalfFloatType: 1016;
 export const UnsignedShort4444Type: 1017;
 export const UnsignedShort5551Type: 1018;
 export const UnsignedInt248Type: 1020;
+
+/**
+ * Texture Types.
+ * @remarks Must correspond to the correct {@link PixelFormat | format}.
+ * @see {@link THREE.Texture.type}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
 export type TextureDataType =
     | typeof UnsignedByteType
     | typeof ByteType
@@ -539,16 +547,25 @@ export const TriangleStripDrawMode: 1;
 export const TriangleFanDrawMode: 2;
 export type TrianglesDrawModes = typeof TrianglesDrawMode | typeof TriangleStripDrawMode | typeof TriangleFanDrawMode;
 
+///////////////////////////////////////////////////////////////////////////////
 // Texture Encodings
+
 export const LinearEncoding: 3000;
 export const sRGBEncoding: 3001;
+
+/**
+ * Texture Encodings.
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ */
 export type TextureEncoding = typeof LinearEncoding | typeof sRGBEncoding;
 
+///////////////////////////////////////////////////////////////////////////////
 // Depth packing strategies
 export const BasicDepthPacking: 3200;
 export const RGBADepthPacking: 3201;
 export type DepthPackingStrategies = typeof BasicDepthPacking | typeof RGBADepthPacking;
 
+///////////////////////////////////////////////////////////////////////////////
 // Normal Map types
 export const TangentSpaceNormalMap: 0;
 export const ObjectSpaceNormalMap: 1;

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -188,7 +188,7 @@ export type CubeTextureMapping =
     | typeof CubeUVReflectionMapping;
 
 /**
- * Texture Mapping Modes for any type of  Textures
+ * Texture Mapping Modes for any type of Textures
  * @see {@link Mapping} and {@link CubeTextureMapping}
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
  */

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -330,7 +330,7 @@ export const RGBAFormat: 1023;
  * {@link LuminanceFormat} reads each element as a single luminance component.
  * This is then converted to a floating point, clamped to the range `[0,1]`, and then assembled into an RGBA element by
  * placing the luminance value in the red, green and blue channels, and attaching `1.0` to the alpha channel.
- * */
+ */
 export const LuminanceFormat: 1024;
 
 /**
@@ -630,7 +630,8 @@ export type GLSLVersion = typeof GLSL1 | typeof GLSL3;
  * @remark Note that the texture must have the correct {@link THREE.Texture.type} set, as well as the correct {@link THREE.Texture.format}.
  * @see {@link WebGLRenderingContext.texImage2D} and {@link WebGLRenderingContext.texImage3D} for more details regarding the possible combination
  * of {@link THREE.Texture.format}, {@link THREE.Texture.internalFormat}, and {@link THREE.Texture.type}.
- * @see {@link https://registry.khronos.org/webgl/specs/latest/2.0/ | WebGL2 Specification} and {@link https://registry.khronos.org/OpenGL/specs/es/3.0/es_spec_3.0.pdf | OpenGL ES 3.0 Specification} For more in-depth information regarding internal formats.
+ * @see {@link https://registry.khronos.org/webgl/specs/latest/2.0/ | WebGL2 Specification} and
+ * {@link https://registry.khronos.org/OpenGL/specs/es/3.0/es_spec_3.0.pdf | OpenGL ES 3.0 Specification} For more in-depth information regarding internal formats.
  */
 export type PixelFormatGPU =
     | 'ALPHA'

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -627,6 +627,58 @@ export type GLSLVersion = typeof GLSL1 | typeof GLSL3;
 
 /**
  * For use with a texture's {@link THREE.Texture.internalFormat} property, these define how elements of a {@link THREE.Texture}, or texels, are stored on the GPU.
+ * - `R8` stores the red component on 8 bits.
+ * - `R8_SNORM` stores the red component on 8 bits. The component is stored as normalized.
+ * - `R8I` stores the red component on 8 bits. The component is stored as an integer.
+ * - `R8UI` stores the red component on 8 bits. The component is stored as an unsigned integer.
+ * - `R16I` stores the red component on 16 bits. The component is stored as an integer.
+ * - `R16UI` stores the red component on 16 bits. The component is stored as an unsigned integer.
+ * - `R16F` stores the red component on 16 bits. The component is stored as floating point.
+ * - `R32I` stores the red component on 32 bits. The component is stored as an integer.
+ * - `R32UI` stores the red component on 32 bits. The component is stored as an unsigned integer.
+ * - `R32F` stores the red component on 32 bits. The component is stored as floating point.
+ * - `RG8` stores the red and green components on 8 bits each.
+ * - `RG8_SNORM` stores the red and green components on 8 bits each. Every component is stored as normalized.
+ * - `RG8I` stores the red and green components on 8 bits each. Every component is stored as an integer.
+ * - `RG8UI` stores the red and green components on 8 bits each. Every component is stored as an unsigned integer.
+ * - `RG16I` stores the red and green components on 16 bits each. Every component is stored as an integer.
+ * - `RG16UI` stores the red and green components on 16 bits each. Every component is stored as an unsigned integer.
+ * - `RG16F` stores the red and green components on 16 bits each. Every component is stored as floating point.
+ * - `RG32I` stores the red and green components on 32 bits each. Every component is stored as an integer.
+ * - `RG32UI` stores the red and green components on 32 bits. Every component is stored as an unsigned integer.
+ * - `RG32F` stores the red and green components on 32 bits. Every component is stored as floating point.
+ * - `RGB8` stores the red, green, and blue components on 8 bits each. RGB8_SNORM` stores the red, green, and blue components on 8 bits each. Every component is stored as normalized.
+ * - `RGB8I` stores the red, green, and blue components on 8 bits each. Every component is stored as an integer.
+ * - `RGB8UI` stores the red, green, and blue components on 8 bits each. Every component is stored as an unsigned integer.
+ * - `RGB16I` stores the red, green, and blue components on 16 bits each. Every component is stored as an integer.
+ * - `RGB16UI` stores the red, green, and blue components on 16 bits each. Every component is stored as an unsigned integer.
+ * - `RGB16F` stores the red, green, and blue components on 16 bits each. Every component is stored as floating point
+ * - `RGB32I` stores the red, green, and blue components on 32 bits each. Every component is stored as an integer.
+ * - `RGB32UI` stores the red, green, and blue components on 32 bits each. Every component is stored as an unsigned integer.
+ * - `RGB32F` stores the red, green, and blue components on 32 bits each. Every component is stored as floating point
+ * - `R11F_G11F_B10F` stores the red, green, and blue components respectively on 11 bits, 11 bits, and 10bits. Every component is stored as floating point.
+ * - `RGB565` stores the red, green, and blue components respectively on 5 bits, 6 bits, and 5 bits.
+ * - `RGB9_E5` stores the red, green, and blue components on 9 bits each.
+ * - `RGBA8` stores the red, green, blue, and alpha components on 8 bits each.
+ * - `RGBA8_SNORM` stores the red, green, blue, and alpha components on 8 bits. Every component is stored as normalized.
+ * - `RGBA8I` stores the red, green, blue, and alpha components on 8 bits each. Every component is stored as an integer.
+ * - `RGBA8UI` stores the red, green, blue, and alpha components on 8 bits. Every component is stored as an unsigned integer.
+ * - `RGBA16I` stores the red, green, blue, and alpha components on 16 bits. Every component is stored as an integer.
+ * - `RGBA16UI` stores the red, green, blue, and alpha components on 16 bits. Every component is stored as an unsigned integer.
+ * - `RGBA16F` stores the red, green, blue, and alpha components on 16 bits. Every component is stored as floating point.
+ * - `RGBA32I` stores the red, green, blue, and alpha components on 32 bits. Every component is stored as an integer.
+ * - `RGBA32UI` stores the red, green, blue, and alpha components on 32 bits. Every component is stored as an unsigned integer.
+ * - `RGBA32F` stores the red, green, blue, and alpha components on 32 bits. Every component is stored as floating point.
+ * - `RGB5_A1` stores the red, green, blue, and alpha components respectively on 5 bits, 5 bits, 5 bits, and 1 bit.
+ * - `RGB10_A2` stores the red, green, blue, and alpha components respectively on 10 bits, 10 bits, 10 bits and 2 bits.
+ * - `RGB10_A2UI` stores the red, green, blue, and alpha components respectively on 10 bits, 10 bits, 10 bits and 2 bits. Every component is stored as an unsigned integer.
+ * - `SRGB8` stores the red, green, and blue components on 8 bits each.
+ * - `SRGB8_ALPHA8` stores the red, green, blue, and alpha components on 8 bits each.
+ * - `DEPTH_COMPONENT16` stores the depth component on 16bits.
+ * - `DEPTH_COMPONENT24` stores the depth component on 24bits.
+ * - `DEPTH_COMPONENT32F` stores the depth component on 32bits. The component is stored as floating point.
+ * - `DEPTH24_STENCIL8` stores the depth, and stencil components respectively on 24 bits and 8 bits. The stencil component is stored as an unsigned integer.
+ * - `DEPTH32F_STENCIL8` stores the depth, and stencil components respectively on 32 bits and 8 bits. The depth component is stored as floating point, and the stencil component as an unsigned integer.
  * @remark Note that the texture must have the correct {@link THREE.Texture.type} set, as well as the correct {@link THREE.Texture.format}.
  * @see {@link WebGLRenderingContext.texImage2D} and {@link WebGLRenderingContext.texImage3D} for more details regarding the possible combination
  * of {@link THREE.Texture.format}, {@link THREE.Texture.internalFormat}, and {@link THREE.Texture.type}.

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -28,6 +28,13 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
     constructor();
 
     /**
+     * Flag to check if a given object is of type {@link Object3D}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isObject3D: true;
+
+    /**
      * Unique number for this {@link Object3D} instance.
      * @remarks Note that ids are assigned in chronological order: 1, 2, 3, ..., incrementing by one for each new object.
      * @remarks Expects a `Integer`
@@ -210,13 +217,6 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
      */
     customDistanceMaterial?: Material | undefined;
 
-    /**
-     * Flag to check if a given object is of type {@link Object3D}.
-     * @remarks This is a _constant_ value
-     * @defaultValue `true`
-     */
-    readonly isObject3D: true;
-    
     /**
      * An optional callback that is executed immediately before a 3D object is rendered.
      * @remarks This function is called with the following parameters: renderer, scene, camera, geometry, material, group.

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -28,7 +28,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
     constructor();
 
     /**
-     * Unique number for this object instance.
+     * Unique number for this {@link Object3D} instance.
      * @remarks Note that ids are assigned in chronological order: 1, 2, 3, ..., incrementing by one for each new object.
      * @remarks Expects a `Integer`
      */
@@ -41,8 +41,9 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
     uuid: string;
 
     /**
-     * Optional name of the object (doesn't need to be unique).
-     * @defaultValue `''`
+     * Optional name of the object
+     * @remarks _(doesn't need to be unique)_.
+     * @defaultValue `""`
      */
     name: string;
 
@@ -215,7 +216,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
      * @defaultValue `true`
      */
     readonly isObject3D: true;
-
+    
     /**
      * An optional callback that is executed immediately before a 3D object is rendered.
      * @remarks This function is called with the following parameters: renderer, scene, camera, geometry, material, group.

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -2,13 +2,19 @@ import { Vector4 } from './../math/Vector4';
 import { Texture } from './../textures/Texture';
 import { DepthTexture } from './../textures/DepthTexture';
 import { EventDispatcher } from './../core/EventDispatcher';
-import { Wrapping, TextureFilter, TextureDataType, TextureEncoding } from '../constants';
+import {
+    Wrapping,
+    TextureDataType,
+    TextureEncoding,
+    MinificationTextureFilter,
+    MagnificationTextureFilter,
+} from '../constants';
 
 export interface WebGLRenderTargetOptions {
     wrapS?: Wrapping | undefined;
     wrapT?: Wrapping | undefined;
-    magFilter?: TextureFilter | undefined;
-    minFilter?: TextureFilter | undefined;
+    magFilter?: MagnificationTextureFilter | undefined;
+    minFilter?: MinificationTextureFilter | undefined;
     format?: number | undefined; // RGBAFormat;
     type?: TextureDataType | undefined; // UnsignedByteType;
     anisotropy?: number | undefined; // 1;

--- a/types/three/src/scenes/Fog.d.ts
+++ b/types/three/src/scenes/Fog.d.ts
@@ -2,42 +2,94 @@ import { ColorRepresentation } from '../utils';
 import { Color } from './../math/Color';
 
 export interface FogBase {
-    name: string;
-    color: Color;
-    clone(): FogBase;
-    toJSON(): any;
-}
-
-/**
- * This class contains the parameters that define linear fog, i.e., that grows linearly denser with the distance.
- */
-export class Fog implements FogBase {
-    constructor(color: ColorRepresentation, near?: number, far?: number);
-
     /**
-     * @default ''
+     * Optional name of the `Fog` object 
+     * @remarks _(doesn't need to be unique)_.
+     * @defaultValue ``
      */
     name: string;
 
     /**
      * Fog color.
+     * @remarks If set to black, far away objects will be rendered black.
      */
     color: Color;
 
     /**
-     * The minimum distance to start applying fog. Objects that are less than 'near' units from the active camera won't be affected by fog.
-     * @default 1
+     * Returns a new Fog instance with the same parameters as this one.
+     */
+    clone(): FogBase;
+
+    /**
+     * Return Fog data in JSON format.
+     */
+    toJSON(): any;
+}
+
+/**
+ * This class contains the parameters that define linear fog, i.e., that grows linearly denser with the distance.
+ *  @example
+ * ```typescript
+ * const scene = new THREE.Scene();
+ * scene.fog = new THREE.Fog(0xcccccc, 10, 15);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/scenes/Fog | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/scenes/Fog.js | Source}
+ */
+export class Fog implements FogBase {
+    /**
+     * The color parameter is passed to the {@link THREE.Color | Color} constructor to set the color property
+     * @remarks
+     * Color can be a hexadecimal integer or a CSS-style string.
+     * @param color
+     * @param near Expects a `Float`
+     * @param far Expects a `Float`
+     */
+    constructor(color: ColorRepresentation, near?: number, far?: number);
+
+    /**
+     * Read-only flag to check if a given object is of type {@link Fog}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isFog: true;
+
+    /**
+     * Optional name of the object 
+     * @remarks _(doesn't need to be unique)_.
+     * @defaultValue ``
+     */
+    name: string;
+
+    /**
+     * Fog color.
+     * @remarks If set to black, far away objects will be rendered black.
+     */
+    color: Color;
+
+    /**
+     * The minimum distance to start applying fog.
+     * @remarks Objects that are less than **near** units from the active camera won't be affected by fog.
+     * @defaultValue `1`
+     * @remarks Expects a `Float`
      */
     near: number;
 
     /**
-     * The maximum distance at which fog stops being calculated and applied. Objects that are more than 'far' units away from the active camera won't be affected by fog.
-     * @default 1000
+     * The maximum distance at which fog stops being calculated and applied.
+     * @remarks Objects that are more than **far** units away from the active camera won't be affected by fog.
+     * @defaultValue `1000`
+     * @remarks Expects a `Float`
      */
     far: number;
 
-    readonly isFog: true;
-
+    /**
+     * Returns a new {@link Fog} instance with the same parameters as this one.
+     */
     clone(): Fog;
+
+    /**
+     * Return {@link Fog} data in JSON format.
+     */
     toJSON(): any;
 }

--- a/types/three/src/scenes/Fog.d.ts
+++ b/types/three/src/scenes/Fog.d.ts
@@ -3,7 +3,7 @@ import { Color } from './../math/Color';
 
 export interface FogBase {
     /**
-     * Optional name of the `Fog` object 
+     * Optional name of the `Fog` object
      * @remarks _(doesn't need to be unique)_.
      * @defaultValue ``
      */
@@ -55,7 +55,7 @@ export class Fog implements FogBase {
     readonly isFog: true;
 
     /**
-     * Optional name of the object 
+     * Optional name of the object
      * @remarks _(doesn't need to be unique)_.
      * @defaultValue ``
      */

--- a/types/three/src/scenes/Fog.d.ts
+++ b/types/three/src/scenes/Fog.d.ts
@@ -5,7 +5,7 @@ export interface FogBase {
     /**
      * Optional name of the `Fog` object
      * @remarks _(doesn't need to be unique)_.
-     * @defaultValue ``
+     * @defaultValue `""`
      */
     name: string;
 
@@ -57,7 +57,7 @@ export class Fog implements FogBase {
     /**
      * Optional name of the object
      * @remarks _(doesn't need to be unique)_.
-     * @defaultValue ``
+     * @defaultValue `""`
      */
     name: string;
 

--- a/types/three/src/scenes/FogExp2.d.ts
+++ b/types/three/src/scenes/FogExp2.d.ts
@@ -1,26 +1,61 @@
+import { ColorRepresentation } from '../utils';
 import { Color } from './../math/Color';
 import { FogBase } from './Fog';
+
 /**
- * This class contains the parameters that define linear fog, i.e., that grows exponentially denser with the distance.
+ * This class contains the parameters that define exponential squared fog, which gives a clear view near the camera and a faster than exponentially densening fog farther from the camera.
+ * @example
+ * ```typescript
+ * const scene = new THREE.Scene();
+ * scene.fog = new THREE.FogExp2(0xcccccc, 0.002);
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl_geometry_terrain | webgl geometry terrain}
+ * @see {@link https://threejs.org/docs/index.html#api/en/scenes/FogExp2 | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/scenes/FogExp2.js | Source}
  */
 export class FogExp2 implements FogBase {
-    constructor(hex: number | string, density?: number);
+    /**
+     * The color parameter is passed to the {@link THREE.Color | Color} constructor to set the color property
+     * @remarks Color can be a hexadecimal integer or a CSS-style string.
+     * @param color
+     * @param density Expects a `Float`
+     */
+    constructor(color: ColorRepresentation, density?: number);
 
     /**
-     * @default ''
+     * Read-only flag to check if a given object is of type {@link FogExp2}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isFogExp2: true;
+
+    /**
+     * Optional name of the object 
+     * @remarks _(doesn't need to be unique)_.
+     * @defaultValue ``
      */
     name: string;
 
+    /**
+     * Fog color.
+     * @remarks If set to black, far away objects will be rendered black.
+     */
     color: Color;
 
     /**
      * Defines how fast the fog will grow dense.
-     * @default 0.00025
+     * @defaultValue `0.00025`
+     * @remarks Expects a `Float`
      */
     density: number;
 
-    readonly isFogExp2: true;
-
+    /**
+     * Returns a new {@link FogExp2} instance with the same parameters as this one.
+     */
     clone(): FogExp2;
+
+    /**
+     * Return {@link FogExp2} data in JSON format.
+     */
     toJSON(): any;
 }

--- a/types/three/src/scenes/FogExp2.d.ts
+++ b/types/three/src/scenes/FogExp2.d.ts
@@ -32,7 +32,7 @@ export class FogExp2 implements FogBase {
     /**
      * Optional name of the object
      * @remarks _(doesn't need to be unique)_.
-     * @defaultValue ``
+     * @defaultValue `""`
      */
     name: string;
 

--- a/types/three/src/scenes/FogExp2.d.ts
+++ b/types/three/src/scenes/FogExp2.d.ts
@@ -30,7 +30,7 @@ export class FogExp2 implements FogBase {
     readonly isFogExp2: true;
 
     /**
-     * Optional name of the object 
+     * Optional name of the object
      * @remarks _(doesn't need to be unique)_.
      * @defaultValue ``
      */

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -1,60 +1,83 @@
-// https://threejs.org/docs/?q=scene#api/en/scenes/Scene
-
 import { FogBase } from './Fog';
 import { Material } from './../materials/Material';
 import { Object3D } from './../core/Object3D';
 import { Color } from '../math/Color';
 import { Texture } from '../textures/Texture';
-import { WebGLRenderer } from '../renderers/WebGLRenderer';
-import { Camera } from '../cameras/Camera';
-
-// Scenes /////////////////////////////////////////////////////////////////////
+import { CubeTexture } from '../Three';
 
 /**
- * Scenes allow you to set up what and where is to be rendered by three.js. This is where you place objects, lights and cameras.
+ * Scenes allow you to set up what and where is to be rendered by three.js
+ * @remarks
+ * This is where you place objects, lights and cameras.
+ * @see Example: {@link https://threejs.org/examples/#webgl_multiple_scenes_comparison | webgl multiple scenes comparison}
+ * @see {@link https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene | Manual: Creating a scene}
+ * @see {@link https://threejs.org/docs/index.html#api/en/scenes/Scene | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/scenes/Scene.js | Source}
  */
 export class Scene extends Object3D {
+    /**
+     * Create a new {@link Scene} object.
+     */
     constructor();
 
+    /**
+     * Read-only flag to check if a given object is of type {@link Scene}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isScene: true;
+
+    /**
+     * @defaultValue `Scene`
+     */
     type: 'Scene';
 
     /**
-     * A fog instance defining the type of fog that affects everything rendered in the scene. Default is null.
-     * @default null
+     * A {@link Fog | fog} instance defining the type of fog that affects everything rendered in the scene.
+     * @defaultValue `null`
      */
     fog: FogBase | null;
 
     /**
-     * Sets the blurriness of the background. Only influences environment maps assigned to Scene.background. Valid input is a float between 0 and 1.
-     *
-     * @default 0
+     * Sets the blurriness of the background. Only influences environment maps assigned to {@link THREE.Scene.background | Scene.background}.
+     * @defaultValue `0`
+     * @remarks Expects a `Float` between `0` and `1`.
      */
     backgroundBlurriness: number;
 
     /**
      * Attenuates the color of the background. Only applies to background textures.
-     *
-     * @default 1
+     * @defaultValue `1`
+     * @remarks Expects a `Float`
      */
     backgroundIntensity: number;
 
     /**
-     * If not null, it will force everything in the scene to be rendered with that material. Default is null.
-     * @default null
+     * Forces everything in the {@link Scene} to be rendered with the defined material.
+     * @defaultValue `null`
      */
     overrideMaterial: Material | null;
 
     /**
-     * @default null
+     * Defines the background of the scene.
+     * @remarks Valid inputs are:
+     *  - A {@link THREE.Color | Color} for defining a uniform colored background.
+     *  - A {@link THREE.Texture | Texture} for defining a (flat) textured background.
+     *  - Texture cubes ({@link THREE.CubeTexture | CubeTexture}) or equirectangular textures for defining a skybox.</li>
+     * @defaultValue `null`
      */
-    background: null | Color | Texture;
+    background: Color | Texture | CubeTexture | null;
 
     /**
-     * @default null
+     * Sets the environment map for all physical materials in the scene.
+     * However, it's not possible to overwrite an existing texture assigned to {@link THREE.MeshStandardMaterial.envMap | MeshStandardMaterial.envMap}.
+     * @defaultValue `null`
      */
-    environment: null | Texture;
+    environment: Texture | null;
 
-    readonly isScene: true;
-
+    /**
+     * Convert the {@link Scene} to three.js {@link https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 | JSON Object/Scene format}.
+     * @param meta Object containing metadata such as textures or images for the scene.
+     */
     toJSON(meta?: any): any;
 }

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -1,5 +1,12 @@
 import { OffscreenCanvas, Texture } from './Texture';
-import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
+import {
+    Mapping,
+    Wrapping,
+    PixelFormat,
+    TextureDataType,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
+} from '../constants';
 
 /**
  * Creates a texture from a {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas | canvas element}.
@@ -29,8 +36,8 @@ export class CanvasTexture extends Texture {
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         format?: PixelFormat,
         type?: TextureDataType,
         anisotropy?: number,

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -7,8 +7,8 @@ import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '
  * This is almost the same as the base {@link Texture | Texture} class,
  * except that it sets {@link Texture.needsUpdate | needsUpdate} to `true` immediately.
  * @see {@link THREE.Texture | Texture}
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/CanvasTexture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/CanvasTexture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/CanvasTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/CanvasTexture.js | Source}
  */
 export class CanvasTexture extends Texture {
     /**

--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -1,18 +1,28 @@
 import { OffscreenCanvas, Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
 
+/**
+ * Creates a texture from a {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas | canvas element}.
+ * @remarks
+ * This is almost the same as the base {@link Texture | Texture} class,
+ * except that it sets {@link Texture.needsUpdate | needsUpdate} to `true` immediately.
+ * @see {@link THREE.Texture | Texture}
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/CanvasTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/CanvasTexture.js | Source}
+ */
 export class CanvasTexture extends Texture {
     /**
-     * @param canvas
-     * @param [format=THREE.RGBAFormat]
-     * @param [type=THREE.UnsignedByteType]
-     * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.LinearFilter]
-     * @param [minFilter=THREE.LinearMipmapLinearFilter]
-     * @param [anisotropy=1]
-     * @param [encoding=THREE.LinearEncoding]
+     * This creates a new {@link THREE.CanvasTexture | CanvasTexture} object.
+     * @param canvas The HTML canvas element from which to load the texture.
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.Texture.DEFAULT_MAPPING}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearMipmapLinearFilter}
+     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
+     * @param encoding See {@link Texture.encoding | .encoding}. Default {@link THREE.LinearEncoding}
      */
     constructor(
         canvas: TexImageSource | OffscreenCanvas,
@@ -26,5 +36,10 @@ export class CanvasTexture extends Texture {
         anisotropy?: number,
     );
 
+    /**
+     * Read-only flag to check if a given object is of type {@link CanvasTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
     readonly isCanvasTexture: true;
 }

--- a/types/three/src/textures/CompressedArrayTexture.d.ts
+++ b/types/three/src/textures/CompressedArrayTexture.d.ts
@@ -1,17 +1,51 @@
 import { CompressedPixelFormat, TextureDataType, Wrapping } from '../constants';
 import { CompressedTexture } from './CompressedTexture.js';
 
+/**
+ * Creates an texture 2D array based on data in compressed form, for example from a
+ * {@link https://en.wikipedia.org/wiki/DirectDraw_Surface | DDS} file.
+ * @remarks For use with the {@link THREE.CompressedTextureLoader | CompressedTextureLoader}.
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/CompressedArrayTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/CompressedArrayTexture.js | Source}
+ */
 export class CompressedArrayTexture extends CompressedTexture {
-    isCompressedArrayTexture: true;
-
-    wrapR: Wrapping;
-
+    /**
+     * Create a new instance of {@link CompressedArrayTexture}
+     * @param mipmaps The mipmaps array should contain objects with data, width and height.
+     * The mipmaps should be of the correct {@link format} and {@link type}. See {@link THREE.mipmaps}.
+     * @param width The width of the biggest mipmap.
+     * @param height The height of the biggest mipmap.
+     * @param depth The number of layers of the 2D array texture
+     * @param format The format used in the mipmaps. See {@link THREE.CompressedPixelFormat}.
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     */
     constructor(
         mipmaps: ImageData[],
         width: number,
         height: number,
         depth: number,
-        format?: CompressedPixelFormat,
+        format: CompressedPixelFormat,
         type?: TextureDataType,
     );
+
+    /**
+     * Read-only flag to check if a given object is of type {@link CompressedArrayTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isCompressedArrayTexture: true;
+
+    /**
+     * Overridden with a object containing width and height.
+     * @override
+     */
+    get image(): { width: number; height: number; depth: number };
+    set image(value: { width: number; height: number; depth: number });
+
+    /**
+     * This defines how the texture is wrapped in the depth direction.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @defaultValue {@link THREE.ClampToEdgeWrapping}
+     */
+    wrapR: Wrapping;
 }

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -8,26 +8,32 @@ import {
     TextureEncoding,
 } from '../constants';
 
-export class CompressedTexture extends Texture {
+/**
+ * Creates a texture based on data in compressed form, for example from a {@link https://en.wikipedia.org/wiki/DirectDraw_Surface | DDS} file.
+ * @remarks For use with the {@link THREE.CompressedTextureLoader | CompressedTextureLoader}.
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/CompressedTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/CompressedTexture.js | Source}
+ */
+export class CompressedTexture extends Texture<CompressedPixelFormat> {
     /**
-     * @param mipmaps
-     * @param width
-     * @param height
-     * @param [format=THREE.RGBAFormat]
-     * @param [type=THREE.UnsignedByteType]
-     * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.LinearFilter]
-     * @param [minFilter=THREE.LinearMipmapLinearFilter]
-     * @param [anisotropy=1]
-     * @param [encoding=THREE.LinearEncoding]
+     * This creates a new {@link THREE.CompressedTexture | CompressedTexture} object.
+     * @param mipmaps The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct {@link format} and {@link type}.
+     * @param width The width of the biggest mipmap.
+     * @param height The height of the biggest mipmap.
+     * @param format The format used in the mipmaps. See {@link THREE.CompressedPixelFormat}.
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.Texture.DEFAULT_MAPPING}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearMipmapLinearFilter}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
      */
     constructor(
         mipmaps: ImageData[],
         width: number,
         height: number,
-        format?: CompressedPixelFormat,
+        format: CompressedPixelFormat,
         type?: TextureDataType,
         mapping?: Mapping,
         wrapS?: Wrapping,
@@ -38,20 +44,38 @@ export class CompressedTexture extends Texture {
         encoding?: TextureEncoding,
     );
 
+    /**
+     * Read-only flag to check if a given object is of type {@link CompressedTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isCompressedTexture: true;
+
+    /**
+     * Overridden with a object containing width and height.
+     * @override
+     */
     get image(): { width: number; height: number };
     set image(value: { width: number; height: number });
 
     mipmaps: ImageData[];
 
     /**
-     * @default false
+     * @override
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link THREE.CompressedPixelFormat}
+     */
+    format: CompressedPixelFormat;
+
+    /**
+     * @override No flipping for cube textures. (also flipping doesn't work for compressed textures)
+     * @defaultValue `false`
      */
     flipY: boolean;
 
     /**
-     * @default false
+     * @override Can't generate mipmaps for compressed textures. mips must be embedded in DDS files
+     * @defaultValue `false`
      */
     generateMipmaps: boolean;
-
-    readonly isCompressedTexture: true;
 }

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -17,7 +17,8 @@ import {
 export class CompressedTexture extends Texture<CompressedPixelFormat> {
     /**
      * This creates a new {@link THREE.CompressedTexture | CompressedTexture} object.
-     * @param mipmaps The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct {@link format} and {@link type}.
+     * @param mipmaps The mipmaps array should contain objects with data, width and height.
+     * The mipmaps should be of the correct {@link format} and {@link type}. See {@link THREE.mipmaps}.
      * @param width The width of the biggest mipmap.
      * @param height The height of the biggest mipmap.
      * @param format The format used in the mipmaps. See {@link THREE.CompressedPixelFormat}.
@@ -58,6 +59,9 @@ export class CompressedTexture extends Texture<CompressedPixelFormat> {
     get image(): { width: number; height: number };
     set image(value: { width: number; height: number });
 
+    /**
+     *  The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct {@link format} and {@link type}.
+     */
     mipmaps: ImageData[];
 
     /**

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -2,10 +2,11 @@ import { Texture } from './Texture';
 import {
     Mapping,
     Wrapping,
-    TextureFilter,
     CompressedPixelFormat,
     TextureDataType,
     TextureEncoding,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
 } from '../constants';
 
 /**
@@ -39,8 +40,8 @@ export class CompressedTexture extends Texture<CompressedPixelFormat> {
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         anisotropy?: number,
         encoding?: TextureEncoding,
     );

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -15,7 +15,7 @@ import {
  * @see {@link https://threejs.org/docs/index.html#api/en/textures/CompressedTexture | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/CompressedTexture.js | Source}
  */
-export class CompressedTexture extends Texture<CompressedPixelFormat> {
+export class CompressedTexture extends Texture {
     /**
      * This creates a new {@link THREE.CompressedTexture | CompressedTexture} object.
      * @param mipmaps The mipmaps array should contain objects with data, width and height.

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -17,8 +17,8 @@ import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, Texture
  *     envMap: textureCube
  * });
  * ```
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/CubeTexture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/CubeTexture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/CubeTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/CubeTexture.js | Source}
  */
 export class CubeTexture extends Texture {
     /**

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -7,6 +7,7 @@ import {
     TextureEncoding,
     MagnificationTextureFilter,
     MinificationTextureFilter,
+    CubeTextureMapping,
 } from '../constants';
 
 /**
@@ -32,7 +33,7 @@ export class CubeTexture extends Texture {
     /**
      * This creates a new {@link THREE.CubeTexture | CubeTexture} object.
      * @param images
-     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.CubeReflectionMapping}
+     * @param mapping See {@link CubeTexture.mapping | .mapping}. Default {@link THREE.CubeReflectionMapping}
      * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
      * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
      * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
@@ -44,7 +45,7 @@ export class CubeTexture extends Texture {
      */
     constructor(
         images?: any[], // HTMLImageElement or HTMLCanvasElement
-        mapping?: Mapping,
+        mapping?: CubeTextureMapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
         magFilter?: MagnificationTextureFilter,
@@ -80,7 +81,7 @@ export class CubeTexture extends Texture {
      * @inheritDoc
      * @defaultValue {@link THREE.CubeReflectionMapping}
      */
-    mapping: Mapping;
+    mapping: CubeTextureMapping;
 
     /**
      * @inheritDoc

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -1,5 +1,13 @@
 import { Texture } from './Texture';
-import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding } from '../constants';
+import {
+    Mapping,
+    Wrapping,
+    PixelFormat,
+    TextureDataType,
+    TextureEncoding,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
+} from '../constants';
 
 /**
  * Creates a cube texture made up of six images.
@@ -39,8 +47,8 @@ export class CubeTexture extends Texture {
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         format?: PixelFormat,
         type?: TextureDataType,
         anisotropy?: number,

--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -1,18 +1,38 @@
 import { Texture } from './Texture';
 import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding } from '../constants';
 
+/**
+ * Creates a cube texture made up of six images.
+ * @remarks
+ * {@link CubeTexture} is almost equivalent in functionality and usage to {@link Texture}.
+ * The only differences are that the images are an array of _6_ images as opposed to a single image,
+ * and the mapping options are {@link THREE.CubeReflectionMapping} (default) or {@link THREE.CubeRefractionMapping}
+ * @example
+ * ```typescript
+ * const loader = new THREE.CubeTextureLoader();
+ * loader.setPath('textures/cube/pisa/');
+ * const textureCube = loader.load(['px.png', 'nx.png', 'py.png', 'ny.png', 'pz.png', 'nz.png']);
+ * const material = new THREE.MeshBasicMaterial({
+ *     color: 0xffffff,
+ *     envMap: textureCube
+ * });
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/CubeTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/CubeTexture.js | Source}
+ */
 export class CubeTexture extends Texture {
     /**
-     * @param [images=[]]
-     * @param [mapping=THREE.CubeReflectionMapping]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.LinearFilter]
-     * @param [minFilter=THREE.LinearMipmapLinearFilter]
-     * @param [format=THREE.RGBAFormat]
-     * @param [type=THREE.UnsignedByteType]
-     * @param [anisotropy=1]
-     * @param [encoding=THREE.LinearEncoding]
+     * This creates a new {@link THREE.CubeTexture | CubeTexture} object.
+     * @param images
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.CubeReflectionMapping}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearMipmapLinearFilter}
+     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
+     * @param encoding See {@link Texture.encoding | .encoding}. Default {@link THREE.LinearEncoding}
      */
     constructor(
         images?: any[], // HTMLImageElement or HTMLCanvasElement
@@ -27,12 +47,36 @@ export class CubeTexture extends Texture {
         encoding?: TextureEncoding,
     );
 
-    images: any; // returns and sets the value of Texture.image in the codde ?
+    /**
+     * Read-only flag to check if a given object is of type {@link CubeTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isCubeTexture: true;
 
     /**
-     * @default false
+     * An image object, typically created using the {@link THREE.CubeTextureLoader.load | CubeTextureLoader.load()} method.
+     * @see {@link Texture.image}
+     */
+    get image(): any;
+    set image(data: any);
+
+    /**
+     * An image object, typically created using the {@link THREE.CubeTextureLoader.load | CubeTextureLoader.load()} method.
+     * @see {@link Texture.image}
+     */
+    get images(): any;
+    set images(data: any);
+
+    /**
+     * @inheritDoc
+     * @defaultValue {@link THREE.CubeReflectionMapping}
+     */
+    mapping: Mapping;
+
+    /**
+     * @inheritDoc
+     * @defaultValue `false`
      */
     flipY: boolean;
-
-    readonly isCubeTexture: true;
 }

--- a/types/three/src/textures/Data3DTexture.d.ts
+++ b/types/three/src/textures/Data3DTexture.d.ts
@@ -1,5 +1,5 @@
 import { Texture } from './Texture';
-import { TextureFilter, Wrapping } from '../constants';
+import { MagnificationTextureFilter, MinificationTextureFilter, Wrapping } from '../constants';
 
 export class Data3DTexture extends Texture {
     constructor(data: BufferSource, width: number, height: number, depth: number);
@@ -7,12 +7,12 @@ export class Data3DTexture extends Texture {
     /**
      * @default THREE.NearestFilter
      */
-    magFilter: TextureFilter;
+    magFilter: MagnificationTextureFilter;
 
     /**
      * @default THREE.NearestFilter
      */
-    minFilter: TextureFilter;
+    minFilter: MinificationTextureFilter;
 
     /**
      * @default THREE.ClampToEdgeWrapping

--- a/types/three/src/textures/Data3DTexture.d.ts
+++ b/types/three/src/textures/Data3DTexture.d.ts
@@ -1,33 +1,97 @@
 import { Texture } from './Texture';
 import { MagnificationTextureFilter, MinificationTextureFilter, Wrapping } from '../constants';
+import { Texture3DImageData } from './types';
 
+/**
+ * Creates a three-dimensional texture from raw data, with parameters to divide it into width, height, and depth
+ * @remarks Compatible only with {@link WebGL2RenderingContext | WebGL 2 Rendering Context}.
+ * @example
+ * ```typescript
+ * This creates a[name] with repeating data, 0 to 255
+ * // create a buffer with some data
+ * const sizeX = 64;
+ * const sizeY = 64;
+ * const sizeZ = 64;
+ * const data = new Uint8Array(sizeX * sizeY * sizeZ);
+ * let i = 0;
+ * for (let z = 0; z & lt; sizeZ; z++) {
+ *     for (let y = 0; y & lt; sizeY; y++) {
+ *         for (let x = 0; x & lt; sizeX; x++) {
+ *             data[i] = i % 256;
+ *             i++;
+ *         }
+ *     }
+ * }
+ * // use the buffer to create the texture
+ * const texture = new THREE.Data3DTexture(data, sizeX, sizeY, sizeZ);
+ * texture.needsUpdate = true;
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl2_materials_texture3d | WebGL2 / materials / texture3d}
+ * @see Example: {@link https://threejs.org/examples/#webgl2_materials_texture3d_partialupdate | WebGL2 / materials / texture3d / partialupdate}
+ * @see Example: {@link https://threejs.org/examples/#webgl2_volume_cloud | WebGL2 / volume / cloud}
+ * @see Example: {@link https://threejs.org/examples/#webgl2_volume_perlin | WebGL2 / volume / perlin}
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/Data3DTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Data3DTexture.js | Source}
+ */
 export class Data3DTexture extends Texture {
-    constructor(data: BufferSource, width: number, height: number, depth: number);
+    /**
+     * Create a new instance of {@link Data3DTexture}
+     * @param data {@link https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView | ArrayBufferView} of the texture. Default `null`.
+     * @param width Width of the texture. Default `1`.
+     * @param height Height of the texture. Default `1`.
+     * @param depth Depth of the texture. Default `1`.
+     */
+    constructor(data?: BufferSource | null, width?: number, height?: number, depth?: number);
 
     /**
-     * @default THREE.NearestFilter
+     * Read-only flag to check if a given object is of type {@link Data3DTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isData3DTexture: true;
+
+    /**
+     * Overridden with a record type holding data, width and height and depth.
+     * @override
+     */
+    get image(): Texture3DImageData;
+    set image(data: Texture3DImageData);
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
      */
     magFilter: MagnificationTextureFilter;
 
     /**
-     * @default THREE.NearestFilter
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
      */
     minFilter: MinificationTextureFilter;
 
     /**
-     * @default THREE.ClampToEdgeWrapping
+     * @override
+     * @defaultValue {@link THREE.ClampToEdgeWrapping}
      */
     wrapR: Wrapping;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue `false`
      */
     flipY: boolean;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue `false`
      */
     generateMipmaps: boolean;
 
-    readonly isData3DTexture: true;
+    /**
+     * @override
+     * @defaultValue `1`
+     */
+    unpackAlignment: number;
 }
+
+export {};

--- a/types/three/src/textures/Data3DTexture.d.ts
+++ b/types/three/src/textures/Data3DTexture.d.ts
@@ -30,8 +30,8 @@ import { Texture3DImageData } from './types';
  * @see Example: {@link https://threejs.org/examples/#webgl2_materials_texture3d_partialupdate | WebGL2 / materials / texture3d / partialupdate}
  * @see Example: {@link https://threejs.org/examples/#webgl2_volume_cloud | WebGL2 / volume / cloud}
  * @see Example: {@link https://threejs.org/examples/#webgl2_volume_perlin | WebGL2 / volume / perlin}
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/Data3DTexture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Data3DTexture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/Data3DTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/Data3DTexture.js | Source}
  */
 export class Data3DTexture extends Texture {
     /**

--- a/types/three/src/textures/DataArrayTexture.d.ts
+++ b/types/three/src/textures/DataArrayTexture.d.ts
@@ -1,33 +1,107 @@
 import { Texture } from './Texture';
 import { MagnificationTextureFilter, MinificationTextureFilter } from '../constants';
+import { Texture3DImageData } from './types';
 
+/**
+ * Creates an array of textures directly from raw data, width and height and depth
+ * @remarks Compatible only with {@link WebGL2RenderingContext | WebGL 2 Rendering Context}.
+ * @example
+ * ```typescript
+ * This creates a[name] where each texture has a different color.
+ * // create a buffer with color data
+ * const width = 512;
+ * const height = 512;
+ * const depth = 100;
+ * const size = width * height;
+ * const data = new Uint8Array(4 * size * depth);
+ * for (let i = 0; i & lt; depth; i++) {
+ *     const color = new THREE.Color(Math.random(), Math.random(), Math.random());
+ *     const r = Math.floor(color.r * 255);
+ *     const g = Math.floor(color.g * 255);
+ *     const b = Math.floor(color.b * 255);
+ *     for (let j = 0; j & lt; size; j++) {
+ *         const stride = (i * size + j) * 4;
+ *         data[stride] = r;
+ *         data[stride + 1] = g;
+ *         data[stride + 2] = b;
+ *         data[stride + 3] = 255;
+ *     }
+ * }
+ * // used the buffer to create a [name]
+ * const texture = new THREE.DataArrayTexture(data, width, height, depth);
+ * texture.needsUpdate = true;
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl2_materials_texture2darray | WebGL2 / materials / texture2darray}
+ * @see Example: {@link https://threejs.org/examples/#webgl2_rendertarget_texture2darray | WebGL2 / rendertarget / texture2darray}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/DataArrayTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/DataArrayTexture.js | Source}
+ */
 export class DataArrayTexture extends Texture {
+    /**
+     * This creates a new {@link THREE.DataArrayTexture | DataArrayTexture} object.
+     * @remarks The interpretation of the data depends on {@link format} and {@link type}.
+     * @remarks If the {@link type} is {@link THREE.UnsignedByteType}, a {@link Uint8Array} will be useful for addressing the texel data
+     * @remarks If the {@link format} is {@link THREE.RGBAFormat}, data needs four values for one texel; Red, Green, Blue and Alpha (typically the opacity).
+     * @remarks For the packed {@link type | types}, {@link THREE.UnsignedShort4444Type} and {@link THREE.UnsignedShort5551Type}
+     * all color components of one texel can be addressed as bitfields within an integer element of a {@link Uint16Array}.
+     * @remarks In order to use the {@link type | types} {@link THREE.FloatType} and {@link THREE.HalfFloatType},
+     * the WebGL implementation must support the respective extensions _OES_texture_float_ and _OES_texture_half_float_
+     * @remarks In order to use {@link THREE.LinearFilter} for component-wise, bilinear interpolation of the texels based on these types,
+     * the WebGL extensions _OES_texture_float_linear_ or _OES_texture_half_float_linear_ must also be present.
+     * @param data {@link https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView | ArrayBufferView} of the texture. Default `null`.
+     * @param width Width of the texture. Default `1`.
+     * @param height Height of the texture. Default `1`.
+     * @param depth Depth of the texture. Default `1`.
+     */
     constructor(data?: BufferSource, width?: number, height?: number, depth?: number);
 
     /**
-     * @default THREE.NearestFilter
+     * Read-only flag to check if a given object is of type {@link DataArrayTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isDataArrayTexture: true;
+
+    /**
+     * Overridden with a record type holding data, width and height and depth.
+     * @override
+     */
+    get image(): Texture3DImageData;
+    set image(data: Texture3DImageData);
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
      */
     magFilter: MagnificationTextureFilter;
 
     /**
-     * @default THREE.NearestFilter
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
      */
     minFilter: MinificationTextureFilter;
 
     /**
-     * @default THREE.ClampToEdgeWrapping
+     * @override
+     * @defaultValue  {@link THREE.ClampToEdgeWrapping}
      */
     wrapR: boolean;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue `false`
      */
     flipY: boolean;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue `false`
      */
     generateMipmaps: boolean;
 
-    readonly isDataArrayTexture: true;
+    /**
+     * @override
+     * @defaultValue `1`
+     */
+    unpackAlignment: number;
 }

--- a/types/three/src/textures/DataArrayTexture.d.ts
+++ b/types/three/src/textures/DataArrayTexture.d.ts
@@ -1,5 +1,5 @@
 import { Texture } from './Texture';
-import { TextureFilter } from '../constants';
+import { MagnificationTextureFilter, MinificationTextureFilter } from '../constants';
 
 export class DataArrayTexture extends Texture {
     constructor(data?: BufferSource, width?: number, height?: number, depth?: number);
@@ -7,12 +7,12 @@ export class DataArrayTexture extends Texture {
     /**
      * @default THREE.NearestFilter
      */
-    magFilter: TextureFilter;
+    magFilter: MagnificationTextureFilter;
 
     /**
      * @default THREE.NearestFilter
      */
-    minFilter: TextureFilter;
+    minFilter: MinificationTextureFilter;
 
     /**
      * @default THREE.ClampToEdgeWrapping

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -1,5 +1,14 @@
 import { Texture } from './Texture';
-import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding, MagnificationTextureFilter, MinificationTextureFilter } from '../constants';
+import {
+    Mapping,
+    Wrapping,
+    TextureFilter,
+    PixelFormat,
+    TextureDataType,
+    TextureEncoding,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
+} from '../constants';
 import { TextureImageData } from './types';
 
 /**
@@ -70,7 +79,7 @@ export class DataTexture extends Texture {
      * Overridden with a record type holding data, width and height and depth.
      * @override
      */
-    get image(): TextureImageData
+    get image(): TextureImageData;
     set image(value: TextureImageData);
 
     /**

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -2,7 +2,6 @@ import { Texture } from './Texture';
 import {
     Mapping,
     Wrapping,
-    TextureFilter,
     PixelFormat,
     TextureDataType,
     TextureEncoding,
@@ -62,8 +61,8 @@ export class DataTexture extends Texture {
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         anisotropy?: number,
         encoding?: TextureEncoding,
     );

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -1,20 +1,48 @@
 import { Texture } from './Texture';
-import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding } from '../constants';
+import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType, TextureEncoding, MagnificationTextureFilter, MinificationTextureFilter } from '../constants';
+import { TextureImageData } from './types';
 
+/**
+ * Creates a texture directly from raw data, width and height.
+ * @example
+ * ```typescript
+ * // create a buffer with color data
+ * const width = 512;
+ * const height = 512;
+ * const size = width * height;
+ * const data = new Uint8Array(4 * size);
+ * const color = new THREE.Color(0xffffff);
+ * const r = Math.floor(color.r * 255);
+ * const g = Math.floor(color.g * 255);
+ * const b = Math.floor(color.b * 255);
+ * for (let i = 0; i & lt; size; i++) {
+ *     const stride = i * 4;
+ *     data[stride] = r;
+ *     data[stride + 1] = g;
+ *     data[stride + 2] = b;
+ *     data[stride + 3] = 255;
+ * }
+ * // used the buffer to create a [name]
+ * const texture = new THREE.DataTexture(data, width, height);
+ * texture.needsUpdate = true;
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/DataTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/DataTexture.js | Source}
+ */
 export class DataTexture extends Texture {
     /**
-     * @param data
-     * @param width
-     * @param height
-     * @param [format=THREE.RGBAFormat]
-     * @param [type=THREE.UnsignedByteType]
-     * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.NearestFilter]
-     * @param [minFilter=THREE.NearestFilter]
-     * @param [anisotropy=1]
-     * @param [encoding=THREE.LinearEncoding]
+     * @param data {@link https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView | ArrayBufferView} of the texture. Default `null`.
+     * @param width Width of the texture. Default `1`.
+     * @param height Height of the texture. Default `1`.
+     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.Texture.DEFAULT_MAPPING}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.NearestFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.NearestFilter}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
+     * @param encoding See {@link Texture.encoding | .encoding}. Default {@link THREE.LinearEncoding}
      */
     constructor(
         data?: BufferSource | null,
@@ -31,28 +59,47 @@ export class DataTexture extends Texture {
         encoding?: TextureEncoding,
     );
 
-    get image(): ImageData;
-    set image(value: ImageData);
+    /**
+     * Read-only flag to check if a given object is of type {@link DataTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isDataTexture: true;
 
     /**
-     * @default false
+     * Overridden with a record type holding data, width and height and depth.
+     * @override
+     */
+    get image(): TextureImageData
+    set image(value: TextureImageData);
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
+     */
+    magFilter: MagnificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
+     */
+    minFilter: MinificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue `false`
      */
     flipY: boolean;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue `false`
      */
     generateMipmaps: boolean;
 
     /**
-     * @default 1
+     * @override
+     * @defaultValue `1`
      */
     unpackAlignment: number;
-
-    /**
-     * @default THREE.DepthFormat
-     */
-    format: PixelFormat;
-
-    readonly isDataTexture: true;
 }

--- a/types/three/src/textures/DataTexture.d.ts
+++ b/types/three/src/textures/DataTexture.d.ts
@@ -35,8 +35,8 @@ import { TextureImageData } from './types';
  * const texture = new THREE.DataTexture(data, width, height);
  * texture.needsUpdate = true;
  * ```
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/DataTexture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/DataTexture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/DataTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/DataTexture.js | Source}
  */
 export class DataTexture extends Texture {
     /**

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -2,7 +2,6 @@ import { Texture } from './Texture';
 import {
     Mapping,
     Wrapping,
-    TextureFilter,
     TextureDataType,
     DeepTexturePixelFormat,
     MagnificationTextureFilter,
@@ -39,8 +38,8 @@ export class DepthTexture extends Texture<DeepTexturePixelFormat> {
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         anisotropy?: number,
         format?: DeepTexturePixelFormat,
     );

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -17,7 +17,7 @@ import {
  * @see {@link https://threejs.org/docs/index.html#api/en/textures/DepthTexture | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/DepthTexture.js | Source}
  */
-export class DepthTexture extends Texture<DeepTexturePixelFormat> {
+export class DepthTexture extends Texture {
     /**
      * Create a new instance of {@link DepthTexture}
      * @param width Width of the texture.

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -4,7 +4,6 @@ import {
     Wrapping,
     TextureFilter,
     TextureDataType,
-    PixelFormat,
     DeepTexturePixelFormat,
     MagnificationTextureFilter,
     MinificationTextureFilter,
@@ -16,10 +15,10 @@ import {
  * When using a **WebGL1** rendering context, {@link DepthTexture} requires support for the
  * {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/ | WEBGL_depth_texture} extension.
  * @see Example: {@link https://threejs.org/examples/#webgl_depth_texture | depth / texture}
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/DepthTexture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/DepthTexture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/DepthTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/DepthTexture.js | Source}
  */
-export class DepthTexture extends Texture {
+export class DepthTexture extends Texture<DeepTexturePixelFormat> {
     /**
      * Create a new instance of {@link DepthTexture}
      * @param width Width of the texture.
@@ -31,7 +30,7 @@ export class DepthTexture extends Texture {
      * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.NearestFilter}
      * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.NearestFilter}
      * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
-     * @param format See {@link DepthTexture.format | .format}. Default {@link THREE.RGBAFormat}
+     * @param format See {@link DepthTexture.format | .format}. Default {@link THREE.DepthFormat}
      */
     constructor(
         width: number,

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -1,17 +1,37 @@
 import { Texture } from './Texture';
-import { Mapping, Wrapping, TextureFilter, TextureDataType } from '../constants';
+import {
+    Mapping,
+    Wrapping,
+    TextureFilter,
+    TextureDataType,
+    PixelFormat,
+    DeepTexturePixelFormat,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
+} from '../constants';
 
+/**
+ * This class can be used to automatically save the depth information of a rendering into a texture
+ * @remarks
+ * When using a **WebGL1** rendering context, {@link DepthTexture} requires support for the
+ * {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/ | WEBGL_depth_texture} extension.
+ * @see Example: {@link https://threejs.org/examples/#webgl_depth_texture | depth / texture}
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/DepthTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/DepthTexture.js | Source}
+ */
 export class DepthTexture extends Texture {
     /**
-     * @param width
-     * @param height
-     * @param type
-     * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.NearestFilter]
-     * @param [minFilter=THREE.NearestFilter]
-     * @param [anisotropy=1]
+     * Create a new instance of {@link DepthTexture}
+     * @param width Width of the texture.
+     * @param height Height of the texture.
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType} or {@link THREE.UnsignedInt248Type}
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.Texture.DEFAULT_MAPPING}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.NearestFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.NearestFilter}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
+     * @param format See {@link DepthTexture.format | .format}. Default {@link THREE.RGBAFormat}
      */
     constructor(
         width: number,
@@ -23,20 +43,58 @@ export class DepthTexture extends Texture {
         magFilter?: TextureFilter,
         minFilter?: TextureFilter,
         anisotropy?: number,
+        format?: DeepTexturePixelFormat,
     );
 
+    /**
+     * Read-only flag to check if a given object is of type {@link DepthTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isDepthTexture: true;
+
+    /**
+     * Overridden with a record type holding width and height.
+     * @override
+     */
     get image(): { width: number; height: number };
     set image(value: { width: number; height: number });
 
     /**
-     * @default false
+     * @override
+     * @defaultValue `false`
      */
     flipY: boolean;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
+     */
+    magFilter: MagnificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
+     */
+    minFilter: MinificationTextureFilter;
+
+    /**
+     * @override Depth textures do not use mipmaps.
+     * @defaultValue `false`
      */
     generateMipmaps: boolean;
 
-    readonly isDepthTexture: true;
+    /**
+     * @override
+     * @see {@link Texture.format | Texture.format}
+     * @defaultValue {@link THREE.DepthFormat}.
+     */
+    format: DeepTexturePixelFormat;
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.UnsignedByteType} when {@link format | .format} === {@link THREE.DepthFormat}
+     * @defaultValue {@link THREE.UnsignedInt248Type} when {@link format | .format} === {@link THREE.DepthStencilFormat}
+     */
+    type: TextureDataType;
 }

--- a/types/three/src/textures/FramebufferTexture.d.ts
+++ b/types/three/src/textures/FramebufferTexture.d.ts
@@ -1,8 +1,63 @@
 import { Texture } from './Texture';
-import { PixelFormat } from '../constants';
+import { MagnificationTextureFilter, MinificationTextureFilter, PixelFormat } from '../constants';
 
+/**
+ * This class can only be used in combination with {@link THREE.WebGLRenderer.copyFramebufferToTexture | WebGLRenderer.copyFramebufferToTexture()}.
+ * @example
+ * ```typescript
+ * const pixelRatio = window.devicePixelRatio;
+ * const textureSize = 128 * pixelRatio;
+ *
+ * // instantiate a framebuffer texture
+ * const frameTexture = new FramebufferTexture( textureSize, textureSize, RGBAFormat );
+ *
+ * // calculate start position for copying part of the frame data
+ * const vector = new Vector2();
+ * vector.x = ( window.innerWidth * pixelRatio / 2 ) - ( textureSize / 2 );
+ * vector.y = ( window.innerHeight * pixelRatio / 2 ) - ( textureSize / 2 );
+ *
+ * // render the scene
+ * renderer.clear();
+ * renderer.render( scene, camera );
+ *
+ * // copy part of the rendered frame into the framebuffer texture
+ * renderer.copyFramebufferToTexture( vector, frameTexture );
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl_framebuffer_texture | webgl_framebuffer_texture}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/FramebufferTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/FramebufferTexture.js | Source}
+ */
 export class FramebufferTexture extends Texture {
+    /**
+     * Create a new instance of {@link FramebufferTexture}
+     * @param width The width of the texture.
+     * @param height The height of the texture.
+     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}.
+     */
+    constructor(width: number, height: number, format: PixelFormat);
+
+    /**
+     * Read-only flag to check if a given object is of type {@link FramebufferTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
     readonly isFramebufferTexture: true;
 
-    constructor(width: number, height: number, format: PixelFormat);
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
+     */
+    magFilter: MagnificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.NearestFilter}
+     */
+    minFilter: MinificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue `false`
+     */
+    generateMipmaps: boolean;
 }

--- a/types/three/src/textures/Source.d.ts
+++ b/types/three/src/textures/Source.d.ts
@@ -1,7 +1,7 @@
 /**
  * Represents the data {@link Source} of a texture.
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/Source | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Source.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/Source | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/Source.js | Source}
  */
 export class Source {
     /**

--- a/types/three/src/textures/Source.d.ts
+++ b/types/three/src/textures/Source.d.ts
@@ -1,39 +1,49 @@
 /**
- * Represents the data source of a texture.
+ * Represents the data {@link Source} of a texture.
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/Source | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Source.js | Source}
  */
 export class Source {
     /**
-     * @param [data] The data definition of a texture. default is **null**.
+     * Create a new instance of {@link Source}
+     * @param data The data definition of a texture. Default `null`
      */
     constructor(data: any);
 
     /**
-     * The actual data of a texture. The type of this property depends on the texture that uses this instance.
+     * Flag to check if a given object is of type {@link Source}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isSource: true;
+
+    /**
+     * The actual data of a texture.
+     * @remarks The type of this property depends on the texture that uses this instance.
      */
     data: any;
 
     /**
-     * Set this to **true** to trigger a data upload to the GPU next time the source is used.
+     * Set this to `true` to trigger a data upload to the GPU next time the {@link Source} is used.
      */
     set needsUpdate(value: boolean);
 
     /**
-     * [UUID](http://en.wikipedia.org/wiki/Universally_unique_identifier) of this object instance.
-     * This gets automatically assigned, so this shouldn't be edited.
+     * {@link http://en.wikipedia.org/wiki/Universally_unique_identifier | UUID} of this object instance.
+     * @remarks This gets automatically assigned and shouldn't be edited.
      */
     uuid: string;
 
     /**
-     * This starts at **0** and counts how many times [property:Boolean needsUpdate] is set to **true**.
+     * This starts at `0` and counts how many times {@link needsUpdate | .needsUpdate} is set to `true`.
+     * @remarks Expects a `Integer`
+     * @defaultValue `0`
      */
     version: number;
 
     /**
-     * Convert the data source to three.js [JSON Object/Scene format](https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4).
-     *
-     * @param [meta] optional object containing metadata.
+     * Convert the data {@link Source} to three.js {@link https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 | JSON Object/Scene format}.
+     * @param meta Optional object containing metadata.
      */
-    toJSON(meta: any): any;
-
-    readonly isTexture: true;
+    toJSON(meta?: string | {}): {};
 }

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -34,7 +34,7 @@ export interface OffscreenCanvas extends EventTarget {}
  * @see Example: {@link https://threejs.org/examples/#webgl_materials_texture_filters | webgl materials texture filters}
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
  * @see {@link https://threejs.org/docs/index.html#api/en/textures/Texture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/Texture.js | Source}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Texture.js | Source}
  * @typeParam TPixelFormat - Used for better support for SubTypes of Texture. Instances of {@link Texture} should use the default {@link THREE.PixelFormat}.
  */
 export class Texture<TPixelFormat extends AnyPixelFormat = PixelFormat> extends EventDispatcher {

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -45,7 +45,7 @@ export class Texture extends EventDispatcher {
      * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
      * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
      * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
-     * @param minFilter See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearMipmapLinearFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearMipmapLinearFilter}
      * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}
      * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
      * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
@@ -100,21 +100,12 @@ export class Texture extends EventDispatcher {
 
     /**
      * An image object, typically created using the {@link THREE.TextureLoader.load | TextureLoader.load()} method.
-     * This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
+     * @remarks This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
      * @remarks To use video as a {@link Texture} you need to have a playing HTML5 video element as a source
      * for your {@link Texture} image and continuously update this {@link Texture}
      * as long as video is playing - the {@link THREE.VideoTexture | VideoTexture} class handles this automatically.
      */
     get image(): any;
-
-    /**
-     * An image object, typically created using the {@link THREE.TextureLoader.load | TextureLoader.load()} method.
-     * This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
-     * @remarks To use video as a {@link Texture} you need to have a playing HTML5 video element as a source
-     * for your {@link Texture} image and continuously update this {@link Texture}
-     * as long as video is playing - the {@link THREE.VideoTexture | VideoTexture} class handles this automatically.
-     * @param data
-     */
     set image(data: any);
 
     /**
@@ -302,7 +293,7 @@ export class Texture extends EventDispatcher {
      *  - `4` (word-alignment)
      *  - `8` (rows start on double-word boundaries).
      * @see {@link http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml | glPixelStorei} for more information.
-     * @defaultValue 4
+     * @defaultValue `4`
      */
     unpackAlignment: number;
 

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -12,12 +12,32 @@ import {
     PixelFormatGPU,
     TextureDataType,
     TextureEncoding,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
 } from '../constants';
 
 /** Shim for OffscreenCanvas. */
 // tslint:disable-next-line:no-empty-interface
 export interface OffscreenCanvas extends EventTarget {}
 
+/**
+ * Create a {@link Texture} to apply to a surface or as a reflection or refraction map.
+ * @remarks
+ * After the initial use of a texture, its **dimensions**, {@link format}, and {@link type} cannot be changed
+ * Instead, call {@link dispose | .dispose()} on the {@link Texture} and instantiate a new {@link Texture}.
+ * @example
+ * ```typescript
+ * // load a texture, set wrap mode to repeat
+ * const texture = new THREE.TextureLoader().load("textures/water.jpg");
+ * texture.wrapS = THREE.RepeatWrapping;
+ * texture.wrapT = THREE.RepeatWrapping;
+ * texture.repeat.set(4, 4);
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl_materials_texture_filters | webgl materials texture filters}
+ * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/Texture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Texture.js | Source}
+ */
 export class Texture extends EventDispatcher {
     /**
      * @param [image]
@@ -44,81 +64,137 @@ export class Texture extends EventDispatcher {
         encoding?: TextureEncoding,
     );
 
-    id: number;
+    /**
+     * Read-only flag to check if a given object is of type {@link Texture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isTexture: true;
+
+    /**
+     * Unique number for this {@link Texture} instance.
+     * @remarks Note that ids are assigned in chronological order: 1, 2, 3, ..., incrementing by one for each new object.
+     * @remarks Expects a `Integer`
+     */
+    readonly id: number;
+
+    /**
+     * {@link http://en.wikipedia.org/wiki/Universally_unique_identifier | UUID} of this object instance.
+     * @remarks This gets automatically assigned and shouldn't be edited.
+     */
     uuid: string;
 
     /**
-     * @default ''
+     * Optional name of the object
+     * @remarks _(doesn't need to be unique)_.
+     * @defaultValue `""`
      */
     name: string;
-    sourceFile: string;
 
     /**
      * The data definition of a texture. A reference to the data source can be shared across textures.
-     * This is often useful in context of spritesheets where multiple textures render the same data but with different texture transformations.
+     * This is often useful in context of spritesheets where multiple textures render the same data
+     * but with different {@link Texture} transformations.
      */
     source: Source;
 
     /**
-     * An image object, typically created using the {@link TextureLoader.load} method.
+     * An image object, typically created using the {@link THREE.TextureLoader.load | TextureLoader.load()} method.
      * This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
-     *
-     * To use video as a texture you need to have a playing HTML5
-     * video element as a source for your texture image and continuously update this texture
-     * as long as video is playing - the {@link VideoTexture} class handles this automatically.
+     * @remarks To use video as a {@link Texture} you need to have a playing HTML5 video element as a source
+     * for your {@link Texture} image and continuously update this {@link Texture}
+     * as long as video is playing - the {@link THREE.VideoTexture | VideoTexture} class handles this automatically.
      */
     get image(): any;
 
     /**
-     * An image object, typically created using the {@link TextureLoader.load} method.
+     * An image object, typically created using the {@link THREE.TextureLoader.load | TextureLoader.load()} method.
      * This can be any image (e.g., PNG, JPG, GIF, DDS) or video (e.g., MP4, OGG/OGV) type supported by three.js.
-     *
-     * To use video as a texture you need to have a playing HTML5
-     * video element as a source for your texture image and continuously update this texture
-     * as long as video is playing - the {@link VideoTexture} class handles this automatically.
+     * @remarks To use video as a {@link Texture} you need to have a playing HTML5 video element as a source
+     * for your {@link Texture} image and continuously update this {@link Texture}
+     * as long as video is playing - the {@link THREE.VideoTexture | VideoTexture} class handles this automatically.
+     * @param data
      */
     set image(data: any);
 
     /**
-     * @default []
+     * Array of user-specified mipmaps
+     * @defaultValue `[]`
      */
     mipmaps: any[]; // ImageData[] for 2D textures and CubeTexture[] for cube textures;
 
     /**
-     * @default THREE.Texture.DEFAULT_MAPPING
+     * How the image is applied to the object.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @defaultValue _value of_ {@link THREE.Texture.DEFAULT_MAPPING}
      */
     mapping: Mapping;
 
     /**
-     * @default THREE.ClampToEdgeWrapping
+     * This defines how the {@link Texture} is wrapped *horizontally* and corresponds to **U** in UV mapping.
+     * @remarks for **WEBGL1** - tiling of images in textures only functions if image dimensions are powers of two
+     * (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...) in terms of pixels.
+     * Individual dimensions need not be equal, but each must be a power of two. This is a limitation of WebGL1, not three.js.
+     * **WEBGL2** does not have this limitation.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link wrapT}
+     * @defaultValue {@link THREE.ClampToEdgeWrapping}
      */
     wrapS: Wrapping;
 
     /**
-     * @default THREE.ClampToEdgeWrapping
+     * This defines how the {@link Texture} is wrapped **vertically** and corresponds to *V* in UV mapping.
+     * @remarks for **WEBGL1** - tiling of images in textures only functions if image dimensions are powers of two
+     * (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...) in terms of pixels.
+     * Individual dimensions need not be equal, but each must be a power of two. This is a limitation of WebGL1, not three.js.
+     * **WEBGL2** does not have this limitation.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link wrapS}
+     * @defaultValue {@link THREE.ClampToEdgeWrapping}
      */
     wrapT: Wrapping;
 
     /**
-     * @default THREE.LinearFilter
+     * How the {@link Texture} is sampled when a texel covers more than one pixel.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link minFilter}
+     * @see {@link THREE.MagnificationTextureFilter}
+     * @defaultValue {@link THREE.LinearFilter}
      */
-    magFilter: TextureFilter;
+    magFilter: MagnificationTextureFilter;
 
     /**
-     * @default THREE.LinearMipmapLinearFilter
+     * How the {@link Texture} is sampled when a texel covers less than one pixel.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link magFilter}
+     * @see {@link THREE.MinificationTextureFilter}
+     * @defaultValue {@link THREE.LinearMipmapLinearFilter}
      */
-    minFilter: TextureFilter;
+    minFilter: MinificationTextureFilter;
 
     /**
+     * The number of samples taken along the axis through the pixel that has the highest density of texels.
+     * @remarks A higher value gives a less blurry result than a basic mipmap, at the cost of more {@link Texture} samples being used.
+     * @remarks Use {@link THREE.WebGLCapabilities.getMaxAnisotropy() | renderer.capabilities.getMaxAnisotropy()} to find the maximum valid anisotropy value for the GPU;
+     * @remarks This value is usually a power of 2.
      * @default 1
      */
     anisotropy: number;
 
     /**
-     * @default THREE.RGBAFormat
+     * These define how elements of a 2D texture, or texels, are read by shaders.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link THREE.PixelFormat}
+     * @defaultValue {@link THREE.RGBAFormat}.
      */
     format: PixelFormat;
 
+    /**
+     * The GPU Pixel Format allows the developer to specify how the data is going to be stored on the GPU.
+     * @remarks Compatible only with {@link WebGL2RenderingContext | WebGL 2 Rendering Context}.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @defaultValue The default value is obtained using a combination of {@link Texture.format | .format} and {@link Texture.type | .type}.
+     */
     internalFormat: PixelFormatGPU | null;
 
     /**
@@ -202,13 +278,12 @@ export class Texture extends EventDispatcher {
      */
     version: number;
     set needsUpdate(value: boolean);
-    readonly isTexture: true;
 
     onUpdate: () => void;
 
     static DEFAULT_ANISOTROPY: number;
     static DEFAULT_IMAGE: any;
-    static DEFAULT_MAPPING: any;
+    static DEFAULT_MAPPING: Mapping;
 
     clone(): this;
     copy(source: Texture): this;

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -7,7 +7,6 @@ import { EventDispatcher } from './../core/EventDispatcher';
 import {
     Mapping,
     Wrapping,
-    TextureFilter,
     PixelFormat,
     PixelFormatGPU,
     TextureDataType,
@@ -40,24 +39,25 @@ export interface OffscreenCanvas extends EventTarget {}
  */
 export class Texture extends EventDispatcher {
     /**
-     * @param [image]
-     * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.LinearFilter]
-     * @param [minFilter=THREE.LinearMipmapLinearFilter]
-     * @param [format=THREE.RGBAFormat]
-     * @param [type=THREE.UnsignedByteType]
-     * @param [anisotropy=THREE.Texture.DEFAULT_ANISOTROPY]
-     * @param [encoding=THREE.LinearEncoding]
+     * This creates a new {@link THREE.Texture | Texture} object.
+     * @param image See {@link Texture.image | .image}. Default {@link THREE.Texture.DEFAULT_IMAGE}
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.Texture.DEFAULT_MAPPING}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
+     * @param minFilter See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearMipmapLinearFilter}
+     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
+     * @param encoding See {@link Texture.encoding | .encoding}. Default {@link THREE.LinearEncoding}
      */
     constructor(
         image?: TexImageSource | OffscreenCanvas,
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         format?: PixelFormat,
         type?: TextureDataType,
         anisotropy?: number,
@@ -179,7 +179,7 @@ export class Texture extends EventDispatcher {
      * @remarks A higher value gives a less blurry result than a basic mipmap, at the cost of more {@link Texture} samples being used.
      * @remarks Use {@link THREE.WebGLCapabilities.getMaxAnisotropy() | renderer.capabilities.getMaxAnisotropy()} to find the maximum valid anisotropy value for the GPU;
      * @remarks This value is usually a power of 2.
-     * @default 1
+     * @default _value of_ {@link THREE.Texture.DEFAULT_ANISOTROPY}. That is normally `1`.
      */
     anisotropy: number;
 
@@ -341,26 +341,78 @@ export class Texture extends EventDispatcher {
     /**
      * This starts at `0` and counts how many times {@link needsUpdate | .needsUpdate} is set to `true`.
      * @remarks Expects a `Integer`
-     * @defaultValue `0``
+     * @defaultValue `0`
      */
     version: number;
 
     /**
-     * Set this to `true` to trigger an update next time the {@link Texture} is used. Particularly important for setting the wrap mode.
+     * Set this to `true` to trigger an update next time the texture is used. Particularly important for setting the wrap mode.
      */
     set needsUpdate(value: boolean);
 
+    /**
+     * The Global default value for {@link anisotropy | .anisotropy}.
+     * @defaultValue `1`.
+     */
     static DEFAULT_ANISOTROPY: number;
+
+    /**
+     * The Global default value for {@link Texture.image | .image}.
+     * @defaultValue `null`.
+     */
     static DEFAULT_IMAGE: any;
+
+    /**
+     * The Global default value for {@link mapping | .mapping}.
+     * @defaultValue {@link THREE.UVMapping}
+     */
     static DEFAULT_MAPPING: Mapping;
 
+    /**
+     * A callback function, called when the texture is updated _(e.g., when needsUpdate has been set to true and then the texture is used)_.
+     */
     onUpdate: () => void;
 
-    clone(): this;
-    copy(source: Texture): this;
-    toJSON(meta: any): any;
+    /**
+     * Transform the **UV** based on the value of this texture's
+     * {@link offset | .offset},
+     * {@link repeat | .repeat},
+     * {@link wrapS | .wrapS},
+     * {@link wrapT | .wrapT} and
+     * {@link flipY | .flipY} properties.
+     * @param uv
+     */
     transformUv(uv: Vector2): Vector2;
+
+    /**
+     * Update the texture's **UV-transform** {@link matrix | .matrix} from the texture properties
+     * {@link offset | .offset},
+     * {@link repeat | .repeat},
+     * {@link rotation | .rotation} and
+     * {@link center | .center}.
+     */
     updateMatrix(): void;
 
+    /**
+     * Make copy of the texture
+     * @remarks Note this is not a **"deep copy"**, the image is shared
+     * @remarks
+     * Besides, cloning a texture does not automatically mark it for a texture upload
+     * You have to set {@link needsUpdate | .needsUpdate} to `true` as soon as it's image property (the data source) is fully loaded or ready.
+     */
+    clone(): this;
+
+    copy(source: Texture): this;
+
+    /**
+     * Convert the texture to three.js {@link https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 | JSON Object/Scene format}.
+     * @param meta Optional object containing metadata.
+     */
+    toJSON(meta: any): any;
+
+    /**
+     * Frees the GPU-related resources allocated by this instance
+     * @remarks Call this method whenever this instance is no longer used in your app.
+     */
     dispose(): void;
 }

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -225,8 +225,29 @@ export class Texture<TPixelFormat extends AnyPixelFormat = PixelFormat> extends 
     matrixAutoUpdate: boolean;
 
     /**
-     *
-     * @default new THREE.Vector2( 0, 0 )
+     * How much a single repetition of the texture is offset from the beginning, in each direction **U** and **V**.
+     * @remarks Typical range is `0.0` to `1.0`.
+     * @remarks
+     * The below texture types share the `first` uv channel in the engine.
+     * The offset (and repeat) setting is evaluated according to the following priorities and then shared by those textures:
+     *  - color map
+     *  - specular map
+     *  - displacement map
+     *  - normal map
+     *  - bump map
+     *  - roughness map
+     *  - metalness map
+     *  - alpha map
+     *  - emissive map
+     *  - clearcoat map
+     *  - clearcoat normal map
+     *  - clearcoat roughnessMap map
+     * @remarks
+     * The below {@link Texture} types share the `second` uv channel in the engine.
+     * The offset (and repeat) setting is evaluated according to the following priorities and then shared by those textures:
+     *  - ao map
+     *  - light map
+     * @defaultValue `new THREE.Vector2(0, 0)`
      */
     offset: Vector2;
 

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -116,6 +116,8 @@ export class Texture extends EventDispatcher {
 
     /**
      * How the image is applied to the object.
+     * @remarks All {@link Texture} types except {@link THREE.CubeTexture} expect the _values_ be {@link THREE.Mapping}
+     * @remarks {@link CubeTexture} expect the _values_ be {@link THREE.CubeTextureMapping}
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @defaultValue _value of_ {@link THREE.Texture.DEFAULT_MAPPING}
      */
@@ -176,6 +178,9 @@ export class Texture extends EventDispatcher {
 
     /**
      * These define how elements of a 2D texture, or texels, are read by shaders.
+     * @remarks All {@link Texture} types except {@link THREE.DeepTexture} and {@link THREE.CompressedPixelFormat} expect the _values_ be {@link THREE.PixelFormat}
+     * @remarks {@link DeepTexture} expect the _values_ be {@link THREE.CubeTextureMapping}
+     * @remarks {@link CompressedPixelFormat} expect the _values_ be {@link THREE.CubeTextureMapping}
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @see {@link THREE.PixelFormat}
      * @defaultValue {@link THREE.RGBAFormat}.

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -1,5 +1,3 @@
-// https://threejs.org/docs/?q=texture#api/en/textures/Texture
-
 import { Vector2 } from './../math/Vector2';
 import { Matrix3 } from './../math/Matrix3';
 import { Source } from './Source';
@@ -13,6 +11,7 @@ import {
     TextureEncoding,
     MagnificationTextureFilter,
     MinificationTextureFilter,
+    AnyPixelFormat,
 } from '../constants';
 
 /** Shim for OffscreenCanvas. */
@@ -34,10 +33,11 @@ export interface OffscreenCanvas extends EventTarget {}
  * ```
  * @see Example: {@link https://threejs.org/examples/#webgl_materials_texture_filters | webgl materials texture filters}
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/Texture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Texture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/Texture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/Texture.js | Source}
+ * @typeParam TPixelFormat - Used for better support for SubTypes of Texture. Instances of {@link Texture} should use the default {@link THREE.PixelFormat}.
  */
-export class Texture extends EventDispatcher {
+export class Texture<TPixelFormat extends AnyPixelFormat = PixelFormat> extends EventDispatcher {
     /**
      * This creates a new {@link THREE.Texture | Texture} object.
      * @param image See {@link Texture.image | .image}. Default {@link THREE.Texture.DEFAULT_IMAGE}
@@ -180,7 +180,7 @@ export class Texture extends EventDispatcher {
      * @see {@link THREE.PixelFormat}
      * @defaultValue {@link THREE.RGBAFormat}.
      */
-    format: PixelFormat;
+    format: TPixelFormat;
 
     /**
      * This must correspond to the {@link Texture.format | .format}.
@@ -295,7 +295,7 @@ export class Texture extends EventDispatcher {
      * @see {@link http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml | glPixelStorei} for more information.
      * @defaultValue `4`
      */
-    unpackAlignment: number;
+    unpackAlignment: number; // TODO Fix typing to only allow the expected values.
 
     /**
      * The {@link Textures | {@link Texture} constants} page for details of other formats.

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -408,7 +408,7 @@ export class Texture extends EventDispatcher {
      * Convert the texture to three.js {@link https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 | JSON Object/Scene format}.
      * @param meta Optional object containing metadata.
      */
-    toJSON(meta: any): any;
+    toJSON(meta?: string | {}): {};
 
     /**
      * Frees the GPU-related resources allocated by this instance

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -138,18 +138,20 @@ export class Texture extends EventDispatcher {
      * **WEBGL2** does not have this limitation.
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @see {@link wrapT}
+     * @see {@link repeat}
      * @defaultValue {@link THREE.ClampToEdgeWrapping}
      */
     wrapS: Wrapping;
 
     /**
-     * This defines how the {@link Texture} is wrapped **vertically** and corresponds to *V* in UV mapping.
+     * This defines how the {@link Texture} is wrapped *vertically* and corresponds to **V** in UV mapping.
      * @remarks for **WEBGL1** - tiling of images in textures only functions if image dimensions are powers of two
      * (2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...) in terms of pixels.
      * Individual dimensions need not be equal, but each must be a power of two. This is a limitation of WebGL1, not three.js.
      * **WEBGL2** does not have this limitation.
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @see {@link wrapS}
+     * @see {@link repeat}
      * @defaultValue {@link THREE.ClampToEdgeWrapping}
      */
     wrapT: Wrapping;
@@ -190,6 +192,15 @@ export class Texture extends EventDispatcher {
     format: PixelFormat;
 
     /**
+     * This must correspond to the {@link Texture.format | .format}.
+     * @remarks {@link THREE.UnsignedByteType}, is the type most used by Texture formats.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link THREE.TextureDataType}
+     * @defaultValue {@link THREE.UnsignedByteType}
+     */
+    type: TextureDataType;
+
+    /**
      * The GPU Pixel Format allows the developer to specify how the data is going to be stored on the GPU.
      * @remarks Compatible only with {@link WebGL2RenderingContext | WebGL 2 Rendering Context}.
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
@@ -198,97 +209,158 @@ export class Texture extends EventDispatcher {
     internalFormat: PixelFormatGPU | null;
 
     /**
-     * @default THREE.UnsignedByteType
-     */
-    type: TextureDataType;
-
-    /**
-     * @default new THREE.Matrix3()
+     * The uv-transform matrix for the texture.
+     * @remarks
+     * When {@link Texture.matrixAutoUpdate | .matrixAutoUpdate} property is `true`.
+     * Will be updated by the renderer from the properties:
+     *  - {@link Texture.offset | .offset}
+     *  - {@link Texture.repeat | .repeat}
+     *  - {@link Texture.rotation | .rotation}
+     *  - {@link Texture.center | .center}
+     * @remarks
+     * When {@link Texture.matrixAutoUpdate | .matrixAutoUpdate} property is `false`.
+     * This matrix may be set manually.
+     * @see {@link matrixAutoUpdate | .matrixAutoUpdate}
+     * @defaultValue `new THREE.Matrix3()`
      */
     matrix: Matrix3;
 
     /**
-     * @default true
+     * Whether is to update the texture's uv-transform {@link matrix | .matrix}.
+     * @remarks Set this to `false` if you are specifying the uv-transform {@link matrix} directly.
+     * @see {@link matrix | .matrix}
+     * @defaultValue `true`
      */
     matrixAutoUpdate: boolean;
 
     /**
+     *
      * @default new THREE.Vector2( 0, 0 )
      */
     offset: Vector2;
 
     /**
-     * @default new THREE.Vector2( 1, 1 )
+     * How many times the texture is repeated across the surface, in each direction **U** and **V**.
+     * @remarks
+     * If repeat is set greater than `1` in either direction, the corresponding *Wrap* parameter should
+     * also be set to {@link THREE.RepeatWrapping} or {@link THREE.MirroredRepeatWrapping} to achieve the desired tiling effect.
+     * @remarks
+     * Setting different repeat values for textures is restricted in the same way like {@link .offset | .offset}.
+     * @see {@link wrapS}
+     * @see {@link wrapT}
+     * @defaultValue `new THREE.Vector2( 1, 1 )`
      */
     repeat: Vector2;
 
     /**
-     * @default new THREE.Vector2( 0, 0 )
+     * The point around which rotation occurs.
+     * @remarks A value of `(0.5, 0.5)` corresponds to the center of the texture.
+     * @defaultValue `new THREE.Vector2( 0, 0 )`, _lower left._
      */
     center: Vector2;
 
     /**
-     * @default 0
+     * How much the texture is rotated around the center point, in radians.
+     * @remarks Positive values are counter-clockwise.
+     * @defaultValue `0`
      */
     rotation: number;
 
     /**
-     * @default true
+     * Whether to generate mipmaps, _(if possible)_ for a texture.
+     * @remarks Set this to false if you are creating mipmaps manually.
+     * @defaultValue true
      */
     generateMipmaps: boolean;
 
     /**
-     * @default false
+     * If set to `true`, the alpha channel, if present, is multiplied into the color channels when the texture is uploaded to the GPU.
+     * @remarks
+     * Note that this property has no effect for {@link https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap | ImageBitmap}.
+     * You need to configure on bitmap creation instead. See {@link THREE.ImageBitmapLoader | ImageBitmapLoader}.
+     * @see {@link THREE.ImageBitmapLoader | ImageBitmapLoader}.
+     * @defaultValue `false`
      */
     premultiplyAlpha: boolean;
 
     /**
-     * @default true
+     * If set to `true`, the texture is flipped along the vertical axis when uploaded to the GPU.
+     * @remarks
+     * Note that this property has no effect for {@link https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap | ImageBitmap}.
+     * You need to configure on bitmap creation instead. See {@link THREE.ImageBitmapLoader | ImageBitmapLoader}.
+     * @see {@link THREE.ImageBitmapLoader | ImageBitmapLoader}.
+     * @defaultValue `true`
      */
     flipY: boolean;
 
     /**
-     * @default 4
+     * Specifies the alignment requirements for the start of each pixel row in memory.
+     * @remarks
+     * The allowable values are:
+     *  - `1` (byte-alignment)
+     *  - `2` (rows aligned to even-numbered bytes)
+     *  - `4` (word-alignment)
+     *  - `8` (rows start on double-word boundaries).
+     * @see {@link http://www.khronos.org/opengles/sdk/docs/man/xhtml/glPixelStorei.xml | glPixelStorei} for more information.
+     * @defaultValue 4
      */
     unpackAlignment: number;
 
     /**
-     * @default THREE.LinearEncoding
+     * The {@link Textures | {@link Texture} constants} page for details of other formats.
+     * @remarks
+     * Values of {@link encoding} !== {@link THREE.LinearEncoding} are only supported on _map_, _envMap_ and _emissiveMap_.
+     * @remarks
+     * Note that if this value is changed on a texture after the material has been used, it is necessary to trigger a {@link THREE.Material.needsUpdate} for this value to be realized in the shader.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link THREE.TextureDataType}
+     * @defaultValue {@link THREE.LinearEncoding}
      */
     encoding: TextureEncoding;
 
     /**
-     * @default false
+     * Indicates whether a texture belongs to a render target or not
+     * @defaultValue `false`
      */
     isRenderTargetTexture: boolean;
 
     /**
-     * @default false
+     * Indicates whether this texture should be processed by {@link THREE.PMREMGenerator} or not.
+     * @remarks Only relevant for render target textures.
+     * @defaultValue `false`
      */
     needsPMREMUpdate: boolean;
 
     /**
-     * An object that can be used to store custom data about the Material. It should not hold references to functions as these will not be cloned.
-     * @default {}
+     * An object that can be used to store custom data about the texture.
+     * @remarks It should not hold references to functions as these will not be cloned.
+     * @defaultValue `{}`
      */
     userData: any;
 
     /**
-     * @default 0
+     * This starts at `0` and counts how many times {@link needsUpdate | .needsUpdate} is set to `true`.
+     * @remarks Expects a `Integer`
+     * @defaultValue `0``
      */
     version: number;
-    set needsUpdate(value: boolean);
 
-    onUpdate: () => void;
+    /**
+     * Set this to `true` to trigger an update next time the {@link Texture} is used. Particularly important for setting the wrap mode.
+     */
+    set needsUpdate(value: boolean);
 
     static DEFAULT_ANISOTROPY: number;
     static DEFAULT_IMAGE: any;
     static DEFAULT_MAPPING: Mapping;
 
+    onUpdate: () => void;
+
     clone(): this;
     copy(source: Texture): this;
     toJSON(meta: any): any;
-    dispose(): void;
     transformUv(uv: Vector2): Vector2;
     updateMatrix(): void;
+
+    dispose(): void;
 }

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -12,6 +12,7 @@ import {
     MagnificationTextureFilter,
     MinificationTextureFilter,
     AnyPixelFormat,
+    AnyMapping,
 } from '../constants';
 
 /** Shim for OffscreenCanvas. */
@@ -35,9 +36,8 @@ export interface OffscreenCanvas extends EventTarget {}
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
  * @see {@link https://threejs.org/docs/index.html#api/en/textures/Texture | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/Texture.js | Source}
- * @typeParam TPixelFormat - Used for better support for SubTypes of Texture. Instances of {@link Texture} should use the default {@link THREE.PixelFormat}.
  */
-export class Texture<TPixelFormat extends AnyPixelFormat = PixelFormat> extends EventDispatcher {
+export class Texture extends EventDispatcher {
     /**
      * This creates a new {@link THREE.Texture | Texture} object.
      * @param image See {@link Texture.image | .image}. Default {@link THREE.Texture.DEFAULT_IMAGE}
@@ -119,7 +119,7 @@ export class Texture<TPixelFormat extends AnyPixelFormat = PixelFormat> extends 
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @defaultValue _value of_ {@link THREE.Texture.DEFAULT_MAPPING}
      */
-    mapping: Mapping;
+    mapping: AnyMapping;
 
     /**
      * This defines how the {@link Texture} is wrapped *horizontally* and corresponds to **U** in UV mapping.
@@ -180,7 +180,7 @@ export class Texture<TPixelFormat extends AnyPixelFormat = PixelFormat> extends 
      * @see {@link THREE.PixelFormat}
      * @defaultValue {@link THREE.RGBAFormat}.
      */
-    format: TPixelFormat;
+    format: AnyPixelFormat;
 
     /**
      * This must correspond to the {@link Texture.format | .format}.

--- a/types/three/src/textures/VideoTexture.d.ts
+++ b/types/three/src/textures/VideoTexture.d.ts
@@ -2,7 +2,6 @@ import { Texture } from './Texture';
 import {
     Mapping,
     Wrapping,
-    TextureFilter,
     PixelFormat,
     TextureDataType,
     MagnificationTextureFilter,
@@ -46,8 +45,8 @@ export class VideoTexture extends Texture {
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
-        magFilter?: TextureFilter,
-        minFilter?: TextureFilter,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
         format?: PixelFormat,
         type?: TextureDataType,
         anisotropy?: number,

--- a/types/three/src/textures/VideoTexture.d.ts
+++ b/types/three/src/textures/VideoTexture.d.ts
@@ -1,17 +1,45 @@
 import { Texture } from './Texture';
-import { Mapping, Wrapping, TextureFilter, PixelFormat, TextureDataType } from '../constants';
+import {
+    Mapping,
+    Wrapping,
+    TextureFilter,
+    PixelFormat,
+    TextureDataType,
+    MagnificationTextureFilter,
+    MinificationTextureFilter,
+} from '../constants';
 
+/**
+ * Creates a texture for use with a video.
+ * @remarks
+ * Note: After the initial use of a texture, the video cannot be changed
+ * Instead, call {@link dispose | .dispose()} on the texture and instantiate a new one.
+ * @example
+ * ```typescript
+ * // assuming you have created a HTML video element with id="video"
+ * const video = document.getElementById('video');
+ * const texture = new THREE.VideoTexture(video);
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl_materials_video | materials / video}
+ * @see Example: {@link https://threejs.org/examples/#webgl_materials_video_webcam | materials / video / webcam}
+ * @see Example: {@link https://threejs.org/examples/#webgl_video_kinect | video / kinect}
+ * @see Example: {@link https://threejs.org/examples/#webgl_video_panorama_equirectangular | video / panorama / equirectangular}
+ * @see Example: {@link https://threejs.org/examples/#webxr_vr_video | vr / video}
+ * @see {@link https://threejs.org/docs/index.html#api/en/Textures/VideoTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/VideoTexture.js | Source}
+ */
 export class VideoTexture extends Texture {
     /**
-     * @param video
-     * @param [mapping=THREE.Texture.DEFAULT_MAPPING]
-     * @param [wrapS=THREE.ClampToEdgeWrapping]
-     * @param [wrapT=THREE.ClampToEdgeWrapping]
-     * @param [magFilter=THREE.LinearFilter]
-     * @param [minFilter=THREE.LinearFilter]
-     * @param [format=THREE.RGBAFormat]
-     * @param [type=THREE.UnsignedByteType]
-     * @param [anisotropy=1]
+     * Create a new instance of {@link VideoTexture}
+     * @param video The video element to use as the texture.
+     * @param mapping See {@link Texture.mapping | .mapping}. Default {@link THREE.Texture.DEFAULT_MAPPING}
+     * @param wrapS See {@link Texture.wrapS | .wrapS}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param wrapT See {@link Texture.wrapT | .wrapT}. Default {@link THREE.ClampToEdgeWrapping}
+     * @param magFilter See {@link Texture.magFilter | .magFilter}. Default {@link THREE.LinearFilter}
+     * @param minFilter  See {@link Texture.minFilter | .minFilter}. Default {@link THREE.LinearFilter}
+     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}
+     * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
+     * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
      */
     constructor(
         video: HTMLVideoElement,
@@ -25,10 +53,39 @@ export class VideoTexture extends Texture {
         anisotropy?: number,
     );
 
+    /**
+     * Read-only flag to check if a given object is of type {@link VideoTexture}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
     readonly isVideoTexture: true;
 
     /**
-     * @default false
+     * @override
+     * @defaultValue {@link THREE.LinearFilter}
+     */
+    magFilter: MagnificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue {@link THREE.LinearFilter}
+     */
+    minFilter: MinificationTextureFilter;
+
+    /**
+     * @override
+     * @defaultValue `false`
      */
     generateMipmaps: boolean;
+
+    /**
+     * @override
+     * You will **not** need to set this manually here as it is handled by the {@link update | update()} method.
+     */
+    set needsUpdate(value: boolean);
+
+    /**
+     * This is called automatically and sets {@link needsUpdate | .needsUpdate } to `true` every time a new frame is available.
+     */
+    update(): void;
 }

--- a/types/three/src/textures/VideoTexture.d.ts
+++ b/types/three/src/textures/VideoTexture.d.ts
@@ -25,8 +25,8 @@ import {
  * @see Example: {@link https://threejs.org/examples/#webgl_video_kinect | video / kinect}
  * @see Example: {@link https://threejs.org/examples/#webgl_video_panorama_equirectangular | video / panorama / equirectangular}
  * @see Example: {@link https://threejs.org/examples/#webxr_vr_video | vr / video}
- * @see {@link https://threejs.org/docs/index.html#api/en/Textures/VideoTexture | Official Documentation}
- * @see {@link https://github.com/mrdoob/three.js/blob/master/src/Textures/VideoTexture.js | Source}
+ * @see {@link https://threejs.org/docs/index.html#api/en/textures/VideoTexture | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/VideoTexture.js | Source}
  */
 export class VideoTexture extends Texture {
     /**

--- a/types/three/src/textures/types.d.ts
+++ b/types/three/src/textures/types.d.ts
@@ -1,0 +1,9 @@
+export interface TextureImageData {
+    readonly data: Uint8ClampedArray;
+    readonly height: number;
+    readonly width: number;
+}
+
+export interface Texture3DImageData extends TextureImageData {
+    depth: number;
+}

--- a/types/three/src/textures/types.d.ts
+++ b/types/three/src/textures/types.d.ts
@@ -5,5 +5,5 @@ export interface TextureImageData {
 }
 
 export interface Texture3DImageData extends TextureImageData {
-    depth: number;
+    readonly depth: number;
 }


### PR DESCRIPTION
### Why

The TSDocs for many classes are missing or outdated.
Some Typing information is missing and could be improved.
Missing overwriting information in Textures classes.

### What

- Improve documentation for all scenes.* and textures.* classes/files.
- Update some Types 
- Update Defalts values for overwriting properties.
- Code Format
- Normalize some TSDOcs across many other classes.
- `Texture`, `format` and `mapping` types updated to allow any sub-texture types.
- Force `format` to be required for `CompressedTexture` and `CompressedArrayTexture`. Internally the default value is a non-compressed constant from `Texture` and not compatible with `CompressedTexture`.


### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

