### PR TITLE
Update documentation for ThreeJS extra Classes, with some Typing improvements

### DIFF
--- a/types/three/examples/jsm/loaders/SVGLoader.d.ts
+++ b/types/three/examples/jsm/loaders/SVGLoader.d.ts
@@ -1,4 +1,4 @@
-import { Loader, LoadingManager, ShapePath, BufferGeometry, Vector3, Shape } from '../../../src/Three';
+import { Loader, LoadingManager, ShapePath, BufferGeometry, Vector3, Shape, Vector2 } from '../../../src/Three';
 
 export interface SVGResultPaths extends ShapePath {
     userData?:
@@ -43,14 +43,25 @@ export class SVGLoader extends Loader {
         lineCap?: string,
         miterLimit?: number,
     ): StrokeStyle;
+
+    /**
+     * Generates a stroke with some witdh around the given path.
+     * @remarks The path can be open or closed (last point equals to first point)
+     * @param points  Array of Vector2D (the path). Minimum 2 points.
+     * @param style  Object with SVG properties as returned by SVGLoader.getStrokeStyle(), or SVGLoader.parse() in the path.userData.style object
+     * @param arcDivisions Arc divisions for round joins and endcaps. (Optional)
+     * @param minDistance Points closer to this distance will be merged. (Optional)
+     * @returns BufferGeometry with stroke triangles (In plane z = 0). UV coordinates are generated ('u' along path. 'v' across it, from left to right)
+     */
     static pointsToStroke(
-        points: Vector3[],
+        points: Vector2[],
         style: StrokeStyle,
         arcDivisions?: number,
         minDistance?: number,
     ): BufferGeometry;
+
     static pointsToStrokeWithBuffers(
-        points: Vector3[],
+        points: Vector2[],
         style: StrokeStyle,
         arcDivisions?: number,
         minDistance?: number,
@@ -59,5 +70,6 @@ export class SVGLoader extends Loader {
         uvs?: number[],
         vertexOffset?: number,
     ): number;
+
     static createShapes(shapePath: ShapePath): Shape[];
 }

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -66,6 +66,7 @@ export * from './extras/core/Path';
 export * from './extras/core/ShapePath';
 export * from './extras/core/CurvePath';
 export * from './extras/core/Curve';
+export * from './extras/core/Interpolations';
 export * as DataUtils from './extras/DataUtils';
 export * from './extras/ImageUtils';
 export * from './extras/ShapeUtils';

--- a/types/three/src/extras/DataUtils.d.ts
+++ b/types/three/src/extras/DataUtils.d.ts
@@ -1,2 +1,15 @@
+/**
+ * Returns a half precision floating point value from the given single precision floating point value.
+ * @param val A single precision floating point value.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/DataUtils | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/DataUtils.js | Source}
+ */
 export function toHalfFloat(val: number): number;
+
+/**
+ * Returns a single precision floating point value from the given half precision floating point value.
+ * @param val A half precision floating point value.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/DataUtils | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/DataUtils.js | Source}
+ */
 export function fromHalfFloat(val: number): number;

--- a/types/three/src/extras/Earcut.d.ts
+++ b/types/three/src/extras/Earcut.d.ts
@@ -1,3 +1,15 @@
+/**
+ * An implementation of the {@link Earcut} polygon triangulation algorithm
+ * @remarks
+ * The code is a port of {@link https://github.com/mapbox/earcut | mapbox/earcut}.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/Earcut | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/Earcut.js | Source}
+ */
 export const Earcut: {
+    /**
+     * Triangulates the given shape definition by returning an array of triangles
+     * @remarks
+     * A triangle is defined by three consecutive integers representing vertex indices.
+     */
     triangulate(data: number[], holeIndices?: number[], dim?: number): number[];
 };

--- a/types/three/src/extras/ImageUtils.d.ts
+++ b/types/three/src/extras/ImageUtils.d.ts
@@ -1,33 +1,33 @@
 import { Mapping } from '../constants';
 import { Texture } from '../textures/Texture';
 
+/**
+ * A class containing utility functions for images.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/ImageUtils | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/ImageUtils.js | Source}
+ */
 export namespace ImageUtils {
-    function getDataURL(image: any): string;
+    /**
+     * Returns a data URI containing a representation of the given image.
+     * @param image The image object.
+     */
+    function getDataURL(
+        image: HTMLImageElement | HTMLCanvasElement | CanvasImageSource | ImageBitmap | ImageData,
+    ): string;
 
     /**
-     * @deprecated
+     * Converts the given sRGB image data to linear color space.
+     * @param image
      */
-    let crossOrigin: string;
+    function sRGBToLinear(image: HTMLImageElement | HTMLCanvasElement | ImageBitmap): HTMLCanvasElement;
 
     /**
-     * @deprecated Use {@link TextureLoader THREE.TextureLoader()} instead.
+     * Converts the given sRGB image data to linear color space.
+     * @param image
      */
-    function loadTexture(
-        url: string,
-        mapping?: Mapping,
-        onLoad?: (texture: Texture) => void,
-        onError?: (message: string) => void,
-    ): Texture;
-
-    /**
-     * @deprecated Use {@link CubeTextureLoader THREE.CubeTextureLoader()} instead.
-     */
-    function loadTextureCube(
-        array: string[],
-        mapping?: Mapping,
-        onLoad?: (texture: Texture) => void,
-        onError?: (message: string) => void,
-    ): Texture;
-
-    function sRGBToLinear(image: any): HTMLCanvasElement | { data: number[]; width: number; height: number };
+    function sRGBToLinear(image: ImageData): {
+        data: ImageData['data'];
+        width: ImageData['width'];
+        height: ImageData['height'];
+    };
 }

--- a/types/three/src/extras/PMREMGenerator.d.ts
+++ b/types/three/src/extras/PMREMGenerator.d.ts
@@ -4,12 +4,78 @@ import { Texture } from '../textures/Texture';
 import { CubeTexture } from '../textures/CubeTexture';
 import { Scene } from '../scenes/Scene';
 
+/**
+ * This class generates a Prefiltered, Mipmapped Radiance Environment Map (PMREM) from a cubeMap environment texture.
+ * @remarks
+ * This allows different levels of blur to be quickly accessed based on material roughness
+ * Unlike a traditional mipmap chain, it only goes down to the LOD_MIN level (above), and then creates extra even more filtered 'mips' at the same LOD_MIN resolution,
+ * associated with higher roughness levels
+ * In this way we maintain resolution to smoothly interpolate diffuse lighting while limiting sampling computation.
+ * @remarks
+ * Note: The minimum {@link THREE.MeshStandardMaterial | MeshStandardMaterial}'s roughness depends on the size of the provided texture
+ * If your render has small dimensions or the shiny parts have a lot of curvature, you may still be able to get away with a smaller texture size.
+ *
+ * | texture size | minimum roughness  |
+ * |--------------|--------------------|
+ * | 16           | 0.21               |
+ * | 32           | 0.15               |
+ * | 64           | 0.11               |
+ * | 128          | 0.076              |
+ * | 256          | 0.054              |
+ * | 512          | 0.038              |
+ * | 1024         | 0.027              |
+ *
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/PMREMGenerator | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/PMREMGenerator.js | Source}
+ */
 export class PMREMGenerator {
+    /**
+     * This constructor creates a new PMREMGenerator.
+     * @param renderer
+     */
     constructor(renderer: WebGLRenderer);
+
+    /**
+     * Generates a PMREM from a supplied Scene, which can be faster than using an image if networking bandwidth is low
+     * @remarks
+     * Optional near and far planes ensure the scene is rendered in its entirety (the cubeCamera is placed at the origin).
+     * @param scene The given scene.
+     * @param sigma Specifies a blur radius in radians to be applied to the scene before PMREM generation. Default `0`.
+     * @param near The near plane value. Default `0.1`.
+     * @param far The far plane value. Default `100`.
+     */
     fromScene(scene: Scene, sigma?: number, near?: number, far?: number): WebGLRenderTarget;
+
+    /**
+     * Generates a PMREM from an equirectangular texture.
+     * @param equirectangular The equirectangular texture.
+     */
     fromEquirectangular(equirectangular: Texture, renderTarget?: WebGLRenderTarget | null): WebGLRenderTarget;
+
+    /**
+     * Generates a PMREM from an cubemap texture.
+     * @param cubemap The cubemap texture.
+     */
     fromCubemap(cubemap: CubeTexture, renderTarget?: WebGLRenderTarget | null): WebGLRenderTarget;
+
+    /**
+     * Pre-compiles the cubemap shader
+     * @remarks
+     * You can get faster start-up by invoking this method during your texture's network fetch for increased concurrency.
+     */
     compileCubemapShader(): void;
+
+    /**
+     * Pre-compiles the equirectangular shader
+     * @remarks
+     * You can get faster start-up by invoking this method during your texture's network fetch for increased concurrency.
+     */
     compileEquirectangularShader(): void;
+
+    /**
+     * Frees the GPU-related resources allocated by this instance
+     * @remarks
+     * Call this method whenever this instance is no longer used in your app.
+     */
     dispose(): void;
 }

--- a/types/three/src/extras/ShapeUtils.d.ts
+++ b/types/three/src/extras/ShapeUtils.d.ts
@@ -3,8 +3,26 @@ export interface Vec2 {
     y: number;
 }
 
+/**
+ * A class containing utility functions for shapes.
+ * @remarks Note that these are all linear functions so it is necessary to calculate separately for x, y (and z, w if present) components of a vector.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/ShapeUtils | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/ShapeUtils.js | Source}
+ */
 export namespace ShapeUtils {
+    /**
+     * Calculate area of a ( 2D ) contour polygon.
+     */
     function area(contour: Vec2[]): number;
-    function triangulateShape(contour: Vec2[], holes: Vec2[][]): number[][];
+
+    /**
+     * Note that this is a linear function so it is necessary to calculate separately for x, y components of a polygon.
+     * @remarks Used internally by {@link THREE.Path | Path}, {@link THREE.ExtrudeGeometry | ExtrudeGeometry} and {@link THREE.ShapeGeometry | ShapeGeometry}.
+     */
     function isClockWise(pts: Vec2[]): boolean;
+
+    /**
+     * Used internally by {@link THREE.ExtrudeGeometry | ExtrudeGeometry} and {@link THREE.ShapeGeometry | ShapeGeometry} to calculate faces in shapes with holes.
+     */
+    function triangulateShape(contour: Vec2[], holes: Vec2[][]): number[][];
 }

--- a/types/three/src/extras/core/Curve.d.ts
+++ b/types/three/src/extras/core/Curve.d.ts
@@ -25,11 +25,8 @@ import { Vector3 } from './../../math/Vector3';
  * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Curve | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Curve.js | Source}
  */
