### PR TITLE
Changes in Pass and RenderPass

### DIFF
--- a/types/three/examples/jsm/postprocessing/Pass.d.ts
+++ b/types/three/examples/jsm/postprocessing/Pass.d.ts
@@ -1,4 +1,4 @@
-import { Material, WebGLRenderer, WebGLRenderTarget } from '../../../src/Three';
+import {Material, WebGLMultipleRenderTargets, WebGLRenderer, WebGLRenderTarget} from '../../../src/Three';
 
 export class Pass {
     constructor();
@@ -12,10 +12,10 @@ export class Pass {
     setSize(width: number, height: number): void;
     render(
         renderer: WebGLRenderer,
-        writeBuffer: WebGLRenderTarget,
-        readBuffer: WebGLRenderTarget,
-        deltaTime: number,
-        maskActive: boolean,
+        writeBuffer: WebGLMultipleRenderTargets | WebGLRenderTarget | null,
+        readBuffer?: WebGLMultipleRenderTargets | WebGLRenderTarget,
+        deltaTime?: number,
+        maskActive?: boolean,
     ): void;
 
     dispose(): void;

--- a/types/three/examples/jsm/postprocessing/Pass.d.ts
+++ b/types/three/examples/jsm/postprocessing/Pass.d.ts
@@ -1,4 +1,4 @@
-import {Material, WebGLMultipleRenderTargets, WebGLRenderer, WebGLRenderTarget} from '../../../src/Three';
+import { Material, WebGLMultipleRenderTargets, WebGLRenderer, WebGLRenderTarget } from '../../../src/Three';
 
 export class Pass {
     constructor();

--- a/types/three/examples/jsm/postprocessing/RenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/RenderPass.d.ts
@@ -1,4 +1,12 @@
-import {Scene, Camera, Material, Color, WebGLMultipleRenderTargets, WebGLRenderTarget, WebGLRenderer} from '../../../src/Three';
+import {
+    Scene,
+    Camera,
+    Material,
+    Color,
+    WebGLMultipleRenderTargets,
+    WebGLRenderTarget,
+    WebGLRenderer,
+} from '../../../src/Three';
 import { Pass, FullScreenQuad } from './Pass';
 
 export class RenderPass extends Pass {
@@ -15,6 +23,6 @@ export class RenderPass extends Pass {
         _: WebGLMultipleRenderTargets | WebGLRenderTarget | null,
         writeBuffer?: WebGLMultipleRenderTargets | WebGLRenderTarget,
         deltaTime?: number,
-        maskActive?: boolean
+        maskActive?: boolean,
     ): void;
 }

--- a/types/three/examples/jsm/postprocessing/RenderPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/RenderPass.d.ts
@@ -1,13 +1,20 @@
-import { Scene, Camera, Material, Color } from '../../../src/Three';
-
+import {Scene, Camera, Material, Color, WebGLMultipleRenderTargets, WebGLRenderTarget, WebGLRenderer} from '../../../src/Three';
 import { Pass, FullScreenQuad } from './Pass';
 
 export class RenderPass extends Pass {
-    constructor(scene: Scene, camera: Camera, overrideMaterial?: Material, clearColor?: Color, clearAlpha?: number);
-    scene: Scene;
-    camera: Camera;
-    overrideMaterial: Material;
-    clearColor: Color;
+    constructor(scene?: Scene, camera?: Camera, overrideMaterial?: Material, clearColor?: Color, clearAlpha?: number);
+    scene?: Scene;
+    camera?: Camera;
+    overrideMaterial?: Material;
+    clearColor?: Color;
     clearAlpha: number;
     clearDepth: boolean;
+
+    render(
+        renderer: WebGLRenderer,
+        _: WebGLMultipleRenderTargets | WebGLRenderTarget | null,
+        writeBuffer?: WebGLMultipleRenderTargets | WebGLRenderTarget,
+        deltaTime?: number,
+        maskActive?: boolean
+    ): void;
 }


### PR DESCRIPTION
Changes in Pass and RenderPass

### What
Allow `WebGLMultipleRenderTargets` in `Pass.render` for read and write buffers. This is required because `WebGLMultipleRenderTargets` does not inherit from WebGLRenderTarget in this types repo(but it does in three.js)

Allow `readBuffer`, `deltaTime`, `maskActive` to be optional in Pass. 

Add render function in RenderPass, which is slightly different from Pass.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged
