### PR TITLE
Revert MOUSE and TOUCH back to enums

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -1,4 +1,4 @@
-import { Camera, MOUSE, MouseButton, TOUCH, TouchCount, Vector3 } from '../../../src/Three';
+import { Camera, MOUSE, TOUCH, Vector3 } from '../../../src/Three';
 
 /**
  * Orbit controls allow the camera to orbit around a target.
@@ -193,13 +193,13 @@ export class OrbitControls {
      * This object contains references to the mouse actions used
      * by the controls.
      */
-    mouseButtons: Partial<{ LEFT: MouseButton; MIDDLE: MouseButton; RIGHT: MouseButton }>;
+    mouseButtons: Partial<{ LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE }>;
 
     /**
      * This object contains references to the touch actions used by
      * the controls.
      */
-    touches: Partial<{ ONE: TouchCount; TWO: TouchCount }>;
+    touches: Partial<{ ONE: TOUCH; TWO: TOUCH }>;
 
     /**
      * Used internally by the .saveState and .reset methods.

--- a/types/three/examples/jsm/controls/TrackballControls.d.ts
+++ b/types/three/examples/jsm/controls/TrackballControls.d.ts
@@ -1,4 +1,4 @@
-import { Camera, EventDispatcher, MOUSE, MouseButton, Vector3 } from '../../../src/Three';
+import { Camera, EventDispatcher, MOUSE, Vector3 } from '../../../src/Three';
 
 export class TrackballControls extends EventDispatcher {
     constructor(object: Camera, domElement?: HTMLElement);
@@ -21,7 +21,7 @@ export class TrackballControls extends EventDispatcher {
     minDistance: number;
     maxDistance: number;
     keys: string[];
-    mouseButtons: { LEFT: MouseButton; MIDDLE: MouseButton; RIGHT: MouseButton };
+    mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
 
     target: Vector3;
     position0: Vector3;

--- a/types/three/examples/jsm/controls/TransformControls.d.ts
+++ b/types/three/examples/jsm/controls/TransformControls.d.ts
@@ -1,4 +1,4 @@
-import { Object3D, Camera, MOUSE, Raycaster, Mesh, Vector3, Quaternion, MouseButton } from '../../../src/Three';
+import { Object3D, Camera, MOUSE, Raycaster, Mesh, Vector3, Quaternion } from '../../../src/Three';
 
 export class TransformControls extends Object3D {
     constructor(object: Camera, domElement?: HTMLElement);
@@ -21,11 +21,7 @@ export class TransformControls extends Object3D {
     showY: boolean;
     showZ: boolean;
     readonly isTransformControls: true;
-    mouseButtons: {
-        LEFT: MouseButton;
-        MIDDLE: MouseButton;
-        RIGHT: MouseButton;
-    };
+    mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
 
     attach(object: Object3D): this;
     detach(): this;

--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -1,25 +1,21 @@
 export const REVISION: string;
 
 // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent.button
-export const MOUSE: {
-    LEFT: 0;
-    MIDDLE: 1;
-    RIGHT: 2;
-    ROTATE: 0;
-    DOLLY: 1;
-    PAN: 2;
-};
+export enum MOUSE {
+    LEFT = 0,
+    MIDDLE = 1,
+    RIGHT = 2,
+    ROTATE = 0,
+    DOLLY = 1,
+    PAN = 2,
+}
 
-export type MouseButton = 0 | 1 | 2;
-
-export const TOUCH: {
-    ROTATE: 0;
-    PAN: 1;
-    DOLLY_PAN: 2;
-    DOLLY_ROTATE: 3;
-};
-
-export type TouchCount = 0 | 1 | 2 | 3;
+export enum TOUCH {
+    ROTATE = 0,
+    PAN = 1,
+    DOLLY_PAN = 2,
+    DOLLY_ROTATE = 3,
+}
 
 // GL STATE CONSTANTS
 export const CullFaceNone: 0;


### PR DESCRIPTION
### Why

https://github.com/three-types/three-ts-types/pull/349 made all of the constants non-enums. While this makes sense for most of the constants, the `MOUSE` and `TOUCH` were the only constants that were indistinguishable from an enum. In an effort to avoid making a breaking change, I think it makes sense to convert them back to enums until it causes issues.

### What

Revert MOUSE and TOUCH back to enums

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