-export class Curve<T extends Vector> {
-    /**
-     * This constructor creates a new Curve.
-     */
-    constructor();
+export abstract class Curve<T extends Vector> {
+    protected constructor();
 
     /**
      * A Read-only _string_ to check if `this` object type.
@@ -50,14 +47,14 @@ export class Curve<T extends Vector> {
     /**
      * Returns a vector for a given position on the curve.
      * @param t A position on the curve. Must be in the range `[ 0, 1 ]`. Expects a `Float`
-     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created.
+     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created. Default `new T`.
      */
     getPoint(t: number, optionalTarget?: T): T;
 
     /**
      * Returns a vector for a given position on the {@link Curve} according to the arc length.
      * @param u A position on the {@link Curve} according to the arc length. Must be in the range `[ 0, 1 ]`. Expects a `Float`
-     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created.
+     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created. Default `new T`.
      */
     getPointAt(u: number, optionalTarget?: T): T;
 

--- a/types/three/src/extras/core/Curve.d.ts
+++ b/types/three/src/extras/core/Curve.d.ts
@@ -1,84 +1,131 @@
 import { Vector } from './../../math/Vector2';
 import { Vector3 } from './../../math/Vector3';
 
-// Extras / Core /////////////////////////////////////////////////////////////////////
-
 /**
- * An extensible curve object which contains methods for interpolation
- * class Curve<T extends Vector>
+ * An abstract base class for creating a {@link Curve} object that contains methods for interpolation
+ * @remarks
+ * For an array of Curves see {@link THREE.CurvePath | CurvePath}.
+ * @remarks
+ * This following curves inherit from THREE.Curve:
+ *
+ * **2D curves**
+ *  - {@link THREE.ArcCurve}
+ *  - {@link THREE.CubicBezierCurve}
+ *  - {@link THREE.EllipseCurve}
+ *  - {@link THREE.LineCurve}
+ *  - {@link THREE.QuadraticBezierCurve}
+ *  - {@link THREE.SplineCurve}
+ *
+ * **3D curves**
+ *  - {@link THREE.CatmullRomCurve3}
+ *  - {@link THREE.CubicBezierCurve3}
+ *  - {@link THREE.LineCurve3}
+ *  - {@link THREE.QuadraticBezierCurve3}
+ *
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Curve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Curve.js | Source}
  */
 export class Curve<T extends Vector> {
     /**
-     * @default 'Curve'
+     * This constructor creates a new Curve.
      */
-    type: string;
+    constructor();
 
     /**
-     * This value determines the amount of divisions when calculating the cumulative segment lengths of a curve via .getLengths.
-     * To ensure precision when using methods like .getSpacedPoints, it is recommended to increase .arcLengthDivisions if the curve is very large.
-     * @default 200
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `Curve`
+     */
+    readonly type: string | 'Curve';
+
+    /**
+     * This value determines the amount of divisions when calculating the cumulative segment lengths of a {@link Curve}
+     * via {@link .getLengths}.
+     * To ensure precision when using methods like {@link .getSpacedPoints}, it is recommended to increase {@link .arcLengthDivisions} if the {@link Curve} is very large.
+     * @defaultValue `200`
+     * @remarks Expects a `Integer`
      */
     arcLengthDivisions: number;
 
     /**
-     * Returns a vector for point t of the curve where t is between 0 and 1
-     * getPoint(t: number, optionalTarget?: T): T;
+     * Returns a vector for a given position on the curve.
+     * @param t A position on the curve. Must be in the range `[ 0, 1 ]`. Expects a `Float`
+     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created.
      */
     getPoint(t: number, optionalTarget?: T): T;
 
     /**
-     * Returns a vector for point at relative position in curve according to arc length
-     * getPointAt(u: number, optionalTarget?: T): T;
+     * Returns a vector for a given position on the {@link Curve} according to the arc length.
+     * @param u A position on the {@link Curve} according to the arc length. Must be in the range `[ 0, 1 ]`. Expects a `Float`
+     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created.
      */
     getPointAt(u: number, optionalTarget?: T): T;
 
     /**
-     * Get sequence of points using getPoint( t )
-     * getPoints(divisions?: number): T[];
+     * Returns a set of divisions `+1` points using {@link .getPoint | getPoint(t)}.
+     * @param divisions Number of pieces to divide the {@link Curve} into. Expects a `Integer`. Default `5`
      */
     getPoints(divisions?: number): T[];
 
     /**
-     * Get sequence of equi-spaced points using getPointAt( u )
-     * getSpacedPoints(divisions?: number): T[];
+     * Returns a set of divisions `+1` equi-spaced points using {@link .getPointAt | getPointAt(u)}.
+     * @param divisions Number of pieces to divide the {@link Curve} into. Expects a `Integer`. Default `5`
      */
     getSpacedPoints(divisions?: number): T[];
 
     /**
-     * Get total curve arc length
+     * Get total {@link Curve} arc length.
      */
     getLength(): number;
 
     /**
-     * Get list of cumulative segment lengths
+     * Get list of cumulative segment lengths.
+     * @param divisions Expects a `Integer`
      */
     getLengths(divisions?: number): number[];
 
     /**
      * Update the cumlative segment distance cache
+     * @remarks
+     * The method must be called every time {@link Curve} parameters are changed
+     * If an updated {@link Curve} is part of a composed {@link Curve} like {@link THREE.CurvePath | CurvePath},
+     * {@link .updateArcLengths}() must be called on the composed curve, too.
      */
     updateArcLengths(): void;
 
     /**
-     * Given u ( 0 .. 1 ), get a t to find p. This gives you points which are equi distance
+     * Given u in the range `[ 0, 1 ]`,
+     * @remarks
+     * `u` and `t` can then be used to give you points which are equidistant from the ends of the curve, using {@link .getPoint}.
+     * @param u Expects a `Float`
+     * @param distance Expects a `Float`
+     * @returns `t` also in the range `[ 0, 1 ]`. Expects a `Float`.
      */
     getUtoTmapping(u: number, distance: number): number;
 
     /**
-     * Returns a unit vector tangent at t. If the subclassed curve do not implement its tangent derivation, 2 points a
-     * small delta apart will be used to find its gradient which seems to give a reasonable approximation
-     * getTangent(t: number, optionalTarget?: T): T;
+     * Returns a unit vector tangent at t
+     * @remarks
+     * If the derived {@link Curve} does not implement its tangent derivation, two points a small delta apart will be used to find its gradient which seems to give a reasonable approximation.
+     * @param t A position on the curve. Must be in the range `[ 0, 1 ]`. Expects a `Float`
+     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created.
      */
     getTangent(t: number, optionalTarget?: T): T;
 
     /**
-     * Returns tangent at equidistance point u on the curve
-     * getTangentAt(u: number, optionalTarget?: T): T;
+     * Returns tangent at a point which is equidistant to the ends of the {@link Curve} from the point given in {@link .getTangent}.
+     * @param u A position on the {@link Curve} according to the arc length. Must be in the range `[ 0, 1 ]`. Expects a `Float`
+     * @param optionalTarget If specified, the result will be copied into this Vector, otherwise a new Vector will be created.
      */
     getTangentAt(u: number, optionalTarget?: T): T;
 
     /**
-     * Generate Frenet frames of the curve
+     * Generates the Frenet Frames
+     * @remarks
+     * Requires a {@link Curve} definition in 3D space
+     * Used in geometries like {@link THREE.TubeGeometry | TubeGeometry} or {@link THREE.ExtrudeGeometry | ExtrudeGeometry}.
+     * @param segments Expects a `Integer`
+     * @param closed
      */
     computeFrenetFrames(
         segments: number,
@@ -89,13 +136,24 @@ export class Curve<T extends Vector> {
         binormals: Vector3[];
     };
 
+    /**
+     * Creates a clone of this instance.
+     */
     clone(): this;
+    /**
+     * Copies another {@link Curve} object to this instance.
+     * @param source
+     */
     copy(source: Curve<T>): this;
-    toJSON(): object;
-    fromJSON(json: object): this;
 
     /**
-     * @deprecated since r84.
+     * Returns a JSON object representation of this instance.
      */
-    static create(constructorFunc: () => void, getPointFunc: () => void): () => void;
+    toJSON(): {};
+
+    /**
+     * Copies the data from the given JSON object to this instance.
+     * @param json
+     */
+    fromJSON(json: {}): this;
 }

--- a/types/three/src/extras/core/CurvePath.d.ts
+++ b/types/three/src/extras/core/CurvePath.d.ts
@@ -1,26 +1,68 @@
 import { Curve } from './Curve';
 import { Vector } from './../../math/Vector2';
 
+/**
+ * Curved Path - a curve path is simply a array of connected curves, but retains the api of a curve.
+ * @remarks
+ * A {@link CurvePath} is simply an array of connected curves, but retains the api of a curve.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/CurvePath | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/CurvePath.js | Source}
+ */
 export class CurvePath<T extends Vector> extends Curve<T> {
+    /**
+     * The constructor take no parameters.
+     */
     constructor();
 
     /**
-     * @default 'CurvePath'
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `CurvePath`
      */
-    type: string;
+    override readonly type: string | 'CurvePath';
 
     /**
-     * @default []
+     * The array of {@link Curve | Curves}.
+     * @defaultValue `[]`
      */
     curves: Array<Curve<T>>;
 
     /**
-     * @default false
+     * Whether or not to automatically close the path.
+     * @defaultValue false
      */
     autoClose: boolean;
 
+    /**
+     * Add a curve to the {@link .curves} array.
+     * @param curve
+     */
     add(curve: Curve<T>): void;
+    /**
+     * Adds a {@link LineCurve | lineCurve} to close the path.
+     */
     closePath(): void;
+
     getPoint(t: number, optionalTarget?: T): T;
+
+    /**
+     * Get list of cumulative curve lengths of the curves in the {@link .curves} array.
+     */
     getCurveLengths(): number[];
+
+    /**
+     * Returns an array of points representing a sequence of curves
+     * @remarks
+     * The `division` parameter defines the number of pieces each curve is divided into
+     * However, for optimization and quality purposes, the actual sampling resolution for each curve depends on its type
+     * For example, for a {@link THREE.LineCurve | LineCurve}, the returned number of points is always just 2.
+     * @param divisions Number of pieces to divide the curve into. Expects a `Integer`. Default `12`
+     */
+    override getPoints(divisions?: number): T[];
+
+    /**
+     * Returns a set of divisions `+1` equi-spaced points using {@link .getPointAt | getPointAt(u)}.
+     * @param divisions Number of pieces to divide the curve into. Expects a `Integer`. Default `40`
+     */
+    override getSpacedPoints(divisions?: number): T[];
 }

--- a/types/three/src/extras/core/Interpolations.d.ts
+++ b/types/three/src/extras/core/Interpolations.d.ts
@@ -5,6 +5,8 @@
  * @param p1 Expects a `Float`
  * @param p2 Expects a `Float`
  * @param p3 P0, p1, p2, the points defining the spline curve. Expects a `Float`
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Interpolations | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Interpolations.js | Source}
  */
 declare function CatmullRom(t: number, p0: number, p1: number, p2: number, p3: number): number;
 
@@ -14,6 +16,8 @@ declare function CatmullRom(t: number, p0: number, p1: number, p2: number, p3: n
  * @param p0 Expects a `Float`
  * @param p1 Expects a `Float`
  * @param p2 P0, p1, the starting, control and end points defining the curve. Expects a `Float`
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Interpolations | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Interpolations.js | Source}
  */
 declare function QuadraticBezier(t: number, p0: number, p1: number, p2: number): number;
 
@@ -24,6 +28,8 @@ declare function QuadraticBezier(t: number, p0: number, p1: number, p2: number):
  * @param p1 Expects a `Float`
  * @param p2 Expects a `Float`
  * @param p3 P0, p1, p2, the starting, control(twice) and end points defining the curve. Expects a `Float`
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Interpolations | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Interpolations.js | Source}
  */
 declare function CubicBezier(t: number, p0: number, p1: number, p2: number, p3: number): number;
 

--- a/types/three/src/extras/core/Interpolations.d.ts
+++ b/types/three/src/extras/core/Interpolations.d.ts
@@ -1,30 +1,30 @@
 /**
  * Used internally by {@link THREE.SplineCurve | SplineCurve}.
-* @param t Interpolation weight. Expects a `Float`
-* @param p0 Expects a `Float`
-* @param p1 Expects a `Float`
-* @param p2 Expects a `Float`
-* @param p3 P0, p1, p2, the points defining the spline curve. Expects a `Float`
+ * @param t Interpolation weight. Expects a `Float`
+ * @param p0 Expects a `Float`
+ * @param p1 Expects a `Float`
+ * @param p2 Expects a `Float`
+ * @param p3 P0, p1, p2, the points defining the spline curve. Expects a `Float`
  */
-declare function CatmullRom( t: number, p0: number, p1: number, p2: number, p3: number ) : number;
+declare function CatmullRom(t: number, p0: number, p1: number, p2: number, p3: number): number;
 
 /**
  * Used internally by {@link THREE.QuadraticBezierCurve3 | QuadraticBezierCurve3} and {@link THREE.QuadraticBezierCurve | QuadraticBezierCurve}.
-* @param t Interpolation weight. Expects a `Float`
-* @param p0 Expects a `Float`
-* @param p1 Expects a `Float`
-* @param p2 P0, p1, the starting, control and end points defining the curve. Expects a `Float`
+ * @param t Interpolation weight. Expects a `Float`
+ * @param p0 Expects a `Float`
+ * @param p1 Expects a `Float`
+ * @param p2 P0, p1, the starting, control and end points defining the curve. Expects a `Float`
  */
-declare function QuadraticBezier( t: number, p0: number, p1: number, p2: number ): number;
+declare function QuadraticBezier(t: number, p0: number, p1: number, p2: number): number;
 
 /**
  * Used internally by {@link THREE.CubicBezierCurve3 | CubicBezierCurve3} and {@link THREE.CubicBezierCurve | CubicBezierCurve}.
-* @param t Interpolation weight. Expects a `Float`
-* @param p0 Expects a `Float`
-* @param p1 Expects a `Float`
-* @param p2 Expects a `Float`
-* @param p3 P0, p1, p2, the starting, control(twice) and end points defining the curve. Expects a `Float`
+ * @param t Interpolation weight. Expects a `Float`
+ * @param p0 Expects a `Float`
+ * @param p1 Expects a `Float`
+ * @param p2 Expects a `Float`
+ * @param p3 P0, p1, p2, the starting, control(twice) and end points defining the curve. Expects a `Float`
  */
-declare function CubicBezier( t: number, p0: number, p1: number, p2: number, p3: number ) : number;
+declare function CubicBezier(t: number, p0: number, p1: number, p2: number, p3: number): number;
 
 export { CatmullRom, QuadraticBezier, CubicBezier };

--- a/types/three/src/extras/core/Interpolations.d.ts
+++ b/types/three/src/extras/core/Interpolations.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Used internally by {@link THREE.SplineCurve | SplineCurve}.
+* @param t Interpolation weight. Expects a `Float`
+* @param p0 Expects a `Float`
+* @param p1 Expects a `Float`
+* @param p2 Expects a `Float`
+* @param p3 P0, p1, p2, the points defining the spline curve. Expects a `Float`
+ */
+declare function CatmullRom( t: number, p0: number, p1: number, p2: number, p3: number ) : number;
+
+/**
+ * Used internally by {@link THREE.QuadraticBezierCurve3 | QuadraticBezierCurve3} and {@link THREE.QuadraticBezierCurve | QuadraticBezierCurve}.
+* @param t Interpolation weight. Expects a `Float`
+* @param p0 Expects a `Float`
+* @param p1 Expects a `Float`
+* @param p2 P0, p1, the starting, control and end points defining the curve. Expects a `Float`
+ */
+declare function QuadraticBezier( t: number, p0: number, p1: number, p2: number ): number;
+
+/**
+ * Used internally by {@link THREE.CubicBezierCurve3 | CubicBezierCurve3} and {@link THREE.CubicBezierCurve | CubicBezierCurve}.
+* @param t Interpolation weight. Expects a `Float`
+* @param p0 Expects a `Float`
+* @param p1 Expects a `Float`
+* @param p2 Expects a `Float`
+* @param p3 P0, p1, p2, the starting, control(twice) and end points defining the curve. Expects a `Float`
+ */
+declare function CubicBezier( t: number, p0: number, p1: number, p2: number, p3: number ) : number;
+
+export { CatmullRom, QuadraticBezier, CubicBezier };

--- a/types/three/src/extras/core/Path.d.ts
+++ b/types/three/src/extras/core/Path.d.ts
@@ -2,43 +2,71 @@ import { Vector2 } from './../../math/Vector2';
 import { CurvePath } from './CurvePath';
 
 /**
- * a 2d path representation, comprising of points, lines, and cubes, similar to the html5 2d canvas api. It extends CurvePath.
+ * A 2D {@link Path} representation.
+ * @remarks
+ * The class provides methods for creating paths and contours of 2D shapes similar to the 2D Canvas API.
+ * @example
+ * ```typescript
+ * const {@link Path} = new THREE.Path();
+ * path.lineTo(0, 0.8);
+ * path.quadraticCurveTo(0, 1, 0.2, 1);
+ * path.lineTo(1, 1);
+ * const points = path.getPoints();
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xffffff
+ * });
+ * const line = new THREE.Line(geometry, material);
+ * scene.add(line);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Path | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Path.js | Source}
  */
 export class Path extends CurvePath<Vector2> {
+    /**
+     * Creates a {@link Path} from the points
+     * @remarks
+     * The first point defines the offset, then successive points are added to the {@link CurvePath.curves | curves} array as {@link LineCurve | LineCurves}.
+     * If no points are specified, an empty {@link Path} is created and the {@link .currentPoint} is set to the origin.
+     * @param points Array of {@link Vector2 | Vector2s}.
+     */
     constructor(points?: Vector2[]);
 
     /**
-     * @default 'Path'
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `Path`
      */
-    type: string;
+    override readonly type: string | 'Path';
 
     /**
-     * @default new THREE.Vector2()
+     * The current offset of the path. Any new {@link THREE.Curve | Curve} added will start here.
+     * @defaultValue `new THREE.Vector2()`
      */
     currentPoint: Vector2;
 
     /**
-     * @deprecated Use {@link Path#setFromPoints .setFromPoints()} instead.
+     * Adds an absolutely positioned {@link THREE.EllipseCurve | EllipseCurve} to the path.
+     * @param x Expects a `Float`
+     * @param y X, The absolute center of the arc. Expects a `Float`
+     * @param radius The radius of the arc. Expects a `Float`
+     * @param startAngle The start angle in radians. Expects a `Float`
+     * @param endAngle The end angle in radians. Expects a `Float`
+     * @param clockwise Sweep the arc clockwise. . Default `false`
      */
-    fromPoints(vectors: Vector2[]): this;
-    setFromPoints(vectors: Vector2[]): this;
-    moveTo(x: number, y: number): this;
-    lineTo(x: number, y: number): this;
-    quadraticCurveTo(aCPx: number, aCPy: number, aX: number, aY: number): this;
-    bezierCurveTo(aCP1x: number, aCP1y: number, aCP2x: number, aCP2y: number, aX: number, aY: number): this;
-    splineThru(pts: Vector2[]): this;
-    arc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): this;
     absarc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): this;
