### PR TITLE
MathUtils: Add support for Uint32 and Int32 to normalize / denormalize functions

### DIFF
--- a/types/three/src/math/MathUtils.d.ts
+++ b/types/three/src/math/MathUtils.d.ts
@@ -5,6 +5,7 @@ import { Quaternion } from './Quaternion';
  */
 
 export const DEG2RAD: number;
+
 export const RAD2DEG: number;
 
 export function generateUUID(): string;
@@ -13,10 +14,11 @@ export function generateUUID(): string;
  * Clamps the x to be between a and b.
  *
  * @param value Value to be clamped.
- * @param min Minimum value
+ * @param min Minimum value.
  * @param max Maximum value.
  */
 export function clamp(value: number, min: number, max: number): number;
+
 export function euclideanModulo(n: number, m: number): number;
 
 /**
@@ -29,44 +31,6 @@ export function euclideanModulo(n: number, m: number): number;
  * @param b2 Maximum value for range B.
  */
 export function mapLinear(x: number, a1: number, a2: number, b1: number, b2: number): number;
-
-export function smoothstep(x: number, min: number, max: number): number;
-
-export function smootherstep(x: number, min: number, max: number): number;
-
-/**
- * Random float from 0 to 1 with 16 bits of randomness.
- * Standard Math.random() creates repetitive patterns when applied over larger space.
- *
- * @deprecated Use {@link Math#random Math.random()}
- */
-export function random16(): number;
-
-/**
- * Random integer from low to high interval.
- */
-export function randInt(low: number, high: number): number;
-
-/**
- * Random float from low to high interval.
- */
-export function randFloat(low: number, high: number): number;
-
-/**
- * Random float from - range / 2 to range / 2 interval.
- */
-export function randFloatSpread(range: number): number;
-
-/**
- * Deterministic pseudo-random float in the interval [ 0, 1 ].
- */
-export function seededRandom(seed?: number): number;
-
-export function degToRad(degrees: number): number;
-
-export function radToDeg(radians: number): number;
-
-export function isPowerOfTwo(value: number): boolean;
 
 export function inverseLerp(x: number, y: number, t: number): number;
 
@@ -99,18 +63,75 @@ export function damp(x: number, y: number, lambda: number, dt: number): number;
  */
 export function pingpong(x: number, length?: number): number;
 
-/**
- * @deprecated Use {@link Math#floorPowerOfTwo .floorPowerOfTwo()}
- */
-export function nearestPowerOfTwo(value: number): number;
+export function smoothstep(x: number, min: number, max: number): number;
+
+export function smootherstep(x: number, min: number, max: number): number;
 
 /**
- * @deprecated Use {@link Math#ceilPowerOfTwo .ceilPowerOfTwo()}
+ * Random integer from low to high interval.
  */
-export function nextPowerOfTwo(value: number): number;
+export function randInt(low: number, high: number): number;
 
-export function floorPowerOfTwo(value: number): number;
+/**
+ * Random float from low to high interval.
+ */
+export function randFloat(low: number, high: number): number;
+
+/**
+ * Random float from - range / 2 to range / 2 interval.
+ */
+export function randFloatSpread(range: number): number;
+
+/**
+ * Deterministic pseudo-random float in the interval [ 0, 1 ].
+ */
+export function seededRandom(seed?: number): number;
+
+export function degToRad(degrees: number): number;
+
+export function radToDeg(radians: number): number;
+
+export function isPowerOfTwo(value: number): boolean;
 
 export function ceilPowerOfTwo(value: number): number;
 
+export function floorPowerOfTwo(value: number): number;
+
 export function setQuaternionFromProperEuler(q: Quaternion, a: number, b: number, c: number, order: string): void;
+
+export function denormalize(
+    value: number,
+    array: Float32Array | Uint32Array | Uint16Array | Uint8Array | Int32Array | Int16Array | Int8Array,
+): number;
+
+export function normalize(
+    value: number,
+    array: Float32Array | Uint32Array | Uint16Array | Uint8Array | Int32Array | Int16Array | Int8Array,
+): number;
+
+export const MathUtils: {
+    DEG2RAD: typeof DEG2RAD;
+    RAD2DEG: typeof RAD2DEG;
+    generateUUID: typeof generateUUID;
+    clamp: typeof clamp;
+    euclideanModulo: typeof euclideanModulo;
+    mapLinear: typeof mapLinear;
+    inverseLerp: typeof inverseLerp;
+    lerp: typeof lerp;
+    damp: typeof damp;
+    pingpong: typeof pingpong;
+    smoothstep: typeof smoothstep;
+    smootherstep: typeof smootherstep;
+    randInt: typeof randInt;
+    randFloat: typeof randFloat;
+    randFloatSpread: typeof randFloatSpread;
+    seededRandom: typeof seededRandom;
+    degToRad: typeof degToRad;
+    radToDeg: typeof radToDeg;
+    isPowerOfTwo: typeof isPowerOfTwo;
+    ceilPowerOfTwo: typeof ceilPowerOfTwo;
+    floorPowerOfTwo: typeof floorPowerOfTwo;
+    setQuaternionFromProperEuler: typeof setQuaternionFromProperEuler;
+    normalize: typeof normalize;
+    denormalize: typeof denormalize;
+};


### PR DESCRIPTION
### Why

Make changes in r153 from https://github.com/mrdoob/three.js/pull/25984.

### What

Add `normalize` and `denormalize` to `MathUtils`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
