### PR TITLE
FramebufferTexture: Remove format parameter.

### DIFF
--- a/types/three/src/textures/FramebufferTexture.d.ts
+++ b/types/three/src/textures/FramebufferTexture.d.ts
@@ -1,5 +1,5 @@
 import { Texture } from './Texture';
-import { MagnificationTextureFilter, MinificationTextureFilter, PixelFormat } from '../constants';
+import { MagnificationTextureFilter, MinificationTextureFilter } from '../constants';
 
 /**
  * This class can only be used in combination with {@link THREE.WebGLRenderer.copyFramebufferToTexture | WebGLRenderer.copyFramebufferToTexture()}.
@@ -32,9 +32,8 @@ export class FramebufferTexture extends Texture {
      * Create a new instance of {@link FramebufferTexture}
      * @param width The width of the texture.
      * @param height The height of the texture.
-     * @param format See {@link Texture.format | .format}. Default {@link THREE.RGBAFormat}.
      */
-    constructor(width: number, height: number, format: PixelFormat);
+    constructor(width: number, height: number);
 
     /**
      * Read-only flag to check if a given object is of type {@link FramebufferTexture}.


### PR DESCRIPTION
### Why

Make r153 changes corresponding to https://github.com/mrdoob/three.js/pull/26027.

### What

Remove `format` parameter from `FrambufferTexture` constructor.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