-    ellipse(
-        aX: number,
-        aY: number,
-        xRadius: number,
-        yRadius: number,
-        aStartAngle: number,
-        aEndAngle: number,
-        aClockwise: boolean,
-        aRotation: number,
-    ): this;
+
+    /**
+     * Adds an absolutely positioned {@link THREE.EllipseCurve | EllipseCurve} to the path.
+     * @param x Expects a `Float`
+     * @param y X, The absolute center of the ellipse. Expects a `Float`
+     * @param xRadius The radius of the ellipse in the x axis. Expects a `Float`
+     * @param yRadius The radius of the ellipse in the y axis. Expects a `Float`
+     * @param startAngle The start angle in radians. Expects a `Float`
+     * @param endAngle The end angle in radians. Expects a `Float`
+     * @param clockwise Sweep the ellipse clockwise. . Default `false`
+     * @param rotation The rotation angle of the ellipse in radians, counterclockwise from the positive X axis. Optional, Expects a `Float`. Default `0`
+     */
     absellipse(
         aX: number,
         aY: number,
@@ -49,4 +77,83 @@ export class Path extends CurvePath<Vector2> {
         aClockwise: boolean,
         aRotation: number,
     ): this;
+
+    /**
+     * Adds an {@link THREE.EllipseCurve | EllipseCurve} to the path, positioned relative to {@link .currentPoint}.
+     * @param x Expects a `Float`
+     * @param y X, The center of the arc offset from the last call. Expects a `Float`
+     * @param radius The radius of the arc. Expects a `Float`
+     * @param startAngle The start angle in radians. Expects a `Float`
+     * @param endAngle The end angle in radians. Expects a `Float`
+     * @param clockwise Sweep the arc clockwise. . Default `false`
+     */
+    arc(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean): this;
+
+    /**
+     * This creates a bezier curve from {@link .currentPoint} with (cp1X, cp1Y) and (cp2X, cp2Y) as control points and updates {@link .currentPoint} to x and y.
+     * @param cp1X Expects a `Float`
+     * @param cp1Y Expects a `Float`
+     * @param cp2X Expects a `Float`
+     * @param cp2Y Expects a `Float`
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
+     */
+    bezierCurveTo(aCP1x: number, aCP1y: number, aCP2x: number, aCP2y: number, aX: number, aY: number): this;
+
+    /**
+     * Adds an {@link THREE.EllipseCurve | EllipseCurve} to the path, positioned relative to {@link .currentPoint}.
+     * @param x Expects a `Float`
+     * @param y X, The center of the ellipse offset from the last call. Expects a `Float`
+     * @param xRadius The radius of the ellipse in the x axis. Expects a `Float`
+     * @param yRadius The radius of the ellipse in the y axis. Expects a `Float`
+     * @param startAngle The start angle in radians. Expects a `Float`
+     * @param endAngle The end angle in radians. Expects a `Float`
+     * @param clockwise Sweep the ellipse clockwise. . Default `false`
+     * @param rotation The rotation angle of the ellipse in radians, counterclockwise from the positive X axis. Optional, Expects a `Float`. Default `0`
+     */
+    ellipse(
+        aX: number,
+        aY: number,
+        xRadius: number,
+        yRadius: number,
+        aStartAngle: number,
+        aEndAngle: number,
+        aClockwise: boolean,
+        aRotation: number,
+    ): this;
+
+    /**
+     * Connects a {@link THREE.LineCurve | LineCurve} from {@link .currentPoint} to x, y onto the path.
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
+     */
+    lineTo(x: number, y: number): this;
+
+    /**
+     * Move the {@link .currentPoint} to x, y.
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
+     */
+    moveTo(x: number, y: number): this;
+
+    /**
+     * Creates a quadratic curve from {@link .currentPoint} with cpX and cpY as control point and updates {@link .currentPoint} to x and y.
+     * @param cpX Expects a `Float`
+     * @param cpY Expects a `Float`
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
+     */
+    quadraticCurveTo(aCPx: number, aCPy: number, aX: number, aY: number): this;
+
+    /**
+     * Points are added to the {@link CurvePath.curves | curves} array as {@link THREE.LineCurve | LineCurves}.
+     * @param vector2s
+     */
+    setFromPoints(vectors: Vector2[]): this;
+
+    /**
+     * Connects a new {@link THREE.SplineCurve | SplineCurve} onto the path.
+     * @param points An array of {@link Vector2 | Vector2's}
+     */
+    splineThru(pts: Vector2[]): this;
 }

