### PR TITLE
Update color space type definitions for three.js r152

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -681,11 +681,14 @@ export type TrianglesDrawModes = typeof TrianglesDrawMode | typeof TriangleStrip
 ///////////////////////////////////////////////////////////////////////////////
 // Texture Encodings
 
+/** @deprecated Use {@link LinearSRGBColorSpace} or {@link NoColorSpace} in three.js r152+. */
 export const LinearEncoding: 3000;
+/** @deprecated Use {@link SRGBColorSpace} in three.js r152+. */
 export const sRGBEncoding: 3001;
 /**
  * Texture Encodings.
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+ * @deprecated Use {@link ColorSpace} in three.js r152+.
  */
 export type TextureEncoding = typeof LinearEncoding | typeof sRGBEncoding;
 

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -8,6 +8,7 @@ import {
     TextureEncoding,
     MinificationTextureFilter,
     MagnificationTextureFilter,
+    ColorSpace,
 } from '../constants';
 
 export interface WebGLRenderTargetOptions {
@@ -22,7 +23,9 @@ export interface WebGLRenderTargetOptions {
     stencilBuffer?: boolean | undefined; // false;
     generateMipmaps?: boolean | undefined; // true;
     depthTexture?: DepthTexture | undefined;
+    /** @deprecated Use 'colorSpace' in three.js r152+. */
     encoding?: TextureEncoding | undefined;
+    colorSpace?: ColorSpace | undefined;
 
     /**
      * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -14,7 +14,7 @@ import { WebGLRenderTarget } from './WebGLRenderTarget';
 import { WebGLMultipleRenderTargets } from './WebGLMultipleRenderTargets';
 import { Object3D } from './../core/Object3D';
 import { Material } from './../materials/Material';
-import { ToneMapping, ShadowMapType, CullFace, TextureEncoding } from '../constants';
+import { ToneMapping, ShadowMapType, CullFace, TextureEncoding, ColorSpace } from '../constants';
 import { WebXRManager } from '../renderers/webxr/WebXRManager';
 import { BufferGeometry } from './../core/BufferGeometry';
 import { OffscreenCanvas, Texture } from '../textures/Texture';
@@ -174,8 +174,16 @@ export class WebGLRenderer implements Renderer {
     /**
      * Default is LinearEncoding.
      * @default THREE.LinearEncoding
+     * @deprecated Use {@link WebGLRenderer.outputColorSpace .outputColorSpace} in three.js r152+.
      */
     outputEncoding: TextureEncoding;
+
+    /**
+     * Color space used for output to HTMLCanvasElement. Supported values are
+     * {@link SRGBColorSpace} and {@link LinearSRGBColorSpace}.
+     * @default THREE.SRGBColorSpace.
+     */
+    outputColorSpace: ColorSpace;
 
     /**
      * @default true

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -13,6 +13,7 @@ import {
     MinificationTextureFilter,
     AnyPixelFormat,
     AnyMapping,
+    ColorSpace,
 } from '../constants';
 
 /** Shim for OffscreenCanvas. */
@@ -50,6 +51,7 @@ export class Texture extends EventDispatcher {
      * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
      * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
      * @param encoding See {@link Texture.encoding | .encoding}. Default {@link THREE.LinearEncoding}
+     * @param colorSpace See {@link Texture.colorSpace | .colorSpace}. Default {@link THREE.NoColorSpace}
      */
     constructor(
         image?: TexImageSource | OffscreenCanvas,
@@ -61,7 +63,7 @@ export class Texture extends EventDispatcher {
         format?: PixelFormat,
         type?: TextureDataType,
         anisotropy?: number,
-        encoding?: TextureEncoding,
+        colorSpace?: ColorSpace | TextureEncoding,
     );
 
     /**
@@ -332,8 +334,23 @@ export class Texture extends EventDispatcher {
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @see {@link THREE.TextureDataType}
      * @defaultValue {@link THREE.LinearEncoding}
+     * @deprecated Use {@link Texture.colorSpace .colorSpace} in three.js r152+.
      */
     encoding: TextureEncoding;
+
+    /**
+     * The {@link Textures | {@link Texture} constants} page for details of other color spaces.
+     * @remarks
+     * Textures containing color data (such as .map) should typically use {@link THREE.SRGBColorSpace},
+     * while textures containing non-color data (such as .normalMap) should use {@link THREE.NoColorSpace}.
+     * @remarks
+     * Note that if this value is changed on a texture after the material has been used, it is necessary to trigger a {@link THREE.Material.needsUpdate} for this value to be realized in the shader.
+     * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
+     * @see {@link THREE.TextureDataType}
+     * @defaultValue {@link THREE.NoColorSpace}
+     * @deprecated Use {@link Texture.colorSpace .colorSpace} in three.js r152+.
+     */
+    colorSpace: ColorSpace;
 
     /**
      * Indicates whether a texture belongs to a render target or not


### PR DESCRIPTION
### Why

three.js r152+ will contain a number of changes related to color management, including:

- Replace WebGLRenderer#outputEncoding with WebGLRenderer#outputColorSpace
- Replace Texture#encoding with Texture#colorSpace
- Replace WebGLRenderTarget 'encoding' option with 'colorSpace'
- Change default renderer output to sRGB

### What

This PR updates the affected properties to values for r152, based on https://github.com/mrdoob/three.js/issues/23614. I've intentionally kept the deprecated properties in the type definitions with `@deprecated` tags, hoping this will make for an easier migration.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

~~Submitting as draft for now, until the upstream changes are merged.~~ Ready for review. r152 will be released later this week.