### PR TITLE
fix: correct GLTFParser.loadSkin return type

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -16,6 +16,7 @@ import {
     TextureLoader,
     FileLoader,
     ImageBitmapLoader,
+    Skeleton,
 } from '../../../src/Three';
 
 import { DRACOLoader } from './DRACOLoader';
@@ -131,10 +132,7 @@ export class GLTFParser {
     ) => Promise<BufferGeometry[]>;
     loadMesh: (meshIndex: number) => Promise<Group | Mesh | SkinnedMesh>;
     loadCamera: (cameraIndex: number) => Promise<Camera>;
-    loadSkin: (skinIndex: number) => Promise<{
-        joints: number[];
-        inverseBindMatrices?: BufferAttribute | InterleavedBufferAttribute | undefined;
-    }>;
+    loadSkin: (skinIndex: number) => Promise<Skeleton>;
     loadAnimation: (animationIndex: number) => Promise<AnimationClip>;
     loadNode: (nodeIndex: number) => Promise<Object3D>;
     loadScene: () => Promise<Group>;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

`GLTFParser.loadSkin()` return type doesn't match implementation.

See [JSDoc signature](https://github.com/mrdoob/three.js/blob/4e361e96bc8a1513febb349dde9f1f3be7bf5ec0/examples/jsm/loaders/GLTFLoader.js#L3694-L3699) and [return statement](https://github.com/mrdoob/three.js/blob/4e361e96bc8a1513febb349dde9f1f3be7bf5ec0/examples/jsm/loaders/GLTFLoader.js#L3758)

### What

Changed `GLTFParser.loadSkin()` return type to `Promise<Skeleton>`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
