### PR TITLE
Fix blinn parameter type in TeapotGeometry

### DIFF
--- a/types/three/examples/jsm/geometries/TeapotGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/TeapotGeometry.d.ts
@@ -8,6 +8,6 @@ export class TeapotGeometry extends BufferGeometry {
         lid?: boolean,
         body?: boolean,
         fitLid?: boolean,
-        blinn?: number,
+        blinn?: boolean,
     );
 }


### PR DESCRIPTION
### Why

The [`blinn` parameter is a boolean](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/geometries/TeapotGeometry.js#L59).

### What

Update type.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