--- a/types/three/src/extras/core/Shape.d.ts
+++ b/types/three/src/extras/core/Shape.d.ts
@@ -2,27 +2,77 @@ import { Vector2 } from './../../math/Vector2';
 import { Path } from './Path';
 
 /**
- * Defines a 2d shape plane using paths.
+ * Defines an arbitrary 2d {@link Shape} plane using paths with optional holes
+ * @remarks
+ * It can be used with {@link THREE.ExtrudeGeometry | ExtrudeGeometry}, {@link THREE.ShapeGeometry | ShapeGeometry}, to get points, or to get triangulated faces.
+ * @example
+ * ```typescript
+ * const heartShape = new THREE.Shape();
+ * heartShape.moveTo(25, 25);
+ * heartShape.bezierCurveTo(25, 25, 20, 0, 0, 0);
+ * heartShape.bezierCurveTo(-30, 0, -30, 35, -30, 35);
+ * heartShape.bezierCurveTo(-30, 55, -10, 77, 25, 95);
+ * heartShape.bezierCurveTo(60, 77, 80, 55, 80, 35);
+ * heartShape.bezierCurveTo(80, 35, 80, 0, 50, 0);
+ * heartShape.bezierCurveTo(35, 0, 25, 25, 25, 25);
+ * const extrudeSettings = {
+ *     depth: 8,
+ *     bevelEnabled: true,
+ *     bevelSegments: 2,
+ *     steps: 2,
+ *     bevelSize: 1,
+ *     bevelThickness: 1
+ * };
+ * const geometry = new THREE.ExtrudeGeometry(heartShape, extrudeSettings);
+ * const mesh = new THREE.Mesh(geometry, new THREE.MeshPhongMaterial());
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl_geometry_shapes | geometry / shapes }
+ * @see Example: {@link https://threejs.org/examples/#webgl_geometry_extrude_shapes | geometry / extrude / shapes }
+ * @see Example: {@link https://threejs.org/examples/#webgl_geometry_extrude_shapes2 | geometry / extrude / shapes2 }
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/core/Shape | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/Shape.js | Source}
  */
 export class Shape extends Path {
+    /**
+     * Creates a {@link Shape} from the points
+     * @remarks
+     * The first point defines the offset, then successive points are added to the {@link CurvePath.curves | curves} array as {@link THREE.LineCurve | LineCurves}.
+     * If no points are specified, an empty {@link Shape} is created and the {@link .currentPoint} is set to the origin.
+     * @param points Array of {@link Vector2 | Vector2s}.
+     */
     constructor(points?: Vector2[]);
 
     /**
-     * @default 'Shape'
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `Shape`
      */
-    type: string;
+    override readonly type: string | 'Shape';
 
+    /**
+     * {@link http://en.wikipedia.org/wiki/Universally_unique_identifier | UUID} of this object instance.
+     * @remarks This gets automatically assigned and shouldn't be edited.
+     */
     uuid: string;
 
     /**
-     * @default []
+     * An array of {@link Path | paths} that define the holes in the shape.
+     * @defaultValue `[]`
      */
     holes: Path[];
 
-    getPointsHoles(divisions: number): Vector2[][];
-
+    /**
+     * Call {@link THREE.Curve.getPoints | getPoints} on the {@link Shape} and the {@link holes} array
+     * @param divisions The fineness of the result. Expects a `Integer`
+     */
     extractPoints(divisions: number): {
         shape: Vector2[];
         holes: Vector2[][];
     };
+
+    /**
+     * Get an array of {@link Vector2 | Vector2's} that represent the holes in the shape.
+     * @param divisions The fineness of the result. Expects a `Integer`
+     */
+    getPointsHoles(divisions: number): Vector2[][];
 }

