### PR TITLE
Define GridHelper Material generic

### DIFF
--- a/types/three/src/helpers/GridHelper.d.ts
+++ b/types/three/src/helpers/GridHelper.d.ts
@@ -1,5 +1,7 @@
 import { ColorRepresentation } from '../math/Color';
 import { LineSegments } from './../objects/LineSegments';
+import { BufferGeometry } from '../core/BufferGeometry';
+import { LineBasicMaterial } from '../materials/LineBasicMaterial';
 
 /**
  * The {@link GridHelper} is an object to define grids
@@ -16,7 +18,7 @@ import { LineSegments } from './../objects/LineSegments';
  * @see {@link https://threejs.org/docs/index.html#api/en/helpers/GridHelper | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/helpers/GridHelper.js | Source}
  */
-export class GridHelper extends LineSegments {
+export class GridHelper extends LineSegments<BufferGeometry, LineBasicMaterial> {
     /**
      * Creates a new {@link GridHelper} of size 'size' and divided into 'divisions' segments per side
      * @remarks


### PR DESCRIPTION
### Why

[`GridHelper` uses a `BufferGeometry` and `LineBasicMaterial`](https://github.com/mrdoob/three.js/blob/master/src/helpers/GridHelper.js#L34C24-L40). Narrowing the generic makes it easier to make updates to the material properties without having to consider whether the material is an array.

### What

Define geometry and material generics for `GridHelper`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
