### PR TITLE
MeshPhysicalMaterial: Add anisotropy property types.

### DIFF
--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -39,6 +39,10 @@ export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialPara
     iridescence?: number | undefined;
     iridescenceThicknessRange?: [number, number] | undefined;
     iridescenceThicknessMap?: Texture | null | undefined;
+
+    anisotropy?: number | undefined;
+    anisotropyRotation?: number | undefined;
+    anisotropyMap?: Texture | null | undefined;
 }
 
 export class MeshPhysicalMaterial extends MeshStandardMaterial {
@@ -193,4 +197,19 @@ export class MeshPhysicalMaterial extends MeshStandardMaterial {
      * @default null
      */
     iridescenceThicknessMap: Texture | null;
+
+    /**
+     * @default 0
+     */
+    anisotropy?: number;
+
+    /**
+     * @default 0
+     */
+    anisotropyRotation?: number;
+
+    /**
+     * @default null
+     */
+    anisotropyMap?: Texture | null;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

three.js r153 includes support for anisotropy effects in MeshPhysicalMaterial.

### What

This PR adds the related properties for anisotropy, to the MeshPhysicalMaterial type definitions.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
