### PR TITLE
delete some methods of WebGLState class

### DIFF
--- a/types/three/src/renderers/webgl/WebGLState.d.ts
+++ b/types/three/src/renderers/webgl/WebGLState.d.ts
@@ -52,22 +52,9 @@ export class WebGLState {
         stencil: WebGLStencilBuffer;
     };
 
-    initAttributes(): void;
-    enableAttribute(attribute: number): void;
-    enableAttributeAndDivisor(attribute: number, meshPerAttribute: number): void;
-    disableUnusedAttributes(): void;
-    vertexAttribPointer(
-        index: number,
-        size: number,
-        type: number,
-        normalized: boolean,
-        stride: number,
-        offset: number,
-    ): void;
     enable(id: number): void;
     disable(id: number): void;
     bindFramebuffer(target: number, framebuffer: WebGLFramebuffer | null): void;
-    bindXRFramebuffer(framebuffer: WebGLFramebuffer | null): void;
     useProgram(program: any): boolean;
     setBlending(
         blending: Blending,


### PR DESCRIPTION
### Why
Delete some methods of WebGLState class since it does have these methods.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged
