### PR TITLE
Add missing functions and properties in several classes

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -266,5 +266,4 @@ export class OrbitControls extends EventDispatcher {
      * Returns the distance from the camera to the target.
      */
     getDistance(): number;
-
 }

--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -1,4 +1,4 @@
-import { Camera, MOUSE, TOUCH, Vector3 } from '../../../src/Three';
+import { Camera, MOUSE, TOUCH, Vector3, EventDispatcher, Event } from '../../../src/Three';
 
 /**
  * Orbit controls allow the camera to orbit around a target.
@@ -7,7 +7,7 @@ import { Camera, MOUSE, TOUCH, Vector3 } from '../../../src/Three';
  * @param domElement - The HTML element used for
  * event listeners.
  */
-export class OrbitControls {
+export class OrbitControls extends EventDispatcher {
     constructor(object: Camera, domElement?: HTMLElement);
 
     /**
@@ -267,12 +267,4 @@ export class OrbitControls {
      */
     getDistance(): number;
 
-    // EventDispatcher mixins
-    addEventListener(type: string, listener: (event: any) => void): void;
-
-    hasEventListener(type: string, listener: (event: any) => void): boolean;
-
-    removeEventListener(type: string, listener: (event: any) => void): void;
-
-    dispatchEvent(event: { type: string; target: any }): void;
 }

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -1,4 +1,4 @@
-import {Object3D, AnimationClip, Texture, Material, Mesh, BufferGeometry, PixelFormat} from '../../../src/Three';
+import { Object3D, AnimationClip, Texture, Material, Mesh, BufferGeometry, PixelFormat } from '../../../src/Three';
 
 export interface GLTFExporterOptions {
     /**
@@ -89,7 +89,7 @@ export class GLTFExporter {
 
     static Utils: {
         GLTFWriter: typeof GLTFWriter;
-    }
+    };
 }
 
 declare class GLTFWriter {
@@ -110,16 +110,16 @@ declare class GLTFWriter {
         options?: GLTFExporterOptions,
     ): Promise<void>;
 
-    serializeUserData( object: Object3D | Material | BufferGeometry, objectDef: { [key: string]: any } ): void;
+    serializeUserData(object: Object3D | Material | BufferGeometry, objectDef: { [key: string]: any }): void;
 
     processObjects(objects: Object3D[]): void;
     processScene(scene: Object3D): void;
-    processMaterial(material: Material): number|null;
-    processImage(image: any, format: PixelFormat, flipY: boolean, mimeType?: string ): number;
-    processBufferViewImage( blob: Blob ): Promise<number>;
+    processMaterial(material: Material): number | null;
+    processImage(image: any, format: PixelFormat, flipY: boolean, mimeType?: string): number;
+    processBufferViewImage(blob: Blob): Promise<number>;
     processSampler(map: Texture): number;
     processTexture(map: Texture): number;
-    applyTextureTransform( mapDef: {[key: string]: any}, texture: Texture): void;
+    applyTextureTransform(mapDef: { [key: string]: any }, texture: Texture): void;
     cache: {
         textures: Map<Texture, number>;
         materials: Map<Material, number>;
@@ -127,7 +127,7 @@ declare class GLTFWriter {
         attributes: Map<BufferGeometry, { [key: string]: number }>;
         attributesNormalized: Map<BufferGeometry, { [key: string]: boolean }>;
         images: Map<any, any>;
-    }
+    };
     json: {
         asset: { [key: string]: any };
         scenes: { [key: string]: any }[];
@@ -147,14 +147,14 @@ declare class GLTFWriter {
         extensions: { [key: string]: any };
         extensionsUsed: string[];
         extensionsRequired: string[];
-    }
+    };
     options: any;
     pending: Promise<any>[];
     plugins: GLTFExporterPlugin[];
     extensionsUsed: { [key: string]: boolean };
-    processBufferViewImageBuffer( buffer: ArrayBuffer ): number;
+    processBufferViewImageBuffer(buffer: ArrayBuffer): number;
 
-    _invokeAll( func: (plugin: GLTFExporterPlugin)=>void ): void;
+    _invokeAll(func: (plugin: GLTFExporterPlugin) => void): void;
 }
 
 export interface GLTFExporterPlugin {

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -1,4 +1,4 @@
-import { Object3D, AnimationClip, Texture, Material, Mesh } from '../../../src/Three';
+import {Object3D, AnimationClip, Texture, Material, Mesh, BufferGeometry, PixelFormat} from '../../../src/Three';
 
 export interface GLTFExporterOptions {
     /**
@@ -86,9 +86,13 @@ export class GLTFExporter {
         input: Object3D | Object3D[],
         options?: GLTFExporterOptions,
     ): Promise<ArrayBuffer | { [key: string]: any }>;
+
+    static Utils: {
+        GLTFWriter: typeof GLTFWriter;
+    }
 }
 
-export class GLTFWriter {
+declare class GLTFWriter {
     constructor();
 
     setPlugins(plugins: GLTFExporterPlugin[]): void;
@@ -105,6 +109,52 @@ export class GLTFWriter {
         onDone: (gltf: ArrayBuffer | { [key: string]: any }) => void,
         options?: GLTFExporterOptions,
     ): Promise<void>;
+
+    serializeUserData( object: Object3D | Material | BufferGeometry, objectDef: { [key: string]: any } ): void;
+
+    processObjects(objects: Object3D[]): void;
+    processScene(scene: Object3D): void;
+    processMaterial(material: Material): number|null;
+    processImage(image: any, format: PixelFormat, flipY: boolean, mimeType?: string ): number;
+    processBufferViewImage( blob: Blob ): Promise<number>;
+    processSampler(map: Texture): number;
+    processTexture(map: Texture): number;
+    applyTextureTransform( mapDef: {[key: string]: any}, texture: Texture): void;
+    cache: {
+        textures: Map<Texture, number>;
+        materials: Map<Material, number>;
+        meshes: Map<Mesh, number>;
+        attributes: Map<BufferGeometry, { [key: string]: number }>;
+        attributesNormalized: Map<BufferGeometry, { [key: string]: boolean }>;
+        images: Map<any, any>;
+    }
+    json: {
+        asset: { [key: string]: any };
+        scenes: { [key: string]: any }[];
+        scene: number;
+        nodes: { [key: string]: any }[];
+        materials: { [key: string]: any }[];
+        meshes: { [key: string]: any }[];
+        cameras: { [key: string]: any }[];
+        skins: { [key: string]: any }[];
+        animations: { [key: string]: any }[];
+        images: { [key: string]: any }[];
+        textures: { [key: string]: any }[];
+        samplers: { [key: string]: any }[];
+        accessors: { [key: string]: any }[];
+        bufferViews: { [key: string]: any }[];
+        buffers: { [key: string]: any }[];
+        extensions: { [key: string]: any };
+        extensionsUsed: string[];
+        extensionsRequired: string[];
+    }
+    options: any;
+    pending: Promise<any>[];
+    plugins: GLTFExporterPlugin[];
+    extensionsUsed: { [key: string]: boolean };
+    processBufferViewImageBuffer( buffer: ArrayBuffer ): number;
+
+    _invokeAll( func: (plugin: GLTFExporterPlugin)=>void ): void;
 }
 
 export interface GLTFExporterPlugin {

--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -139,6 +139,7 @@ export class GLTFParser {
 }
 
 export interface GLTFLoaderPlugin {
+    name: string;
     beforeRoot?: (() => Promise<void> | null) | undefined;
     afterRoot?: ((result: GLTF) => Promise<void> | null) | undefined;
     loadNode?: ((nodeIndex: number) => Promise<Object3D> | null) | undefined;

--- a/types/three/examples/jsm/nodes/loaders/NodeObjectLoader.d.ts
+++ b/types/three/examples/jsm/nodes/loaders/NodeObjectLoader.d.ts
@@ -5,7 +5,5 @@ import { AnyJson } from '../core/constants';
 export default class NodeObjectLoader extends ObjectLoader {
     parseNodes(json: AnyJson, textures: { [key: string]: Texture }): NodeLoaderResult;
 
-    // tslint:disable-next-line:comment-format
-    //@ts-expect-error
     parseMaterials(json: AnyJson, textures: { [key: string]: Texture }): { [key: string]: Material };
 }

--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -1,12 +1,14 @@
 import { Loader } from './Loader';
 import { LoadingManager } from './LoadingManager';
 import { Object3D } from './../core/Object3D';
+import { Shape } from './../extras/core/Shape';
 import { Texture } from './../textures/Texture';
 import { Material } from './../materials/Material';
 import { AnimationClip } from './../animation/AnimationClip';
 import { InstancedBufferGeometry } from '../core/InstancedBufferGeometry';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Source } from '../textures/Source';
+import { Skeleton } from '../objects/Skeleton'
 
 export class ObjectLoader extends Loader {
     constructor(manager?: LoadingManager);
@@ -26,17 +28,21 @@ export class ObjectLoader extends Loader {
     parse<T extends Object3D>(json: any, onLoad?: (object: Object3D) => void): T;
     // tslint:disable-next-line:no-unnecessary-generics
     parseAsync<T extends Object3D>(json: any): Promise<T>;
-    parseGeometries(json: any): { [key: string]: InstancedBufferGeometry | BufferGeometry }; // Array of BufferGeometry or Geometry or Geometry2.
-    parseMaterials(json: any, textures: { [key: string]: Texture }): Material[]; // Array of Classes that inherits from Matrial.
-    parseAnimations(json: any): AnimationClip[];
-    parseImages(json: any, onLoad?: () => void): { [key: string]: Source };
-    parseImagesAsync(json: any): Promise<{ [key: string]: Source }>;
-    parseTextures(json: any, images: any): Texture[];
+    parseGeometries(json: any[], shapes: Shape[]): { [key: string]: InstancedBufferGeometry | BufferGeometry }; // Array of BufferGeometry or Geometry or Geometry2.
+    parseMaterials(json: any[], textures: { [key: string]: Texture }): { [key: string]: Material }; // Array of Classes that inherits from Matrial.
+    parseAnimations(json: any[]): { [key: string]: AnimationClip };
+    parseShapes(json: any[]): { [key: string]: Shape };
+    parseImages(json: any[], onLoad?: () => void): { [key: string]: Source };
+    parseImagesAsync(json: any[]): Promise<{ [key: string]: Source }>;
+    parseTextures(json: any[], images: any): { [key: string]: Texture };
+    parseSkeletons(json: any[], object: Object3D): { [key: string]: Skeleton };
+    bindSkeletons(object: Object3D, skeletons: Record<string, Skeleton>): void;
     parseObject<T extends Object3D>(
         data: any,
-        geometries: any[],
-        materials: Material[],
-        animations: AnimationClip[],
+        geometries: Record<string, InstancedBufferGeometry | BufferGeometry>,
+        materials: Record<string, Material>,
+        textures: Record<string, Texture>,
+        animations: Record<string, AnimationClip>,
     ): // tslint:disable-next-line:no-unnecessary-generics
     T;
 }

--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -8,7 +8,7 @@ import { AnimationClip } from './../animation/AnimationClip';
 import { InstancedBufferGeometry } from '../core/InstancedBufferGeometry';
 import { BufferGeometry } from '../core/BufferGeometry';
 import { Source } from '../textures/Source';
-import { Skeleton } from '../objects/Skeleton'
+import { Skeleton } from '../objects/Skeleton';
 
 export class ObjectLoader extends Loader {
     constructor(manager?: LoadingManager);

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -13,6 +13,10 @@ import {
     StencilOp,
     PixelFormat,
 } from '../constants';
+import {Scene} from '../scenes/Scene'
+import {Camera} from '../cameras/Camera'
+import {BufferGeometry} from '../core/BufferGeometry'
+import {Object3D} from '../core/Object3D'
 
 export interface MaterialParameters {
     alphaTest?: number | undefined;
@@ -384,6 +388,8 @@ export class Material extends EventDispatcher {
      * @param renderer WebGLRenderer Context that is initializing the material
      */
     onBeforeCompile(shader: Shader, renderer: WebGLRenderer): void;
+
+    onBeforeRender(renderer: WebGLRenderer, scene: Scene, camera: Camera, geometry: BufferGeometry, object: Object3D): void
 
     /**
      * In case onBeforeCompile is used, this callback can be used to identify values of settings used in onBeforeCompile, so three.js can reuse a cached shader or recompile the shader as needed.

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -13,10 +13,10 @@ import {
     StencilOp,
     PixelFormat,
 } from '../constants';
-import {Scene} from '../scenes/Scene'
-import {Camera} from '../cameras/Camera'
-import {BufferGeometry} from '../core/BufferGeometry'
-import {Object3D} from '../core/Object3D'
+import { Scene } from '../scenes/Scene';
+import { Camera } from '../cameras/Camera';
+import { BufferGeometry } from '../core/BufferGeometry';
+import { Object3D } from '../core/Object3D';
 
 export interface MaterialParameters {
     alphaTest?: number | undefined;
@@ -389,7 +389,13 @@ export class Material extends EventDispatcher {
      */
     onBeforeCompile(shader: Shader, renderer: WebGLRenderer): void;
 
-    onBeforeRender(renderer: WebGLRenderer, scene: Scene, camera: Camera, geometry: BufferGeometry, object: Object3D): void
+    onBeforeRender(
+        renderer: WebGLRenderer,
+        scene: Scene,
+        camera: Camera,
+        geometry: BufferGeometry,
+        object: Object3D,
+    ): void;
 
     /**
      * In case onBeforeCompile is used, this callback can be used to identify values of settings used in onBeforeCompile, so three.js can reuse a cached shader or recompile the shader as needed.

--- a/types/three/src/math/Matrix3.d.ts
+++ b/types/three/src/math/Matrix3.d.ts
@@ -56,6 +56,8 @@ export class Matrix3 implements Matrix {
      */
     constructor();
 
+    readonly isMatrix3: true;
+
     /**
      * Array with matrix values.
      * @default [1, 0, 0, 0, 1, 0, 0, 0, 1]

--- a/types/three/src/math/Matrix4.d.ts
+++ b/types/three/src/math/Matrix4.d.ts
@@ -43,6 +43,8 @@ export type Matrix4Tuple = [
 export class Matrix4 implements Matrix {
     constructor();
 
+    readonly isMatrix4: true;
+
     /**
      * Array with matrix values.
      * @default [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]

--- a/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
+++ b/types/three/src/renderers/WebGLMultipleRenderTargets.d.ts
@@ -26,4 +26,10 @@ export class WebGLMultipleRenderTargets extends EventDispatcher {
     dispose(): void;
     // This is an available method, however it will break the code see https://github.com/mrdoob/three.js/issues/21930
     setTexture(texture: Texture): void;
+
+    /**
+     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
+     * @default 0
+     */
+    samples: number;
 }

--- a/types/three/test/integration/loaders-gltfloader-plugin.ts
+++ b/types/three/test/integration/loaders-gltfloader-plugin.ts
@@ -19,6 +19,7 @@ init().then(() => {
 
 class ExamplePlugin implements GLTFLoaderPlugin {
     parser: GLTFParser;
+    name = 'ExamplePlugin';
 
     constructor(parser: GLTFParser) {
         this.parser = parser;


### PR DESCRIPTION

Changes in: OrbitControls, GLTFExporter, GLTFWriter, ObjectLoader, Material, Matrix3, Matrix4, WebGLMultipleRenderTargets

### Why

Add missing properties and functions.

### What

- Extend OrbitControls from EventDispatcher like in three.js
- Put GLTFWriter in GLTFExporter.Utils like in three.js
- Add functions to GLTFWriter
- Add `name` property in GLTFLoaderPlugin
- Add missing parse functions to GLTFLoader and fix return types of others.
- Add onBeforeRender in Material
- Add readonly props isMatrix3 and isMatrix4
- Add samples to MultisampleRenderTargets


-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged
