### PR TITLE
Improve ColladaExporter types

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -15,7 +15,6 @@ examples/jsm/effects/AsciiEffect.d.ts
 examples/jsm/effects/ParallaxBarrierEffect.d.ts
 examples/jsm/effects/PeppersGhostEffect.d.ts
 examples/jsm/effects/StereoEffect.d.ts
-examples/jsm/exporters/ColladaExporter.d.ts
 examples/jsm/exporters/DRACOExporter.d.ts
 examples/jsm/exporters/EXRExporter.d.ts
 examples/jsm/exporters/GLTFExporter.d.ts

--- a/types/three/examples/jsm/exporters/ColladaExporter.d.ts
+++ b/types/three/examples/jsm/exporters/ColladaExporter.d.ts
@@ -1,14 +1,25 @@
-import { Object3D } from '../../../src/Three';
+import { Object3D, Texture } from '../../../src/Three';
 
 export interface ColladaExporterOptions {
+    version?: string;
     author?: string;
     textureDirectory?: string;
-    version?: string;
+    upAxis?: 'Y_UP' | 'Z_UP' | 'X_UP';
+    unitName?: string;
+    unitMeter?: number;
+}
+
+export interface ColladaTexture {
+    directory: string;
+    name: string;
+    ext: string;
+    data: Uint8Array;
+    original: Texture;
 }
 
 export interface ColladaExporterResult {
     data: string;
-    textures: object[];
+    textures: ColladaTexture[];
 }
 
 export class ColladaExporter {
@@ -16,7 +27,7 @@ export class ColladaExporter {
 
     parse(
         object: Object3D,
-        onDone: (res: ColladaExporterResult) => void,
+        onDone: ((res: ColladaExporterResult) => void) | undefined,
         options: ColladaExporterOptions,
     ): ColladaExporterResult | null;
 }

--- a/types/three/test/unit/examples/jsm/exporters/ColladaExporter.ts
+++ b/types/three/test/unit/examples/jsm/exporters/ColladaExporter.ts
@@ -1,0 +1,34 @@
+import * as THREE from 'three';
+
+import { ColladaExporter } from 'three/examples/jsm/exporters/ColladaExporter';
+
+const exporter = new ColladaExporter();
+declare const mesh: THREE.Mesh;
+
+const result = exporter.parse(mesh, undefined, {
+    upAxis: 'Y_UP',
+    unitName: 'millimeter',
+    unitMeter: 0.001,
+})!;
+
+saveString(result.data, 'mesh.dae');
+
+result.textures.forEach(tex => {
+    saveArrayBuffer(tex.data, `${tex.name}.${tex.ext}`);
+});
+
+function save(blob: Blob, filename: string) {
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+}
+
+function saveString(text: string, filename: string) {
+    save(new Blob([text], { type: 'text/plain' }), filename);
+}
+
+function saveArrayBuffer(buffer: BufferSource, filename: string) {
+    save(new Blob([buffer], { type: 'application/octet-stream' }), filename);
+}
+
+const link = document.createElement('a');

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -79,6 +79,7 @@
         "test/integration/three-examples/webxr_ar_lighting.ts",
         "test/integration/three-examples/webxr_vr_handinput_cubes.ts",
         "test/integration/webxr-vr-cube.ts",
+        "test/unit/examples/jsm/exporters/ColladaExporter.ts",
         "test/unit/examples/jsm/helpers/ViewHelper.ts",
         "test/unit/examples/jsm/libs/lil-gui.ts",
         "test/unit/examples/jsm/libs/tween.ts",


### PR DESCRIPTION
### Why

The ColladaExporter types were missing some detail.

### What

Update types based on [the docs](https://threejs.org/docs/index.html?q=collada#examples/en/exporters/ColladaExporter).

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
