### PR TITLE
fix: support DisplayP3ColorSpace in other ColorManagement methods

### DIFF
--- a/types/three/src/math/ColorManagement.d.ts
+++ b/types/three/src/math/ColorManagement.d.ts
@@ -24,11 +24,11 @@ export namespace ColorManagement {
 
     function fromWorkingColorSpace(
         color: Color,
-        targetColorSpace: typeof SRGBColorSpace | typeof LinearSRGBColorSpace,
+        targetColorSpace: typeof SRGBColorSpace | typeof LinearSRGBColorSpace | typeof DisplayP3ColorSpace,
     ): Color;
 
     function toWorkingColorSpace(
         color: Color,
-        sourceColorSpace: typeof SRGBColorSpace | typeof LinearSRGBColorSpace,
+        sourceColorSpace: typeof SRGBColorSpace | typeof LinearSRGBColorSpace | typeof DisplayP3ColorSpace,
     ): Color;
 }


### PR DESCRIPTION
### Why

Missed in https://github.com/three-types/three-ts-types/pull/377, I believe these other `ColorManagement` methods also support `DisplayP3ColorSpace` since [they just call `convert` under the hood](https://github.com/mrdoob/three.js/blob/dev/src/math/ColorManagement.js#L121-L131).

### What

Added `DisplayP3ColorSpace` to more method parameters.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
