### PR TITLE
feat: Add types for VectorX iterators

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -733,6 +733,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "magnostherobot",
+      "name": "Tom Harley",
+      "avatar_url": "https://avatars.githubusercontent.com/u/24718981?v=4",
+      "profile": "https://github.com/magnostherobot",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Mik-pe"><img src="https://avatars.githubusercontent.com/u/5653426?v=4?s=100" width="100px;" alt="Mikael Pettersson"/><br /><sub><b>Mikael Pettersson</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Mik-pe" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/magnostherobot"><img src="https://avatars.githubusercontent.com/u/24718981?v=4?s=100" width="100px;" alt="Tom Harley"/><br /><sub><b>Tom Harley</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Mik-pe" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/types/three/src/math/Vector2.d.ts
+++ b/types/three/src/math/Vector2.d.ts
@@ -448,4 +448,9 @@ export class Vector2 implements Vector {
      * Sets this vector's x and y from Math.random
      */
     random(): this;
+
+    /**
+     * Iterating through a Vector2 instance will yield its components (x, y) in the corresponding order.
+     */
+    [Symbol.iterator](): Iterator<number>;
 }

--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -301,4 +301,9 @@ export class Vector3 implements Vector {
     random(): this;
 
     randomDirection(): this;
+
+    /**
+     * Iterating through a Vector3 instance will yield its components (x, y, z) in the corresponding order.
+     */
+    [Symbol.iterator](): Iterator<number>;
 }

--- a/types/three/src/math/Vector4.d.ts
+++ b/types/three/src/math/Vector4.d.ts
@@ -220,4 +220,9 @@ export class Vector4 implements Vector {
      * Sets this vector's x, y, z and w from Math.random
      */
     random(): this;
+
+    /**
+     * Iterating through a Vector4 instance will yield its components (x, y, z, w) in the corresponding order.
+     */
+    [Symbol.iterator](): Iterator<number>;
 }


### PR DESCRIPTION


<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

The threejs Vector classes can be iterated (and therefore spread in function calls). It would be nice to enable this functionality in TypeScript projects that use three.

### What

<!-- what have you done, if its a bug, whats your solution? -->

This PR adds `[Symbol.iterator]()` method type declarations in the `Vector2`, `Vector3`, and `Vector4` classes.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

I am unable to add myself as a contributor to the repo using the instructions in the contribution guidelines - I get an `API rate limit exceeded` error :s

The doc-comments in this PR are copied from threejs documentation, from the commit that added iterators to the vector classes: https://github.com/mrdoob/three.js/commit/fbdb7453b968bfd35f8853653c5f6d4613718cc2
