### PR TITLE
fix: allow any string in ColorRepresentation

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -3,7 +3,6 @@
  */
 export * from './constants';
 export * from './Three.Legacy';
-export * from './utils';
 /**
  * Animation
  */

--- a/types/three/src/helpers/ArrowHelper.d.ts
+++ b/types/three/src/helpers/ArrowHelper.d.ts
@@ -2,7 +2,7 @@ import { Vector3 } from './../math/Vector3';
 import { Line } from './../objects/Line';
 import { Mesh } from './../objects/Mesh';
 import { Object3D } from './../core/Object3D';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 // Extras / Helpers /////////////////////////////////////////////////////////////////////
 

--- a/types/three/src/helpers/BoxHelper.d.ts
+++ b/types/three/src/helpers/BoxHelper.d.ts
@@ -1,4 +1,4 @@
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { Object3D } from './../core/Object3D';
 import { LineSegments } from './../objects/LineSegments';
 

--- a/types/three/src/helpers/DirectionalLightHelper.d.ts
+++ b/types/three/src/helpers/DirectionalLightHelper.d.ts
@@ -2,7 +2,7 @@ import { DirectionalLight } from './../lights/DirectionalLight';
 import { Line } from './../objects/Line';
 import { Matrix4 } from './../math/Matrix4';
 import { Object3D } from './../core/Object3D';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 export class DirectionalLightHelper extends Object3D {
     /**

--- a/types/three/src/helpers/GridHelper.d.ts
+++ b/types/three/src/helpers/GridHelper.d.ts
@@ -1,4 +1,4 @@
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { LineSegments } from './../objects/LineSegments';
 
 export class GridHelper extends LineSegments {

--- a/types/three/src/helpers/HemisphereLightHelper.d.ts
+++ b/types/three/src/helpers/HemisphereLightHelper.d.ts
@@ -1,9 +1,8 @@
 import { HemisphereLight } from './../lights/HemisphereLight';
-import { Color } from './../math/Color';
 import { Matrix4 } from './../math/Matrix4';
 import { MeshBasicMaterial } from './../materials/MeshBasicMaterial';
 import { Object3D } from './../core/Object3D';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 export class HemisphereLightHelper extends Object3D {
     constructor(light: HemisphereLight, size: number, color?: ColorRepresentation);

--- a/types/three/src/helpers/PointLightHelper.d.ts
+++ b/types/three/src/helpers/PointLightHelper.d.ts
@@ -1,7 +1,7 @@
 import { PointLight } from './../lights/PointLight';
 import { Matrix4 } from './../math/Matrix4';
 import { Object3D } from './../core/Object3D';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 export class PointLightHelper extends Object3D {
     constructor(light: PointLight, sphereSize?: number, color?: ColorRepresentation);

--- a/types/three/src/helpers/PolarGridHelper.d.ts
+++ b/types/three/src/helpers/PolarGridHelper.d.ts
@@ -1,5 +1,5 @@
 import { LineSegments } from '../objects/LineSegments';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 export class PolarGridHelper extends LineSegments {
     /**

--- a/types/three/src/helpers/SpotLightHelper.d.ts
+++ b/types/three/src/helpers/SpotLightHelper.d.ts
@@ -2,7 +2,7 @@ import { Light } from './../lights/Light';
 import { Matrix4 } from './../math/Matrix4';
 import { Object3D } from './../core/Object3D';
 import { LineSegments } from '../objects/LineSegments';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 export class SpotLightHelper extends Object3D {
     constructor(light: Light, color?: ColorRepresentation);

--- a/types/three/src/lights/AmbientLight.d.ts
+++ b/types/three/src/lights/AmbientLight.d.ts
@@ -1,4 +1,4 @@
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { Light } from './Light';
 
 /**

--- a/types/three/src/lights/AmbientLightProbe.d.ts
+++ b/types/three/src/lights/AmbientLightProbe.d.ts
@@ -1,4 +1,4 @@
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { LightProbe } from './LightProbe';
 
 export class AmbientLightProbe extends LightProbe {

--- a/types/three/src/lights/DirectionalLight.d.ts
+++ b/types/three/src/lights/DirectionalLight.d.ts
@@ -2,7 +2,7 @@ import { Object3D } from './../core/Object3D';
 import { DirectionalLightShadow } from './DirectionalLightShadow';
 import { Light } from './Light';
 import { Vector3 } from '../math/Vector3';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 /**
  * see {@link https://github.com/mrdoob/three.js/blob/master/src/lights/DirectionalLight.js|src/lights/DirectionalLight.js}

--- a/types/three/src/lights/HemisphereLight.d.ts
+++ b/types/three/src/lights/HemisphereLight.d.ts
@@ -1,7 +1,6 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Vector3 } from '../math/Vector3';
 import { Light } from './Light';
-import { ColorRepresentation } from '../utils';
 
 export class HemisphereLight extends Light {
     /**

--- a/types/three/src/lights/HemisphereLightProbe.d.ts
+++ b/types/three/src/lights/HemisphereLightProbe.d.ts
@@ -1,4 +1,4 @@
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { LightProbe } from './LightProbe';
 
 export class HemisphereLightProbe extends LightProbe {

--- a/types/three/src/lights/PointLight.d.ts
+++ b/types/three/src/lights/PointLight.d.ts
@@ -1,4 +1,4 @@
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { Light } from './Light';
 import { PointLightShadow } from './PointLightShadow';
 

--- a/types/three/src/lights/RectAreaLight.d.ts
+++ b/types/three/src/lights/RectAreaLight.d.ts
@@ -1,5 +1,5 @@
 import { Light } from './Light';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 
 export class RectAreaLight extends Light {
     constructor(color?: ColorRepresentation, intensity?: number, width?: number, height?: number);

--- a/types/three/src/lights/SpotLight.d.ts
+++ b/types/three/src/lights/SpotLight.d.ts
@@ -1,9 +1,8 @@
-import { Color } from './../math/Color';
 import { Vector3 } from '../math/Vector3';
 import { Object3D } from './../core/Object3D';
 import { SpotLightShadow } from './SpotLightShadow';
 import { Light } from './Light';
-import { ColorRepresentation } from '../utils';
+import { ColorRepresentation } from '../math/Color';
 import { Texture } from '../textures/Texture';
 
 /**

--- a/types/three/src/materials/LineBasicMaterial.d.ts
+++ b/types/three/src/materials/LineBasicMaterial.d.ts
@@ -1,5 +1,4 @@
-import { ColorRepresentation } from '../utils';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { MaterialParameters, Material } from './Material';
 
 export interface LineBasicMaterialParameters extends MaterialParameters {

--- a/types/three/src/materials/MeshBasicMaterial.d.ts
+++ b/types/three/src/materials/MeshBasicMaterial.d.ts
@@ -1,8 +1,7 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { MaterialParameters, Material } from './Material';
 import { Combine } from '../constants';
-import { ColorRepresentation } from '../utils';
 /**
  * parameters is an object with one or more properties defining the material's appearance.
  */

--- a/types/three/src/materials/MeshLambertMaterial.d.ts
+++ b/types/three/src/materials/MeshLambertMaterial.d.ts
@@ -1,8 +1,7 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { MaterialParameters, Material } from './Material';
 import { Combine, NormalMapTypes } from '../constants';
-import { ColorRepresentation } from '../utils';
 import { Vector2 } from '../Three';
 
 export interface MeshLambertMaterialParameters extends MaterialParameters {

--- a/types/three/src/materials/MeshMatcapMaterial.d.ts
+++ b/types/three/src/materials/MeshMatcapMaterial.d.ts
@@ -1,9 +1,8 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
 import { NormalMapTypes } from '../constants';
-import { ColorRepresentation } from '../utils';
 
 export interface MeshMatcapMaterialParameters extends MaterialParameters {
     color?: ColorRepresentation | undefined;

--- a/types/three/src/materials/MeshPhongMaterial.d.ts
+++ b/types/three/src/materials/MeshPhongMaterial.d.ts
@@ -1,9 +1,8 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
 import { Combine, NormalMapTypes } from '../constants';
-import { ColorRepresentation } from '../utils';
 
 export interface MeshPhongMaterialParameters extends MaterialParameters {
     /** geometry color in hexadecimal. Default is 0xffffff. */

--- a/types/three/src/materials/MeshStandardMaterial.d.ts
+++ b/types/three/src/materials/MeshStandardMaterial.d.ts
@@ -1,9 +1,8 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
 import { NormalMapTypes } from '../constants';
-import { ColorRepresentation } from '../utils';
 
 export interface MeshStandardMaterialParameters extends MaterialParameters {
     color?: ColorRepresentation | undefined;

--- a/types/three/src/materials/MeshToonMaterial.d.ts
+++ b/types/three/src/materials/MeshToonMaterial.d.ts
@@ -1,9 +1,8 @@
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
 import { NormalMapTypes } from '../constants';
-import { ColorRepresentation } from '../utils';
 
 export interface MeshToonMaterialParameters extends MaterialParameters {
     /** geometry color in hexadecimal. Default is 0xffffff. */

--- a/types/three/src/materials/PointsMaterial.d.ts
+++ b/types/three/src/materials/PointsMaterial.d.ts
@@ -1,7 +1,6 @@
 import { Material, MaterialParameters } from './Material';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
-import { ColorRepresentation } from '../utils';
 
 export interface PointsMaterialParameters extends MaterialParameters {
     color?: ColorRepresentation | undefined;

--- a/types/three/src/materials/ShadowMaterial.d.ts
+++ b/types/three/src/materials/ShadowMaterial.d.ts
@@ -1,5 +1,4 @@
-import { ColorRepresentation } from '../utils';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { MaterialParameters, Material } from './Material';
 
 export interface ShadowMaterialParameters extends MaterialParameters {

--- a/types/three/src/materials/SpriteMaterial.d.ts
+++ b/types/three/src/materials/SpriteMaterial.d.ts
@@ -1,5 +1,4 @@
-import { ColorRepresentation } from '../utils';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { MaterialParameters, Material } from './Material';
 

--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -1,5 +1,4 @@
 import { ColorSpace } from '../constants';
-import { ColorRepresentation } from '../utils';
 
 import { BufferAttribute } from './../core/BufferAttribute';
 import { InterleavedBufferAttribute } from './../core/InterleavedBufferAttribute';
@@ -157,7 +156,7 @@ declare const _colorKeywords: {
     yellowgreen: 0x9acd32;
 };
 
-export type ColorKeyword = keyof typeof _colorKeywords;
+export type ColorRepresentation = Color | string | number;
 
 export interface HSL {
     h: number;
@@ -236,7 +235,7 @@ export class Color {
      * Faster than {@link Color#setStyle .setStyle()} method if you don't need the other CSS-style formats.
      * @param style Color name in X11 format.
      */
-    setColorName(style: ColorKeyword, colorSpace?: ColorSpace): Color;
+    setColorName(style: string, colorSpace?: ColorSpace): Color;
 
     /**
      * Clones this color.

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -9,7 +9,7 @@ import { WebGLRenderLists } from './webgl/WebGLRenderLists';
 import { WebGLState } from './webgl/WebGLState';
 import { Vector2 } from './../math/Vector2';
 import { Vector4 } from './../math/Vector4';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { WebGLRenderTarget } from './WebGLRenderTarget';
 import { WebGLMultipleRenderTargets } from './WebGLMultipleRenderTargets';
 import { Object3D } from './../core/Object3D';
@@ -22,7 +22,6 @@ import { Data3DTexture } from '../textures/Data3DTexture';
 import { Vector3 } from '../math/Vector3';
 import { Box3 } from '../math/Box3';
 import { DataArrayTexture } from '../textures/DataArrayTexture';
-import { ColorRepresentation } from '../utils';
 
 export interface Renderer {
     domElement: HTMLCanvasElement;

--- a/types/three/src/scenes/Fog.d.ts
+++ b/types/three/src/scenes/Fog.d.ts
@@ -1,5 +1,4 @@
-import { ColorRepresentation } from '../utils';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 
 export interface FogBase {
     /**

--- a/types/three/src/scenes/FogExp2.d.ts
+++ b/types/three/src/scenes/FogExp2.d.ts
@@ -1,5 +1,4 @@
-import { ColorRepresentation } from '../utils';
-import { Color } from './../math/Color';
+import { Color, ColorRepresentation } from './../math/Color';
 import { FogBase } from './Fog';
 
 /**

--- a/types/three/src/utils.d.ts
+++ b/types/three/src/utils.d.ts
@@ -1,6 +1,0 @@
-import { Color, ColorKeyword } from './math/Color';
-
-export type ColorModelString = `${'rgb' | 'hsl'}(${string})`;
-export type HexColorString = `#${string}`;
-
-export type ColorRepresentation = Color | ColorKeyword | ColorModelString | HexColorString | number | string;

--- a/types/three/src/utils.d.ts
+++ b/types/three/src/utils.d.ts
@@ -3,4 +3,4 @@ import { Color, ColorKeyword } from './math/Color';
 export type ColorModelString = `${'rgb' | 'hsl'}(${string})`;
 export type HexColorString = `#${string}`;
 
-export type ColorRepresentation = Color | ColorKeyword | ColorModelString | HexColorString | number;
+export type ColorRepresentation = Color | ColorKeyword | ColorModelString | HexColorString | number | string;


### PR DESCRIPTION
Is it possible to add a string type to ColorRepresentation, now I want to update the version of three.js and I have an error on creating Color class, because the data comes as a string and the string is not specified here. Otherwise, it will be necessary to rewrite "as ColorRepresentation" everywhere

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
