### PR TITLE
NodeBuilder remove outdated methods

### DIFF
--- a/types/three/examples/jsm/nodes/core/NodeBuilder.d.ts
+++ b/types/three/examples/jsm/nodes/core/NodeBuilder.d.ts
@@ -85,13 +85,6 @@ export default abstract class NodeBuilder {
 
     isFlipY(): boolean;
 
-    abstract getTexture(textureProperty: string, uvSnippet: string): string;
-
-    abstract getTextureLevel(textureProperty: string, uvSnippet: string, levelSnippet: string): string;
-
-    abstract getCubeTexture(textureProperty: string, uvSnippet: string): string;
-    abstract getCubeTextureLevel(textureProperty: string, uvSnippet: string, levelSnippet: string): string;
-
     // @TODO: rename to .generateConst()
     getConst(type: NodeTypeOption, value?: unknown): Node;
     getType(type: NodeTypeOption): NodeTypeOption;

--- a/types/three/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.d.ts
+++ b/types/three/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder.d.ts
@@ -13,25 +13,6 @@ export class WebGLNodeBuilder extends NodeBuilder {
 
     addSlot(shaderStage: NodeShaderStageOption, slotNode: SlotNode): Node;
 
-    getTexture(textureProperty: string, uvSnippet: string): string;
-    getTextureBias(textureProperty: string, uvSnippet: string, biasSnippet: string): string;
-
-    getTextureLevel(
-        textureProperty: string,
-        uvSnippet: string,
-        biasSnippet: string,
-        shaderStage?: NodeShaderStageOption,
-    ): string;
-    getCubeTexture(texturePropert: string, uvSnippet: string, shaderStage?: NodeShaderStageOption): string;
-
-    getCubeTextureLevel(
-        textureProperty: string,
-        uvSnippet: string,
-        biasSnippet: string,
-        shaderStage?: NodeShaderStageOption,
-    ): string;
-
-    getCubeTextureBias(textureProperty: string, uvSnippet: string, biasSnippet: string): string;
     getUniforms(shaderStage: string): string;
 
     getAttributes(shaderStage: string): string;


### PR DESCRIPTION
### Why

Make type changes corresponding to https://github.com/mrdoob/three.js/pull/25766.

### What

Some methods were changed/removed. I removed the modified methods from the types since they are no longer accurate and I'm not sure what type the `texture` parameter should be.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
