### PR TITLE
Make DRACOExporter.parse options optional

### DIFF
--- a/types/three/examples/jsm/exporters/DRACOExporter.d.ts
+++ b/types/three/examples/jsm/exporters/DRACOExporter.d.ts
@@ -13,5 +13,5 @@ export interface DRACOExporterOptions {
 export class DRACOExporter {
     constructor();
 
-    parse(object: Mesh | Points, options: DRACOExporterOptions): Int8Array;
+    parse(object: Mesh | Points, options?: DRACOExporterOptions): Int8Array;
 }


### PR DESCRIPTION
### Why

The `options` for `DRACOExporter.parse` should [be optional](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/exporters/DRACOExporter.js#L22).

### What

Make the parameter optional.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
