### PR TITLE
Color: Let set() accept RGB values.

### DIFF
--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -204,7 +204,8 @@ export class Color {
      */
     b: number;
 
-    set(color: ColorRepresentation): Color;
+    set(color: ColorRepresentation): this;
+    set(r: number, g: number, b: number): this;
 
     /**
      * Sets this color's {@link r}, {@link g} and {@link b} components from the x, y, and z components of the specified


### PR DESCRIPTION
### Why

Make changes in r153 corresponding to https://github.com/mrdoob/three.js/pull/25999.

### What

Allow `Color.set()` to accept RGB values.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
