### PR TITLE
Disable tween.js updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
             "groupName": "prettier"
         },
         {
+            "matchPackageNames": ["@tweenjs/tween.js"],
+            "matchUpdateTypes": ["major", "minor"],
+            "enabled": false
+        },
+        {
             "matchPackageNames": ["fflate"],
             "matchUpdateTypes": ["major", "minor"],
             "enabled": false


### PR DESCRIPTION
### Why

tween.js version should match with three.js's version.

### What

Disable Renovate updates for tween.js.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