--- a/types/three/src/extras/core/ShapePath.d.ts
+++ b/types/three/src/extras/core/ShapePath.d.ts
@@ -1,34 +1,99 @@
 import { Vector2 } from './../../math/Vector2';
 import { Shape } from './Shape';
 import { Color } from '../../math/Color';
+import { Path } from './Path';
 
+/**
+ * This class is used to convert a series of shapes to an array of {@link THREE.Path | Path's},
+ * for example an SVG shape to a path (see the example below).
+ * @see Example: {@link https://threejs.org/examples/#webgl_geometry_extrude_shapes2 | geometry / extrude / shapes2}
+ *  @see {@link https://threejs.org/docs/index.html#api/en/extras/core/ShapePath | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/core/ShapePath.js | Source}
+ */
 export class ShapePath {
+    /**
+     * Creates a new {@link ShapePath}
+     * @remarks
+     * Unlike a {@link THREE.Path | Path}, no points are passed in as the {@link ShapePath} is designed to be generated after creation.
+     */
     constructor();
 
     /**
-     * @default 'ShapePath'
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `ShapePath`
      */
-    type: string;
+    readonly type: 'ShapePath';
 
     /**
-     * @default new THREE.Color()
+     * Array of {@link THREE.Path | Path's}s.
+     * @defaultValue `[]`
+     */
+    subPaths: Path[];
+
+    /**
+     * The current {@link THREE.Path | Path} that is being generated.
+     * @defaultValue `null`
+     */
+    readonly currentPath: Path | null;
+
+    /**
+     * {@link THREE.Color | Color} of the shape, by default set to white _(0xffffff)_.
+     * @defaultValue `new THREE.Color()`
      */
     color: Color;
 
     /**
-     * @default []
+     * Starts a new {@link THREE.Path | Path} and calls {@link THREE.Path.moveTo | Path.moveTo}( x, y ) on that {@link THREE.Path | Path}
+     * @remarks
+     * Also points {@link ShapePath.currentPath | currentPath} to that {@link THREE.Path | Path}.
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
      */
-    subPaths: any[];
+    moveTo(x: number, y: number): this;
 
     /**
-     * @default null
+     * This creates a line from the {@link ShapePath.currentPath | currentPath}'s offset to X and Y and updates the offset to X and Y.
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
      */
-    currentPath: any;
-
-    moveTo(x: number, y: number): this;
     lineTo(x: number, y: number): this;
+
+    /**
+     * This creates a quadratic curve from the {@link ShapePath.currentPath | currentPath}'s
+     * offset to _x_ and _y_ with _cpX_ and _cpY_ as control point and updates the {@link ShapePath.currentPath | currentPath}'s offset to _x_ and _y_.
+     * @param cpX Expects a `Float`
+     * @param cpY Expects a `Float`
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
+     */
     quadraticCurveTo(aCPx: number, aCPy: number, aX: number, aY: number): this;
+
+    /**
+     * This creates a bezier curve from the {@link ShapePath.currentPath | currentPath}'s
+     * offset to _x_ and _y_ with _cp1X_, _cp1Y_ and _cp2X_, _cp2Y_ as control points and
+     * updates the {@link ShapePath.currentPath | currentPath}'s offset to _x_ and _y_.
+     * @param cp1X Expects a `Float`
+     * @param cp1Y Expects a `Float`
+     * @param cp2X Expects a `Float`
+     * @param cp2Y Expects a `Float`
+     * @param x Expects a `Float`
+     * @param y Expects a `Float`
+     */
     bezierCurveTo(aCP1x: number, aCP1y: number, aCP2x: number, aCP2y: number, aX: number, aY: number): this;
+
+    /**
+     * Connects a new {@link THREE.SplineCurve | SplineCurve} onto the {@link ShapePath.currentPath | currentPath}.
+     * @param points An array of {@link THREE.Vector2 | Vector2}s
+     */
     splineThru(pts: Vector2[]): this;
+
+    /**
+     * Converts the {@link ShapePath.subPaths | subPaths} array into an array of Shapes
+     * @remarks
+     * By default solid shapes are defined clockwise (CW) and holes are defined counterclockwise (CCW)
+     * If isCCW is set to true, then those are flipped.
+     * @param isCCW Changes how solids and holes are generated
+     */
     toShapes(isCCW: boolean): Shape[];
 }

