### PR TITLE
fix: wrong typing of SpotLight

### DIFF
--- a/types/three/src/lights/SpotLight.d.ts
+++ b/types/three/src/lights/SpotLight.d.ts
@@ -63,7 +63,7 @@ export class SpotLight extends Light<SpotLightShadow> {
      * This is set equal to {@link THREE.Object3D.DEFAULT_UP | Object3D.DEFAULT_UP} (0, 1, 0), so that the light shines from the top down.
      * @defaultValue `{@link Object3D.DEFAULT_UP}`
      */
-    position: Vector3;
+    readonly position: Vector3;
 
     /**
      * The {@link SpotLight} points from its {@link SpotLight.position | position} to target.position.


### PR DESCRIPTION
position should be readonly

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
