### PR TITLE
Improve STLExporter types

### DIFF
--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -23,7 +23,6 @@ examples/jsm/exporters/KTX2Exporter.d.ts
 examples/jsm/exporters/MMDExporter.d.ts
 examples/jsm/exporters/OBJExporter.d.ts
 examples/jsm/exporters/PLYExporter.d.ts
-examples/jsm/exporters/STLExporter.d.ts
 examples/jsm/exporters/USDZExporter.d.ts
 examples/jsm/geometries/BoxLineGeometry.d.ts
 examples/jsm/geometries/ConvexGeometry.d.ts

--- a/types/three/examples/jsm/exporters/STLExporter.d.ts
+++ b/types/three/examples/jsm/exporters/STLExporter.d.ts
@@ -1,5 +1,13 @@
 import { Object3D } from '../../../src/Three';
 
+export interface STLExporterOptionsBinary {
+    binary: true;
+}
+
+export interface STLExporterOptionsString {
+    binary?: false;
+}
+
 export interface STLExporterOptions {
     binary?: boolean;
 }
@@ -7,5 +15,7 @@ export interface STLExporterOptions {
 export class STLExporter {
     constructor();
 
-    parse(scene: Object3D, options?: STLExporterOptions): string;
+    parse(scene: Object3D, options: STLExporterOptionsBinary): DataView;
+    parse(scene: Object3D, options?: STLExporterOptionsString): string;
+    parse(scene: Object3D, options?: STLExporterOptions): string | DataView;
 }

--- a/types/three/test/unit/examples/jsm/exporters/STLExporter.ts
+++ b/types/three/test/unit/examples/jsm/exporters/STLExporter.ts
@@ -1,0 +1,34 @@
+import * as THREE from 'three';
+
+import { STLExporter } from 'three/examples/jsm/exporters/STLExporter';
+
+const exporter = new STLExporter();
+declare const mesh: THREE.Mesh;
+
+function exportASCII() {
+    const result = exporter.parse(mesh);
+    saveString(result, 'box.stl');
+}
+
+function exportBinary() {
+    const result = exporter.parse(mesh, { binary: true });
+    saveArrayBuffer(result, 'box.stl');
+}
+
+const link = document.createElement('a');
+link.style.display = 'none';
+document.body.appendChild(link);
+
+function save(blob: Blob, filename: string) {
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+}
+
+function saveString(text: string, filename: string) {
+    save(new Blob([text], { type: 'text/plain' }), filename);
+}
+
+function saveArrayBuffer(buffer: BufferSource, filename: string) {
+    save(new Blob([buffer], { type: 'application/octet-stream' }), filename);
+}

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -79,6 +79,7 @@
         "test/integration/three-examples/webxr_ar_lighting.ts",
         "test/integration/three-examples/webxr_vr_handinput_cubes.ts",
         "test/integration/webxr-vr-cube.ts",
+        "test/unit/examples/jsm/exporters/STLExporter.ts",
         "test/unit/examples/jsm/helpers/ViewHelper.ts",
         "test/unit/examples/jsm/libs/lil-gui.ts",
         "test/unit/examples/jsm/libs/tween.ts",


### PR DESCRIPTION
### Why

[STLExporter.parse() returns a different type if provided the `binary` option](https://threejs.org/docs/index.html?q=stlex#examples/en/exporters/STLExporter.parse).

### What

Add function overloads to `STLExporter.parse()` to work with the `binary` option.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
