### PR TITLE
Fixed incorrect type specification in GPUComputationRenderer

### DIFF
--- a/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
+++ b/types/three/examples/jsm/misc/GPUComputationRenderer.d.ts
@@ -49,7 +49,7 @@ export class GPUComputationRenderer {
         magFilter: MagnificationTextureFilter,
     ): WebGLRenderTarget;
     createTexture(): DataTexture;
-    renderTexture(input: Texture, output: Texture): void;
+    renderTexture(input: Texture, output: WebGLRenderTarget): void;
     doRenderTarget(material: Material, output: WebGLRenderTarget): void;
     dispose(): void;
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

 Incorrect type specification in GPUComputationRenderer

### What

Fixed `output` parameter of function `renderTexture` being incorrectly specified as `Texture`, which is now `WebGLRenderTarget`.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
