### PR TITLE
Fix FilmPass grayscale parameter type

### DIFF
--- a/types/three/examples/jsm/postprocessing/FilmPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/FilmPass.d.ts
@@ -3,7 +3,7 @@ import { ShaderMaterial } from '../../../src/Three';
 import { Pass, FullScreenQuad } from './Pass';
 
 export class FilmPass extends Pass {
-    constructor(noiseIntensity?: number, scanlinesIntensity?: number, scanlinesCount?: number, grayscale?: number);
+    constructor(noiseIntensity?: number, scanlinesIntensity?: number, scanlinesCount?: number, grayscale?: boolean);
     uniforms: object;
     material: ShaderMaterial;
     fsQuad: FullScreenQuad;


### PR DESCRIPTION
### Why

The `grayscale` parameter to `FilmPass` should be of type `boolean` as seen in [this example](https://github.com/mrdoob/three.js/blob/dev/examples/misc_controls_fly.html#L231).

### What

Make `grayscale` parameter a `boolean`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
