### PR TITLE
fix(HemisphereLight): correct position modifier

### DIFF
--- a/types/three/src/lights/HemisphereLight.d.ts
+++ b/types/three/src/lights/HemisphereLight.d.ts
@@ -20,7 +20,7 @@ export class HemisphereLight extends Light {
      *
      * @default {@link Object3D.DEFAULT_UP}
      */
-    position: Vector3;
+    readonly position: Vector3;
 
     groundColor: Color;
 


### PR DESCRIPTION
the position member has to be readonly

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

because setting the position on HemisphereLight throws an error about readonly property

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