--- a/types/three/src/extras/curves/ArcCurve.d.ts
+++ b/types/three/src/extras/curves/ArcCurve.d.ts
@@ -1,9 +1,41 @@
 import { EllipseCurve } from './EllipseCurve';
+
+/**
+ * Alias for {@link THREE.EllipseCurve | EllipseCurve}.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/ArcCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/ArcCurve.js | Source}
+ */
 export class ArcCurve extends EllipseCurve {
-    constructor(aX: number, aY: number, aRadius: number, aStartAngle: number, aEndAngle: number, aClockwise: boolean);
+    /**
+     * This constructor creates a new {@link ArcCurve}.
+     * @param aX The X center of the ellipse. Expects a `Float`. Default is `0`.
+     * @param aY The Y center of the ellipse. Expects a `Float`. Default is `0`.
+     * @param xRadius The radius of the ellipse in the x direction. Expects a `Float`. Default is `1`.
+     * @param yRadius The radius of the ellipse in the y direction. Expects a `Float`. Default is `1`.
+     * @param aStartAngle The start angle of the curve in radians starting from the positive X axis. Default is `0`.
+     * @param aEndAngle The end angle of the curve in radians starting from the positive X axis. Default is `2 x Math.PI`.
+     * @param aClockwise Whether the ellipse is drawn clockwise. Default is `false`.
+     */
+    constructor(
+        aX?: number,
+        aY?: number,
+        aRadius?: number,
+        aStartAngle?: number,
+        aEndAngle?: number,
+        aClockwise?: boolean,
+    );
 
     /**
-     * @default 'ArcCurve'
+     * Read-only flag to check if a given object is of type {@link ArcCurve}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
      */
-    type: string;
+    readonly isArcCurve = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `ArcCurve`
+     */
+    override readonly type: string | 'ArcCurve';
 }

--- a/types/three/src/extras/curves/CatmullRomCurve3.d.ts
+++ b/types/three/src/extras/curves/CatmullRomCurve3.d.ts
@@ -1,30 +1,77 @@
 import { Vector3 } from './../../math/Vector3';
 import { Curve } from './../core/Curve';
 
-// Extras / Curves /////////////////////////////////////////////////////////////////////
-export namespace CurveUtils {
-    function tangentQuadraticBezier(t: number, p0: number, p1: number, p2: number): number;
-    function tangentCubicBezier(t: number, p0: number, p1: number, p2: number, p3: number): number;
-    function tangentSpline(t: number, p0: number, p1: number, p2: number, p3: number): number;
-    function interpolate(p0: number, p1: number, p2: number, p3: number, t: number): number;
-}
+export type CurveType = 'centripetal' | 'chordal' | 'catmullrom';
 
+/**
+ * Create a smooth **3D** spline curve from a series of points using the {@link https://en.wikipedia.org/wiki/Centripetal_Catmull-Rom_spline | Catmull-Rom} algorithm.
+ * @example
+ * ```typescript
+ * //Create a closed wavey loop
+ * const curve = new THREE.CatmullRomCurve3([
+ * new THREE.Vector3(-10, 0, 10),
+ * new THREE.Vector3(-5, 5, 5),
+ * new THREE.Vector3(0, 0, 0),
+ * new THREE.Vector3(5, -5, 5),
+ * new THREE.Vector3(10, 0, 10)]);
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xff0000
+ * });
+ * // Create the final object to add to the scene
+ * const curveObject = new THREE.Line(geometry, material);
+ * ```
+ * @see Example: {@link https://threejs.org/examples/#webgl_geometry_extrude_splines | WebGL / geometry / extrude / splines}
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/CatmullRomCurve3 | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/CatmullRomCurve3.js | Source}
+ */
 export class CatmullRomCurve3 extends Curve<Vector3> {
     /**
-     * @param [points=[]]
-     * @param [closed=false]
-     * @param [curveType='centripetal']
-     * @param [tension=0.5]
+     * This constructor creates a new {@link CatmullRomCurve3}.
+     * @param points An array of {@link THREE.Vector3 | Vector3} points
+     * @param closed Whether the curve is closed. Default `false`
+     * @param curveType Type of the curve. Default `centripetal`
+     * @param tension Tension of the curve. Expects a `Float`. Default `0.5`
      */
-    constructor(points?: Vector3[], closed?: boolean, curveType?: string, tension?: number);
+    constructor(points?: Vector3[], closed?: boolean, curveType?: CurveType, tension?: number);
 
     /**
-     * @default 'CatmullRomCurve3'
+     * Read-only flag to check if a given object is of type {@link CatmullRomCurve3}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
      */
-    type: string;
+    readonly isCatmullRomCurve3 = true;
 
     /**
-     * @default []
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `CatmullRomCurve3`
+     */
+    override readonly type: string | 'CatmullRomCurve3';
+
+    /**
+     * The curve will loop back onto itself when this is true.
+     * @defaultValue `false`
+     */
+    closed: boolean;
+
+    /**
+     * The array of {@link THREE.Vector3 | Vector3} points that define the curve.
+     * @remarks It needs at least two entries.
+     * @defaultValue `[]`
      */
     points: Vector3[];
+
+    /**
+     * Possible values are `centripetal`, `chordal` and `catmullrom`.
+     * @defaultValue `centripetal`
+     */
+    curveType: CurveType;
+
+    /**
+     * When {@link .curveType} is `catmullrom`, defines catmullrom's tension.
+     * @remarks Expects a `Float`
+     */
+    tension: number;
 }

--- a/types/three/src/extras/curves/CubicBezierCurve.d.ts
+++ b/types/three/src/extras/curves/CubicBezierCurve.d.ts
@@ -1,31 +1,72 @@
 import { Vector2 } from './../../math/Vector2';
 import { Curve } from './../core/Curve';
 
