### PR TITLE
WebGLRenderer: Deprecate useLegacyLights, change default to false.

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -210,6 +210,7 @@ export class WebGLRenderer implements Renderer {
     get coordinateSystem(): typeof WebGLCoordinateSystem;
 
     /**
+     * @deprecated
      * @default true
      */
     useLegacyLights: boolean;

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -210,7 +210,8 @@ export class WebGLRenderer implements Renderer {
     get coordinateSystem(): typeof WebGLCoordinateSystem;
 
     /**
-     * @deprecated
+     * @deprecated Migrate your lighting according to the following guide:
+     * https://discourse.threejs.org/t/updates-to-lighting-in-three-js-r155/53733.
      * @default true
      */
     useLegacyLights: boolean;


### PR DESCRIPTION
### Why

r155 change

### What

https://github.com/mrdoob/three.js/pull/26392

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
