### PR TITLE
MeshSurfaceSampler: Add targetUV parameter

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -781,6 +781,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "mrxz",
+      "name": "Noeri Huisman",
+      "avatar_url": "https://avatars.githubusercontent.com/u/8823461?v=4",
+      "profile": "https://github.com/mrxz",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Yonet"><img src="https://avatars.githubusercontent.com/u/3523671?v=4?s=100" width="100px;" alt="Yönet"/><br /><sub><b>Yönet</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=Yonet" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ericbroberic"><img src="https://avatars.githubusercontent.com/u/9359928?v=4?s=100" width="100px;" alt="Eric Benn"/><br /><sub><b>Eric Benn</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=ericbroberic" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ybt-new"><img src="https://avatars.githubusercontent.com/u/131513278?v=4?s=100" width="100px;" alt="Botao Yang"/><br /><sub><b>Botao Yang</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=ybt-new" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mrxz"><img src="https://avatars.githubusercontent.com/u/8823461?v=4?s=100" width="100px;" alt="Noeri Huisman"/><br /><sub><b>Noeri Huisman</b></sub></a><br /><a href="https://github.com/three-types/three-ts-types/commits?author=mrxz" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/types/three/examples/jsm/math/MeshSurfaceSampler.d.ts
+++ b/types/three/examples/jsm/math/MeshSurfaceSampler.d.ts
@@ -1,4 +1,4 @@
-import { BufferGeometry, Color, Mesh, Vector3 } from '../../../src/Three.js';
+import { BufferGeometry, Color, Mesh, Vector2, Vector3 } from '../../../src/Three.js';
 
 export class MeshSurfaceSampler {
     distribution: Float32Array | null;
@@ -9,7 +9,13 @@ export class MeshSurfaceSampler {
     constructor(mesh: Mesh);
     binarySearch(x: number): number;
     build(): this;
-    sample(targetPosition: Vector3, targetNormal?: Vector3, targetColor?: Color): this;
-    sampleFace(faceIndex: number, targetPosition: Vector3, targetNormal?: Vector3, targetColor?: Color): this;
+    sample(targetPosition: Vector3, targetNormal?: Vector3, targetColor?: Color, targetUV?: Vector2): this;
+    sampleFace(
+        faceIndex: number,
+        targetPosition: Vector3,
+        targetNormal?: Vector3,
+        targetColor?: Color,
+        targetUV?: Vector2,
+    ): this;
     setWeightAttribute(name: string | null): this;
 }


### PR DESCRIPTION
### Why

In r154 a `targetUV` parameter was added to the `MeshSurfaceSampler` (https://github.com/mrdoob/three.js/pull/26207).

### What

Added the optional `targetUV` parameter to the `sample` and `sampleFace` method of `MeshSurfaceSampler`

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
