### PR TITLE
BufferAttribute: add gpuType

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -323,6 +323,8 @@ export const UnsignedShort4444Type: 1017;
 export const UnsignedShort5551Type: 1018;
 export const UnsignedInt248Type: 1020;
 
+export type AttributeGPUType = typeof FloatType | typeof IntType;
+
 /**
  * Texture Types.
  * @remarks Must correspond to the correct {@link PixelFormat | format}.

--- a/types/three/src/core/BufferAttribute.d.ts
+++ b/types/three/src/core/BufferAttribute.d.ts
@@ -69,7 +69,8 @@ export class BufferAttribute {
     /**
      * Configures the bound GPU type for use in shaders. Either {@link FloatType} or {@link IntType}, default is {@link FloatType}.
      *
-     * Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see https://threejs.org/docs/#api/en/core/bufferAttributeTypes/BufferAttributeTypes.
+     * Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision
+     * float types, see https://threejs.org/docs/#api/en/core/bufferAttributeTypes/BufferAttributeTypes.
      */
     gpuType: AttributeGPUType;
 

--- a/types/three/src/core/BufferAttribute.d.ts
+++ b/types/three/src/core/BufferAttribute.d.ts
@@ -1,4 +1,4 @@
-import { Usage } from '../constants';
+import { Usage, AttributeGPUType } from '../constants';
 import { Matrix3 } from './../math/Matrix3';
 import { Matrix4 } from './../math/Matrix4';
 
@@ -65,6 +65,13 @@ export class BufferAttribute {
      * @defaultValue {@link THREE.StaticDrawUsage | THREE.StaticDrawUsage}.
      */
     usage: Usage;
+
+    /**
+     * Configures the bound GPU type for use in shaders. Either {@link FloatType} or {@link IntType}, default is {@link FloatType}.
+     *
+     * Note: this only has an effect for integer arrays and is not configurable for float arrays. For lower precision float types, see https://threejs.org/docs/#api/en/core/bufferAttributeTypes/BufferAttributeTypes.
+     */
+    gpuType: AttributeGPUType;
 
     /**
      * This can be used to only update some components of stored vectors (for example, just the component related to color).


### PR DESCRIPTION
### Why

Follow-up to https://github.com/mrdoob/three.js/pull/26084.

### What

I've added `gpuType` to `BufferAttribute` to formalize its usage. `@link FloatType` doesn't work for the JSDoc though. Maybe we export type aliases for them -- `export type FloatType = typeof FloatType;`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged
