### PR TITLE
DepthTexture: Support texture depth comparison.

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -756,6 +756,24 @@ export type StencilFunc =
     | typeof GreaterEqualStencilFunc
     | typeof AlwaysStencilFunc;
 
+export const NeverCompare: 512;
+export const LessCompare: 513;
+export const EqualCompare: 514;
+export const LessEqualCompare: 515;
+export const GreaterCompare: 516;
+export const NotEqualCompare: 517;
+export const GreaterEqualCompare: 518;
+export const AlwaysCompare: 519;
+export type TextureComparisonFunction =
+    | typeof NeverCompare
+    | typeof LessCompare
+    | typeof EqualCompare
+    | typeof LessEqualCompare
+    | typeof GreaterCompare
+    | typeof NotEqualCompare
+    | typeof GreaterEqualCompare
+    | typeof AlwaysCompare;
+
 // usage types
 export const StaticDrawUsage: 35044;
 export const DynamicDrawUsage: 35048;

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -6,6 +6,7 @@ import {
     DeepTexturePixelFormat,
     MagnificationTextureFilter,
     MinificationTextureFilter,
+    TextureComparisonFunction,
 } from '../constants';
 
 /**
@@ -95,4 +96,12 @@ export class DepthTexture extends Texture {
      * @defaultValue {@link THREE.UnsignedInt248Type} when {@link format | .format} === {@link THREE.DepthStencilFormat}
      */
     type: TextureDataType;
+
+    /**
+     * This is used to define the comparison function used when comparing texels in the depth texture to the value in
+     * the depth buffer. Default is `null` which means comparison is disabled.
+     *
+     * See {@link THREE.TextureComparisonFunction} for functions.
+     */
+    compareFunction: TextureComparisonFunction | null;
 }


### PR DESCRIPTION
### Why

Make changes for r153 from https://github.com/mrdoob/three.js/pull/25958.

### What

Add DepthTexture compareFunction.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