+/**
+ * Create a smooth **2D** {@link http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:Bezier_curve.svg | cubic bezier curve},
+ * defined by a start point, endpoint and two control points.
+ * @example
+ * ```typescript
+ * const curve = new THREE.CubicBezierCurve(
+ * new THREE.Vector2(-10, 0),
+ * new THREE.Vector2(-5, 15),
+ * new THREE.Vector2(20, 15),
+ * new THREE.Vector2(10, 0));
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xff0000
+ * });
+ * // Create the final object to add to the scene
+ * const curveObject = new THREE.Line(geometry, material);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/CubicBezierCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/CubicBezierCurve.js | Source}
+ */
 export class CubicBezierCurve extends Curve<Vector2> {
-    constructor(v0: Vector2, v1: Vector2, v2: Vector2, v3: Vector2);
-
     /**
-     * @default 'CubicBezierCurve'
+     * This constructor creates a new {@link CubicBezierCurve}.
+     * @param v0 The starting point. Default is `new THREE.Vector2()`.
+     * @param v1 The first control point. Default is `new THREE.Vector2()`.
+     * @param v2 The second control point. Default is `new THREE.Vector2()`.
+     * @param v3 The ending point. Default is `new THREE.Vector2()`.
      */
-    type: string;
+    constructor(v0?: Vector2, v1?: Vector2, v2?: Vector2, v3?: Vector2);
 
     /**
-     * @default new THREE.Vector2()
+     * Read-only flag to check if a given object is of type {@link CubicBezierCurve}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isCubicBezierCurve = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `CubicBezierCurve`
+     */
+    override readonly type: string | 'CubicBezierCurve';
+
+    /**
+     * The starting point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v0: Vector2;
 
     /**
-     * @default new THREE.Vector2()
+     * The first control point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v1: Vector2;
 
     /**
-     * @default new THREE.Vector2()
+     * The second control point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v2: Vector2;
 
     /**
-     * @default new THREE.Vector2()
+     * The ending point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v3: Vector2;
 }

--- a/types/three/src/extras/curves/CubicBezierCurve3.d.ts
+++ b/types/three/src/extras/curves/CubicBezierCurve3.d.ts
@@ -1,31 +1,72 @@
 import { Vector3 } from './../../math/Vector3';
 import { Curve } from './../core/Curve';
 
+/**
+ * Create a smooth **3D** {@link http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:Bezier_curve.svg | cubic bezier curve},
+ * defined by a start point, endpoint and two control points.
+ * @example
+ * ```typescript
+ * const curve = new THREE.CubicBezierCurve(
+ * new THREE.Vector2(-10, 0),
+ * new THREE.Vector2(-5, 15),
+ * new THREE.Vector2(20, 15),
+ * new THREE.Vector2(10, 0));
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xff0000
+ * });
+ * // Create the final object to add to the scene
+ * const curveObject = new THREE.Line(geometry, material);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/CubicBezierCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/CubicBezierCurve.js | Source}
+ */
 export class CubicBezierCurve3 extends Curve<Vector3> {
-    constructor(v0: Vector3, v1: Vector3, v2: Vector3, v3: Vector3);
-
     /**
-     * @default 'CubicBezierCurve3'
+     * This constructor creates a new {@link CubicBezierCurve3}.
+     * @param v0 The starting point. Default is `new THREE.Vector3()`.
+     * @param v1 The first control point. Default is `new THREE.Vector3()`.
+     * @param v2 The second control point. Default is `new THREE.Vector3()`.
+     * @param v3 The ending point. Default is `new THREE.Vector3()`.
      */
-    type: string;
+    constructor(v0?: Vector3, v1?: Vector3, v2?: Vector3, v3?: Vector3);
 
     /**
-     * @default new THREE.Vector3()
+     * Read-only flag to check if a given object is of type {@link CubicBezierCurve3}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isCubicBezierCurve3 = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `CubicBezierCurve3`
+     */
+    override readonly type: string | 'CubicBezierCurve3';
+
+    /**
+     * The starting point.
+     * @defaultValue `new THREE.Vector3()`.
      */
     v0: Vector3;
 
     /**
-     * @default new THREE.Vector3()
+     * The first control point.
+     * @defaultValue `new THREE.Vector3()`.
      */
     v1: Vector3;
 
     /**
-     * @default new THREE.Vector3()
+     * The second control point.
+     * @defaultValue `new THREE.Vector3()`.
      */
     v2: Vector3;
 
     /**
-     * @default new THREE.Vector3()
+     * The ending point.
+     * @defaultValue `new THREE.Vector3()`.
      */
     v3: Vector3;
 }

--- a/types/three/src/extras/curves/EllipseCurve.d.ts
+++ b/types/three/src/extras/curves/EllipseCurve.d.ts
@@ -1,60 +1,115 @@
 import { Curve } from './../core/Curve';
 import { Vector2 } from '../../math/Vector2';
 
+/**
+ * Creates a 2d curve in the shape of an ellipse
+ * @remarks
+ * Setting the {@link xRadius} equal to the {@link yRadius} will result in a circle.
+ * @example
+ * ```typescript
+ * const curve = new THREE.EllipseCurve(
+ *   0,  0,  // ax, aY
+ *   10, 10, // xRadius, yRadius
+ *   0,  2 * Math.PI, // aStartAngle, aEndAngle
+ *   false,  // aClockwise
+ *   0       // aRotation
+ *   );
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({ color: 0xff0000 });
+ * // Create the final object to add to the scene
+ * const ellipse = new THREE.Line(geometry, material);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/EllipseCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/EllipseCurve.js | Source}
+ */
 export class EllipseCurve extends Curve<Vector2> {
+    /**
+     * This constructor creates a new {@link EllipseCurve}.
+     * @param aX The X center of the ellipse. Expects a `Float`. Default is `0`.
+     * @param aY The Y center of the ellipse. Expects a `Float`. Default is `0`.
+     * @param xRadius The radius of the ellipse in the x direction. Expects a `Float`. Default is `1`.
+     * @param yRadius The radius of the ellipse in the y direction. Expects a `Float`. Default is `1`.
+     * @param aStartAngle The start angle of the curve in radians starting from the positive X axis. Default is `0`.
+     * @param aEndAngle The end angle of the curve in radians starting from the positive X axis. Default is `2 x Math.PI`.
+     * @param aClockwise Whether the ellipse is drawn clockwise. Default is `false`.
+     * @param aRotation The rotation angle of the ellipse in radians, counterclockwise from the positive X axis. Default is `0`.
+     */
     constructor(
-        aX: number,
-        aY: number,
-        xRadius: number,
-        yRadius: number,
-        aStartAngle: number,
-        aEndAngle: number,
-        aClockwise: boolean,
-        aRotation: number,
+        aX?: number,
+        aY?: number,
+        xRadius?: number,
+        yRadius?: number,
+        aStartAngle?: number,
+        aEndAngle?: number,
+        aClockwise?: boolean,
+        aRotation?: number,
     );
 
     /**
-     * @default 'EllipseCurve'
+     * Read-only flag to check if a given object is of type {@link EllipseCurve}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
      */
-    type: string;
+    readonly isEllipseCurve = true;
 
     /**
-     * @default 0
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `EllipseCurve`
+     */
+    override readonly type: string | 'EllipseCurve';
+
+    /**
+     * The X center of the ellipse.
+     * @remarks Expects a `Float`
+     * @defaultValue `0`
      */
     aX: number;
 
     /**
-     * @default 0
+     * The Y center of the ellipse.
+     * @remarks Expects a `Float`
+     * @defaultValue `0`
      */
     aY: number;
 
     /**
-     * @default 1
+     * The radius of the ellipse in the x direction.
+     * @defaultValue `1`
      */
     xRadius: number;
 
     /**
-     * @default 1
+     * The radius of the ellipse in the y direction.
+     * @defaultValue `1`
      */
     yRadius: number;
 
     /**
-     * @default 0
+     * The start angle of the curve in radians starting from the middle right side.
+     * @remarks Expects a `Float`
+     * @defaultValue `0`
      */
     aStartAngle: number;
 
     /**
-     * @default 2 * Math.PI
+     * The end angle of the curve in radians starting from the middle right side.
+     * @remarks Expects a `Float`
+     * @defaultValue `2 * Math.PI`
      */
     aEndAngle: number;
 
     /**
-     * @default false
+     * Whether the ellipse is drawn clockwise.
+     * @defaultValue `false``
      */
     aClockwise: boolean;
 
     /**
-     * @default 0
+     * The rotation angle of the ellipse in radians, counterclockwise from the positive X axis (optional).
+     * @remarks Expects a `Float`
+     * @defaultValue `0`
      */
     aRotation: number;
 }

--- a/types/three/src/extras/curves/LineCurve.d.ts
+++ b/types/three/src/extras/curves/LineCurve.d.ts
@@ -1,21 +1,42 @@
 import { Vector2 } from './../../math/Vector2';
 import { Curve } from './../core/Curve';
 
+/**
+ * A curve representing a **2D** line segment.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/LineCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/LineCurve.js | Source}
+ */
 export class LineCurve extends Curve<Vector2> {
-    constructor(v1: Vector2, v2: Vector2);
-
     /**
-     * @default 'LineCurve'
+     * This constructor creates a new {@link LineCurve}.
+     * @param v1 The start point. Default is `new THREE.Vector2()`.
+     * @param v2 The end point. Default is `new THREE.Vector2()`.
      */
-    type: string;
+    constructor(v1?: Vector2, v2?: Vector2);
 
     /**
-     * @default new THREE.Vector2()
+     * Read-only flag to check if a given object is of type {@link LineCurve}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isLineCurve = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `LineCurve`
+     */
+    override readonly type: string | 'LineCurve';
+
+    /**
+     * The start point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v1: Vector2;
 
     /**
-     * @default new THREE.Vector2()
+     * The end point
+     * @defaultValue `new THREE.Vector2()`
      */
     v2: Vector2;
 }

--- a/types/three/src/extras/curves/LineCurve3.d.ts
+++ b/types/three/src/extras/curves/LineCurve3.d.ts
@@ -1,21 +1,42 @@
 import { Vector3 } from './../../math/Vector3';
 import { Curve } from './../core/Curve';
 
+/**
+ * A curve representing a **3D** line segment.
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/LineCurve3 | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/LineCurve3.js | Source}
+ */
 export class LineCurve3 extends Curve<Vector3> {
-    constructor(v1: Vector3, v2: Vector3);
-
     /**
-     * @default 'LineCurve3'
+     * This constructor creates a new {@link LineCurve3}.
+     * @param v1 The start point. Default is `new THREE.Vector3()`.
+     * @param v2 The end point. Default is `new THREE.Vector3()`.
      */
-    type: string;
+    constructor(v1?: Vector3, v2?: Vector3);
 
     /**
-     * @default new THREE.Vector3()
+     * Read-only flag to check if a given object is of type {@link LineCurve3}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isLineCurve3 = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `LineCurve3`
+     */
+    override readonly type: string | 'LineCurve3';
+
+    /**
+     * The start point.
+     * @defaultValue `new THREE.Vector3()`.
      */
     v1: Vector3;
 
     /**
-     * @default new THREE.Vector3()
+     * The end point.
+     * @defaultValue `new THREE.Vector3()`.
      */
     v2: Vector3;
 }

--- a/types/three/src/extras/curves/QuadraticBezierCurve.d.ts
+++ b/types/three/src/extras/curves/QuadraticBezierCurve.d.ts
@@ -1,26 +1,64 @@
 import { Vector2 } from './../../math/Vector2';
 import { Curve } from './../core/Curve';
 
+/**
+ * Create a smooth **2D** {@link http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:B%C3%A9zier_2_big.gif | quadratic bezier curve},
+ * defined by a start point, end point and a single control point.
+ * @example
+ * ```typescript
+ * const curve = new THREE.QuadraticBezierCurve(
+ * new THREE.Vector2(-10, 0),
+ * new THREE.Vector2(20, 15),
+ * new THREE.Vector2(10, 0));
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xff0000
+ * });
+ * // Create the final object to add to the scene
+ * const curveObject = new THREE.Line(geometry, material);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/QuadraticBezierCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/QuadraticBezierCurve.js | Source}
+ */
 export class QuadraticBezierCurve extends Curve<Vector2> {
-    constructor(v0: Vector2, v1: Vector2, v2: Vector2);
-
     /**
-     * @default 'QuadraticBezierCurve'
+     * This constructor creates a new {@link QuadraticBezierCurve}.
+     * @param v0 The start point. Default is `new THREE.Vector2()`.
+     * @param v1 The control point. Default is `new THREE.Vector2()`.
+     * @param v2 The end point. Default is `new THREE.Vector2()`.
      */
-    type: string;
+    constructor(v0?: Vector2, v1?: Vector2, v2?: Vector2);
 
     /**
-     * @default new THREE.Vector2()
+     * Read-only flag to check if a given object is of type {@link LineCurve3}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isQuadraticBezierCurve = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `QuadraticBezierCurve`
+     */
+    override readonly type: string | 'QuadraticBezierCurve';
+
+    /**
+     * The start point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v0: Vector2;
 
     /**
-     * @default new THREE.Vector2()
+     * The control point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v1: Vector2;
 
     /**
-     * @default new THREE.Vector2()
+     * The end point.
+     * @defaultValue `new THREE.Vector2()`
      */
     v2: Vector2;
 }

--- a/types/three/src/extras/curves/QuadraticBezierCurve3.d.ts
+++ b/types/three/src/extras/curves/QuadraticBezierCurve3.d.ts
@@ -1,26 +1,64 @@
 import { Vector3 } from './../../math/Vector3';
 import { Curve } from './../core/Curve';
 
+/**
+ * Create a smooth **3D** {@link http://en.wikipedia.org/wiki/B%C3%A9zier_curve#mediaviewer/File:B%C3%A9zier_2_big.gif | quadratic bezier curve},
+ * defined by a start point, end point and a single control point.
+ * @example
+ * ```typescript
+ * const curve = new THREE.QuadraticBezierCurve3(
+ * new THREE.Vector3(-10, 0, 0),
+ * new THREE.Vector3(20, 15, 0),
+ * new THREE.Vector3(10, 0, 0));
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xff0000
+ * });
+ * // Create the final object to add to the scene
+ * const curveObject = new THREE.Line(geometry, material);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/QuadraticBezierCurve3 | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/QuadraticBezierCurve3.js | Source}
+ */
 export class QuadraticBezierCurve3 extends Curve<Vector3> {
-    constructor(v0: Vector3, v1: Vector3, v2: Vector3);
-
     /**
-     * @default 'QuadraticBezierCurve3'
+     * This constructor creates a new {@link QuadraticBezierCurve}.
+     * @param v0 The start point. Default is `new THREE.Vector3()`.
+     * @param v1 The control point. Default is `new THREE.Vector3()`.
+     * @param v2 The end point. Default is `new THREE.Vector3()`.
      */
-    type: string;
+    constructor(v0?: Vector3, v1?: Vector3, v2?: Vector3);
 
     /**
-     * @default new THREE.Vector3()
+     * Read-only flag to check if a given object is of type {@link QuadraticBezierCurve3}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isQuadraticBezierCurve3 = true;
+
+    /**
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `QuadraticBezierCurve3`
+     */
+    override readonly type: string | 'QuadraticBezierCurve3';
+
+    /**
+     * The start point.
+     * @defaultValue `new THREE.Vector3()`
      */
     v0: Vector3;
 
     /**
-     * @default new THREE.Vector3()
+     * The control point.
+     * @defaultValue `new THREE.Vector3()`
      */
     v1: Vector3;
 
     /**
-     * @default new THREE.Vector3()
+     * The end point.
+     * @defaultValue `new THREE.Vector3()`
      */
     v2: Vector3;
 }

--- a/types/three/src/extras/curves/SplineCurve.d.ts
+++ b/types/three/src/extras/curves/SplineCurve.d.ts
@@ -1,16 +1,52 @@
 import { Vector2 } from './../../math/Vector2';
 import { Curve } from './../core/Curve';
 
+/**
+ * Create a smooth **2D** spline curve from a series of points.
+ * @example
+ * ```typescript
+ * // Create a sine-like wave
+ * const curve = new THREE.SplineCurve([
+ * new THREE.Vector2(-10, 0),
+ * new THREE.Vector2(-5, 5),
+ * new THREE.Vector2(0, 0),
+ * new THREE.Vector2(5, -5),
+ * new THREE.Vector2(10, 0)]);
+ * const points = curve.getPoints(50);
+ * const geometry = new THREE.BufferGeometry().setFromPoints(points);
+ * const material = new THREE.LineBasicMaterial({
+ *     color: 0xff0000
+ * });
+ * // Create the final object to add to the scene
+ * const splineObject = new THREE.Line(geometry, material);
+ * ```
+ * @see {@link https://threejs.org/docs/index.html#api/en/extras/curves/SplineCurve | Official Documentation}
+ * @see {@link https://github.com/mrdoob/three.js/blob/master/src/extras/curves/SplineCurve.js | Source}
+ */
 export class SplineCurve extends Curve<Vector2> {
+    /**
+     * This constructor creates a new {@link SplineCurve}.
+     * @param points An array of {@link THREE.Vector2 | Vector2} points that define the curve. Default `[]`
+     */
     constructor(points?: Vector2[]);
 
     /**
-     * @default 'SplineCurve'
+     * Read-only flag to check if a given object is of type {@link SplineCurve}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
      */
-    type: string;
+    readonly isSplineCurve = true;
 
     /**
-     * @default []
+     * A Read-only _string_ to check if `this` object type.
+     * @remarks Sub-classes will update this value.
+     * @defaultValue `SplineCurve`
+     */
+    override readonly type: string | 'SplineCurve';
+
+    /**
+     * The array of {@link THREE.Vector2 | Vector2} points that define the curve.
+     * @defaultValue `[]`
      */
     points: Vector2[];
 }


### PR DESCRIPTION
### Why

The TSDocs for many classes are missing or outdated.
Some Typing information is missing and could be improved.

### What

- Improve documentation for all extra.* classes/files.
- Add Missing Definition Type
- Update some Types 
- Fix some wrong  Types 
- Code Format

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged