### PR TITLE
Improve PLYExporter types

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -22,7 +22,6 @@ examples/jsm/exporters/GLTFExporter.d.ts
 examples/jsm/exporters/KTX2Exporter.d.ts
 examples/jsm/exporters/MMDExporter.d.ts
 examples/jsm/exporters/OBJExporter.d.ts
-examples/jsm/exporters/PLYExporter.d.ts
 examples/jsm/exporters/STLExporter.d.ts
 examples/jsm/exporters/USDZExporter.d.ts
 examples/jsm/geometries/BoxLineGeometry.d.ts

--- a/types/three/examples/jsm/exporters/PLYExporter.d.ts
+++ b/types/three/examples/jsm/exporters/PLYExporter.d.ts
@@ -1,13 +1,30 @@
 import { Object3D } from '../../../src/Three';
 
-export interface PLYExporterOptions {
-    binary?: boolean;
+export interface PLYExporterOptionsBase {
     excludeAttributes?: string[];
     littleEndian?: boolean;
+}
+
+export interface PLYExporterOptionsBinary extends PLYExporterOptionsBase {
+    binary: true;
+}
+
+export interface PLYExporterOptionsString extends PLYExporterOptionsBase {
+    binary?: false;
+}
+
+export interface PLYExporterOptions extends PLYExporterOptionsBase {
+    binary?: boolean;
 }
 
 export class PLYExporter {
     constructor();
 
-    parse(object: Object3D, onDone: (res: string) => void, options: PLYExporterOptions): string | null;
+    parse(object: Object3D, onDone: (res: ArrayBuffer) => void, options: PLYExporterOptionsBinary): ArrayBuffer | null;
+    parse(object: Object3D, onDone: (res: string) => void, options?: PLYExporterOptionsString): string | null;
+    parse(
+        object: Object3D,
+        onDone: (res: string | ArrayBuffer) => void,
+        options?: PLYExporterOptions,
+    ): string | ArrayBuffer | null;
 }

--- a/types/three/test/unit/examples/jsm/exporters/PLYExporter.ts
+++ b/types/three/test/unit/examples/jsm/exporters/PLYExporter.ts
@@ -1,0 +1,50 @@
+import * as THREE from 'three';
+
+import { PLYExporter } from 'three/examples/jsm/exporters/PLYExporter';
+
+const exporter = new PLYExporter();
+declare const mesh: THREE.Mesh;
+
+function exportASCII() {
+    exporter.parse(mesh, result => {
+        saveString(result, 'box.ply');
+    });
+}
+
+function exportBinaryBigEndian() {
+    exporter.parse(
+        mesh,
+        result => {
+            saveArrayBuffer(result, 'box.ply');
+        },
+        { binary: true },
+    );
+}
+
+function exportBinaryLittleEndian() {
+    exporter.parse(
+        mesh,
+        result => {
+            saveArrayBuffer(result, 'box.ply');
+        },
+        { binary: true, littleEndian: true },
+    );
+}
+
+const link = document.createElement('a');
+link.style.display = 'none';
+document.body.appendChild(link);
+
+function save(blob: Blob, filename: string) {
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+}
+
+function saveString(text: string, filename: string) {
+    save(new Blob([text], { type: 'text/plain' }), filename);
+}
+
+function saveArrayBuffer(buffer: BufferSource, filename: string) {
+    save(new Blob([buffer], { type: 'application/octet-stream' }), filename);
+}

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -79,6 +79,7 @@
         "test/integration/three-examples/webxr_ar_lighting.ts",
         "test/integration/three-examples/webxr_vr_handinput_cubes.ts",
         "test/integration/webxr-vr-cube.ts",
+        "test/unit/examples/jsm/exporters/PLYExporter.ts",
         "test/unit/examples/jsm/helpers/ViewHelper.ts",
         "test/unit/examples/jsm/libs/lil-gui.ts",
         "test/unit/examples/jsm/libs/tween.ts",


### PR DESCRIPTION
### Why

[PLYExporter.parse() returns a different type if provided the `binary` option](https://threejs.org/docs/index.html?q=plyex#examples/en/exporters/PLYExporter.parse).

### What

Add function overloads to `PLYExporter.parse()` to work with the `binary` option.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
