### PR TITLE
Update ObjectLoader.d.ts

### DIFF
--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -27,7 +27,7 @@ export class ObjectLoader extends Loader {
     // tslint:disable-next-line:no-unnecessary-generics
     parseAsync<T extends Object3D>(json: any): Promise<T>;
     parseGeometries(json: Record<string, any>): { [key: string]: InstancedBufferGeometry | BufferGeometry }; // Array of BufferGeometry or Geometry or Geometry2.
-    parseMaterials(json: Record<string, any>, textures: { [key: string]: Texture }): Material[]; // Array of Classes that inherits from Matrial.
+    parseMaterials(json: Record<string, any>, textures: { [key: string]: Texture }): Record<string, Material>; // Array of Classes that inherits from Matrial.
     parseAnimations(json: Record<string, any>): Record<string, AnimationClip>;
     parseImages(json: Record<string, any>, onLoad?: () => void): { [key: string]: Source };
     parseImagesAsync(json: Record<string, any>): Promise<{ [key: string]: Source }>;

--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -26,8 +26,8 @@ export class ObjectLoader extends Loader {
     parse<T extends Object3D>(json: any, onLoad?: (object: Object3D) => void): T;
     // tslint:disable-next-line:no-unnecessary-generics
     parseAsync<T extends Object3D>(json: any): Promise<T>;
-    parseGeometries(json: Record<string, any>): { [key: string]: InstancedBufferGeometry | BufferGeometry }; // Array of BufferGeometry or Geometry or Geometry2.
-    parseMaterials(json: Record<string, any>, textures: { [key: string]: Texture }): Record<string, Material>; // Array of Classes that inherits from Matrial.
+    parseGeometries(json: Record<string, any>): { [key: string]: InstancedBufferGeometry | BufferGeometry };
+    parseMaterials(json: Record<string, any>, textures: { [key: string]: Texture }): Record<string, Material>;
     parseAnimations(json: Record<string, any>): Record<string, AnimationClip>;
     parseImages(json: Record<string, any>, onLoad?: () => void): { [key: string]: Source };
     parseImagesAsync(json: Record<string, any>): Promise<{ [key: string]: Source }>;

--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -26,17 +26,18 @@ export class ObjectLoader extends Loader {
     parse<T extends Object3D>(json: any, onLoad?: (object: Object3D) => void): T;
     // tslint:disable-next-line:no-unnecessary-generics
     parseAsync<T extends Object3D>(json: any): Promise<T>;
-    parseGeometries(json: any): { [key: string]: InstancedBufferGeometry | BufferGeometry }; // Array of BufferGeometry or Geometry or Geometry2.
-    parseMaterials(json: any, textures: { [key: string]: Texture }): Material[]; // Array of Classes that inherits from Matrial.
-    parseAnimations(json: any): AnimationClip[];
-    parseImages(json: any, onLoad?: () => void): { [key: string]: Source };
-    parseImagesAsync(json: any): Promise<{ [key: string]: Source }>;
-    parseTextures(json: any, images: any): Texture[];
+    parseGeometries(json: Record<string, any>): { [key: string]: InstancedBufferGeometry | BufferGeometry }; // Array of BufferGeometry or Geometry or Geometry2.
+    parseMaterials(json: Record<string, any>, textures: { [key: string]: Texture }): Material[]; // Array of Classes that inherits from Matrial.
+    parseAnimations(json: Record<string, any>): Record<string, AnimationClip>;
+    parseImages(json: Record<string, any>, onLoad?: () => void): { [key: string]: Source };
+    parseImagesAsync(json: Record<string, any>): Promise<{ [key: string]: Source }>;
+    parseTextures(json: Record<string, any>, images: any): Record<string, Texture>;
     parseObject<T extends Object3D>(
         data: any,
-        geometries: any[],
-        materials: Material[],
-        animations: AnimationClip[],
+        geometries: Record<string, InstancedBufferGeometry | BufferGeometry>,
+        materials: Record<string, Material>,
+        textures: Record<string, Texture>,
+        animations: Record<string, AnimationClip>,
     ): // tslint:disable-next-line:no-unnecessary-generics
     T;
 }


### PR DESCRIPTION
Accept Records instead of Arrays, Missing argument in `ObjectLoader.parseObject`

### Why#399 

If you look at [ObjectLoader.parseObject#L683](https://github.com/mrdoob/three.js/blob/17cde661d11a76d663c92d5489fd1b83df36ae35/src/loaders/ObjectLoader.js#L683)
```js
parseObject( data, geometries, materials, textures, animations ) {
```
You'll notice that they're accepting textures as an argument before animations

I you look at [getGeometry](https://github.com/mrdoob/three.js/blob/17cde661d11a76d663c92d5489fd1b83df36ae35/src/loaders/ObjectLoader.js#L687) you'll notice that the `geometries` is expected to be an object/record

I you look at [getMaterial](https://github.com/mrdoob/three.js/blob/17cde661d11a76d663c92d5489fd1b83df36ae35/src/loaders/ObjectLoader.js#L699) you'll notice that the `materials` is expected to be an object/record

Same goes for [getTexture](https://github.com/mrdoob/three.js/blob/17cde661d11a76d663c92d5489fd1b83df36ae35/src/loaders/ObjectLoader.js#L735) which was missing in the arguments in `ObjectLoader.d.ts`

Those arguments are then passed to `parseImages`, `parseAnimations`, `parseMaterials`, `.parseGeometries` etc...

Ref: [.parseImages#L363](https://github.com/mrdoob/three.js/blob/17cde661d11a76d663c92d5489fd1b83df36ae35/src/loaders/ObjectLoader.js#L363)