### PR TITLE
Make size paramter optional in UVsDebug

### DIFF
--- a/types/three/examples/jsm/utils/UVsDebug.d.ts
+++ b/types/three/examples/jsm/utils/UVsDebug.d.ts
@@ -1,3 +1,3 @@
 import { BufferGeometry } from '../../../src/Three';
 
-export function UVsDebug(geometry: BufferGeometry, size: number): HTMLCanvasElement;
+export function UVsDebug(geometry: BufferGeometry, size?: number): HTMLCanvasElement;


### PR DESCRIPTION
### Why

[The `size` parameter should be optional](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/utils/UVsDebug.js#L13).

### What

Make it optional.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
