### PR TITLE
NodeUtils: getNodesKeys -> getNodeChildren

### DIFF
--- a/types/three/examples/jsm/nodes/core/NodeUtils.d.ts
+++ b/types/three/examples/jsm/nodes/core/NodeUtils.d.ts
@@ -1,7 +1,13 @@
 import { NodeValueOption } from './constants';
 import Node from './Node';
 
-export function getNodesKeys(object: Node): string[];
+export interface NodeChild {
+    property: string;
+    index?: number | string;
+    childNode: Node;
+}
+
+export function getCacheKey(object: Node): string;
+export function getNodeChildren(object: Node): Generator<NodeChild, void>;
 export function getValueType(value: NodeValueOption): string | null;
 export function getValueFromType(type: string, ...params: number[]): NodeValueOption | null;
-export function getCacheKey(object: Node): string;

--- a/types/three/test/nodes/nodes-webgl.ts
+++ b/types/three/test/nodes/nodes-webgl.ts
@@ -18,7 +18,7 @@ new SlotNode({
     nodeType: 'float',
 });
 
-NodeUtils.getNodesKeys(new Nodes.ConstNode(1));
+NodeUtils.getNodeChildren(new Nodes.ConstNode(1));
 NodeUtils.getValueType(1);
 NodeUtils.getValueFromType('color');
 


### PR DESCRIPTION
### Why

Make type changes corresponding to https://github.com/mrdoob/three.js/pull/25581.

### What

Replace `getNodeKeys` with `getNodeChildren`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
