### PR TITLE
Add event type as generic in EventDispatcher

### DIFF
--- a/types/three/src/cameras/Camera.d.ts
+++ b/types/three/src/cameras/Camera.d.ts
@@ -2,7 +2,7 @@ import { Matrix4 } from './../math/Matrix4';
 import { Vector3 } from './../math/Vector3';
 import { Object3D } from './../core/Object3D';
 import { Layers } from '../Three';
-import { BaseEvent, Event } from '../core/EventDispatcher'
+import { BaseEvent, Event } from '../core/EventDispatcher';
 
 /**
  * Abstract base class for cameras

--- a/types/three/src/cameras/Camera.d.ts
+++ b/types/three/src/cameras/Camera.d.ts
@@ -2,6 +2,7 @@ import { Matrix4 } from './../math/Matrix4';
 import { Vector3 } from './../math/Vector3';
 import { Object3D } from './../core/Object3D';
 import { Layers } from '../Three';
+import { BaseEvent, Event } from '../core/EventDispatcher'
 
 /**
  * Abstract base class for cameras
@@ -10,7 +11,7 @@ import { Layers } from '../Three';
  * @see {@link https://threejs.org/docs/index.html#api/en/cameras/Camera | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/cameras/Camera.js | Source}
  */
-export abstract class Camera extends Object3D {
+export abstract class Camera<E extends BaseEvent = Event, ET = string> extends Object3D<E, ET> {
     /**
      * @remarks
      * Note that this class is not intended to be called directly; you probably want a

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -75,7 +75,8 @@ export type NormalOrGLBufferAttributes = Record<
  */
 export class BufferGeometry<
     Attributes extends NormalOrGLBufferAttributes = NormalBufferAttributes,
-    E extends BaseEvent = Event, ET = string
+    E extends BaseEvent = Event,
+    ET = string,
 > extends EventDispatcher<E, ET> {
     /**
      * This creates a new {@link THREE.BufferGeometry | BufferGeometry} object.

--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -6,7 +6,7 @@ import { Matrix4 } from '../math/Matrix4';
 import { Quaternion } from '../math/Quaternion';
 import { Vector2 } from '../math/Vector2';
 import { Vector3 } from '../math/Vector3';
-import { EventDispatcher } from './EventDispatcher';
+import { BaseEvent, EventDispatcher } from './EventDispatcher';
 import { GLBufferAttribute } from './GLBufferAttribute';
 
 export type NormalBufferAttributes = Record<string, BufferAttribute | InterleavedBufferAttribute>;
@@ -75,7 +75,8 @@ export type NormalOrGLBufferAttributes = Record<
  */
 export class BufferGeometry<
     Attributes extends NormalOrGLBufferAttributes = NormalBufferAttributes,
-> extends EventDispatcher {
+    E extends BaseEvent = Event, ET = string
+> extends EventDispatcher<E, ET> {
     /**
      * This creates a new {@link THREE.BufferGeometry | BufferGeometry} object.
      */

--- a/types/three/src/core/EventDispatcher.d.ts
+++ b/types/three/src/core/EventDispatcher.d.ts
@@ -63,5 +63,5 @@ export class EventDispatcher<E extends BaseEvent = Event, ET = string> {
      * Fire an event type.
      * @param event The event that gets fired.
      */
-    dispatchEvent(event: E & {type: ET, [a: string]: any}): void;
+    dispatchEvent(event: E & { type: ET; [a: string]: any }): void;
 }

--- a/types/three/src/core/EventDispatcher.d.ts
+++ b/types/three/src/core/EventDispatcher.d.ts
@@ -32,7 +32,7 @@ export type EventListener<E, T, U> = (event: E & { type: T } & { target: U }) =>
  * @see {@link https://threejs.org/docs/index.html#api/en/core/EventDispatcher | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/core/EventDispatcher.js | Source}
  */
-export class EventDispatcher<E extends BaseEvent = Event> {
+export class EventDispatcher<E extends BaseEvent = Event, ET = string> {
     /**
      * Creates {@link THREE.EventDispatcher | EventDispatcher} object.
      */
@@ -43,25 +43,25 @@ export class EventDispatcher<E extends BaseEvent = Event> {
      * @param type The type of event to listen to.
      * @param listener The function that gets called when the event is fired.
      */
-    addEventListener<T extends E['type']>(type: T, listener: EventListener<E, T, this>): void;
+    addEventListener<T extends E['type'] & ET>(type: T, listener: EventListener<E, T, this>): void;
 
     /**
      * Checks if listener is added to an event type.
      * @param type The type of event to listen to.
      * @param listener The function that gets called when the event is fired.
      */
-    hasEventListener<T extends E['type']>(type: T, listener: EventListener<E, T, this>): boolean;
+    hasEventListener<T extends E['type'] & ET>(type: T, listener: EventListener<E, T, this>): boolean;
 
     /**
      * Removes a listener from an event type.
      * @param type The type of the listener that gets removed.
      * @param listener The listener function that gets removed.
      */
-    removeEventListener<T extends E['type']>(type: T, listener: EventListener<E, T, this>): void;
+    removeEventListener<T extends E['type'] & ET>(type: T, listener: EventListener<E, T, this>): void;
 
     /**
      * Fire an event type.
      * @param event The event that gets fired.
      */
-    dispatchEvent(event: E): void;
+    dispatchEvent(event: E & {type: ET, [a: string]: any}): void;
 }

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -21,7 +21,7 @@ import { AnimationClip } from '../animation/AnimationClip';
  * @see {@link https://threejs.org/docs/index.html#api/en/core/Object3D | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/core/Object3D.js | Source}
  */
-export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
+export class Object3D<E extends BaseEvent = Event, ET = string> extends EventDispatcher<E, ET> {
     /**
      * This creates a new {@link Object3D} object.
      */
@@ -45,7 +45,7 @@ export class Object3D<E extends BaseEvent = Event> extends EventDispatcher<E> {
      * {@link http://en.wikipedia.org/wiki/Universally_unique_identifier | UUID} of this object instance.
      * @remarks This gets automatically assigned and shouldn't be edited.
      */
-    uuid: string;
+    readonly uuid: string;
 
     /**
      * Optional name of the object

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -13,10 +13,6 @@ import {
     StencilOp,
     PixelFormat,
 } from '../constants';
-import {Scene} from '../scenes/Scene'
-import {Camera} from '../cameras/Camera'
-import {BufferGeometry} from '../core/BufferGeometry'
-import {Object3D} from '../core/Object3D'
 
 export interface MaterialParameters {
     alphaTest?: number | undefined;

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -1,5 +1,5 @@
 import { Plane } from './../math/Plane';
-import { EventDispatcher } from './../core/EventDispatcher';
+import { Event, EventDispatcher } from './../core/EventDispatcher';
 import { WebGLRenderer } from './../renderers/WebGLRenderer';
 import { Shader } from './../renderers/shaders/ShaderLib';
 import {
@@ -13,17 +13,21 @@ import {
     StencilOp,
     PixelFormat,
 } from '../constants';
+import {Scene} from '../scenes/Scene'
+import {Camera} from '../cameras/Camera'
+import {BufferGeometry} from '../core/BufferGeometry'
+import {Object3D} from '../core/Object3D'
 
 export interface MaterialParameters {
     alphaTest?: number | undefined;
     alphaToCoverage?: boolean | undefined;
     blendDst?: BlendingDstFactor | undefined;
-    blendDstAlpha?: number | undefined;
+    blendDstAlpha?: number | undefined | null;
     blendEquation?: BlendingEquation | undefined;
-    blendEquationAlpha?: number | undefined;
+    blendEquationAlpha?: number | undefined | null;
     blending?: Blending | undefined;
     blendSrc?: BlendingSrcFactor | BlendingDstFactor | undefined;
-    blendSrcAlpha?: number | undefined;
+    blendSrcAlpha?: number | undefined | null;
     clipIntersection?: boolean | undefined;
     clippingPlanes?: Plane[] | undefined;
     clipShadows?: boolean | undefined;
@@ -42,7 +46,7 @@ export interface MaterialParameters {
     forceSinglePass?: boolean | undefined;
     dithering?: boolean | undefined;
     side?: Side | undefined;
-    shadowSide?: Side | undefined;
+    shadowSide?: Side | undefined | null;
     toneMapped?: boolean | undefined;
     transparent?: boolean | undefined;
     vertexColors?: boolean | undefined;
@@ -62,7 +66,7 @@ export interface MaterialParameters {
 /**
  * Materials describe the appearance of objects. They are defined in a (mostly) renderer-independent way, so you don't have to rewrite materials if you decide to use a different renderer.
  */
-export class Material extends EventDispatcher {
+export class Material<E extends Event = Event, TEvents = string> extends EventDispatcher<E, TEvents | 'dispose'> {
     constructor();
 
     /**

--- a/types/three/src/materials/MeshBasicMaterial.d.ts
+++ b/types/three/src/materials/MeshBasicMaterial.d.ts
@@ -2,7 +2,7 @@ import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { MaterialParameters, Material } from './Material';
 import { Combine } from '../constants';
-import { Event } from '../core/EventDispatcher'
+import { Event } from '../core/EventDispatcher';
 /**
  * parameters is an object with one or more properties defining the material's appearance.
  */

--- a/types/three/src/materials/MeshBasicMaterial.d.ts
+++ b/types/three/src/materials/MeshBasicMaterial.d.ts
@@ -2,6 +2,7 @@ import { Color, ColorRepresentation } from './../math/Color';
 import { Texture } from './../textures/Texture';
 import { MaterialParameters, Material } from './Material';
 import { Combine } from '../constants';
+import { Event } from '../core/EventDispatcher'
 /**
  * parameters is an object with one or more properties defining the material's appearance.
  */
@@ -26,7 +27,7 @@ export interface MeshBasicMaterialParameters extends MaterialParameters {
     wireframeLinejoin?: string | undefined;
 }
 
-export class MeshBasicMaterial extends Material {
+export class MeshBasicMaterial<E extends Event = Event, TEvents = ''> extends Material<E, TEvents> {
     constructor(parameters?: MeshBasicMaterialParameters);
 
     /**

--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -2,7 +2,7 @@ import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MeshStandardMaterialParameters, MeshStandardMaterial } from './MeshStandardMaterial';
 import { Color } from './../math/Color';
-import { Event } from '../core/EventDispatcher'
+import { Event } from '../core/EventDispatcher';
 
 export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
     clearcoat?: number | undefined;
@@ -42,7 +42,7 @@ export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialPara
     iridescenceThicknessMap?: Texture | null | undefined;
 }
 
-export class MeshPhysicalMaterial<E extends Event = Event, TEvents = ''> extends MeshStandardMaterial<E, TEvents>  {
+export class MeshPhysicalMaterial<E extends Event = Event, TEvents = ''> extends MeshStandardMaterial<E, TEvents> {
     constructor(parameters?: MeshPhysicalMaterialParameters);
 
     /**

--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -2,6 +2,7 @@ import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MeshStandardMaterialParameters, MeshStandardMaterial } from './MeshStandardMaterial';
 import { Color } from './../math/Color';
+import { Event } from '../core/EventDispatcher'
 
 export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialParameters {
     clearcoat?: number | undefined;
@@ -41,7 +42,7 @@ export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialPara
     iridescenceThicknessMap?: Texture | null | undefined;
 }
 
-export class MeshPhysicalMaterial extends MeshStandardMaterial {
+export class MeshPhysicalMaterial<E extends Event = Event, TEvents = ''> extends MeshStandardMaterial<E, TEvents>  {
     constructor(parameters?: MeshPhysicalMaterialParameters);
 
     /**

--- a/types/three/src/materials/MeshStandardMaterial.d.ts
+++ b/types/three/src/materials/MeshStandardMaterial.d.ts
@@ -3,6 +3,7 @@ import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
 import { NormalMapTypes } from '../constants';
+import { Event } from '../core/EventDispatcher'
 
 export interface MeshStandardMaterialParameters extends MaterialParameters {
     color?: ColorRepresentation | undefined;
@@ -35,7 +36,7 @@ export interface MeshStandardMaterialParameters extends MaterialParameters {
     flatShading?: boolean | undefined;
 }
 
-export class MeshStandardMaterial extends Material {
+export class MeshStandardMaterial<E extends Event = Event, TEvents = ''> extends Material<E, TEvents> {
     constructor(parameters?: MeshStandardMaterialParameters);
 
     /**

--- a/types/three/src/materials/MeshStandardMaterial.d.ts
+++ b/types/three/src/materials/MeshStandardMaterial.d.ts
@@ -3,7 +3,7 @@ import { Texture } from './../textures/Texture';
 import { Vector2 } from './../math/Vector2';
 import { MaterialParameters, Material } from './Material';
 import { NormalMapTypes } from '../constants';
-import { Event } from '../core/EventDispatcher'
+import { Event } from '../core/EventDispatcher';
 
 export interface MeshStandardMaterialParameters extends MaterialParameters {
     color?: ColorRepresentation | undefined;

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -1,6 +1,7 @@
 import { IUniform } from '../renderers/shaders/UniformsLib';
 import { MaterialParameters, Material } from './Material';
 import { GLSLVersion } from '../constants';
+import { Event } from '../core/EventDispatcher'
 
 export interface ShaderMaterialParameters extends MaterialParameters {
     uniforms?: { [uniform: string]: IUniform } | undefined;
@@ -23,7 +24,7 @@ export interface ShaderMaterialParameters extends MaterialParameters {
     glslVersion?: GLSLVersion | undefined;
 }
 
-export class ShaderMaterial extends Material {
+export class ShaderMaterial<E extends Event = Event, ET = string> extends Material<E, ET> {
     constructor(parameters?: ShaderMaterialParameters);
 
     /**

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -1,7 +1,7 @@
 import { IUniform } from '../renderers/shaders/UniformsLib';
 import { MaterialParameters, Material } from './Material';
 import { GLSLVersion } from '../constants';
-import { Event } from '../core/EventDispatcher'
+import { Event } from '../core/EventDispatcher';
 
 export interface ShaderMaterialParameters extends MaterialParameters {
     uniforms?: { [uniform: string]: IUniform } | undefined;

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -4,7 +4,7 @@ import { Object3D } from './../core/Object3D';
 import { Color } from '../math/Color';
 import { Texture } from '../textures/Texture';
 import { CubeTexture } from '../Three';
-import { BaseEvent, Event } from '../core/EventDispatcher'
+import { BaseEvent, Event } from '../core/EventDispatcher';
 
 /**
  * Scenes allow you to set up what and where is to be rendered by three.js

--- a/types/three/src/scenes/Scene.d.ts
+++ b/types/three/src/scenes/Scene.d.ts
@@ -4,6 +4,7 @@ import { Object3D } from './../core/Object3D';
 import { Color } from '../math/Color';
 import { Texture } from '../textures/Texture';
 import { CubeTexture } from '../Three';
+import { BaseEvent, Event } from '../core/EventDispatcher'
 
 /**
  * Scenes allow you to set up what and where is to be rendered by three.js
@@ -14,7 +15,7 @@ import { CubeTexture } from '../Three';
  * @see {@link https://threejs.org/docs/index.html#api/en/scenes/Scene | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/scenes/Scene.js | Source}
  */
-export class Scene extends Object3D {
+export class Scene<E extends BaseEvent = Event, ET = string> extends Object3D<E, ET> {
     /**
      * Create a new {@link Scene} object.
      */

--- a/types/three/test/unit/src/core/EventDispatcher.ts
+++ b/types/three/test/unit/src/core/EventDispatcher.ts
@@ -22,7 +22,7 @@ type TestEvent = { type: 'foo'; foo: number } | { type: 'bar'; bar: string };
 const eveDisForTestEvent = new THREE.EventDispatcher<TestEvent>();
 eveDisForTestEvent.addEventListener('foo', e => {
     e.type; // $ExpectType "foo"
-    e.target; // $ExpectType EventDispatcher<TestEvent>
+    e.target; // $ExpectType EventDispatcher<TestEvent, string>
 
     // NOTE: Error in ts lower than 3.9. The minimum typescript version cannot be raised from 3.6 because of the dependency from aframe.
     // e.foo; // $ExpectType number


### PR DESCRIPTION
Add event type as generic in EventDispatcher

Add Support for event types in Object3D, Material, MeshBasicMaterial, MeshPhysicalMaterial, MeshStandardMaterial, ShaderMaterial, BufferGeometry, Camera.

### Why

Makes it easier to specify types of events like: `OrbitControls extends EventDispatcher<Event, 'change'|'end'|'start'>`.

Also adds generics for Core classes so that event types can be specified when inheriting the three.js classes.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

One of my first contributions here. Let me know if anything is wrong. Thanks.