### PR TITLE
add some missing api

### DIFF
--- a/types/three/src/renderers/webgl/WebGLAttributes.d.ts
+++ b/types/three/src/renderers/webgl/WebGLAttributes.d.ts
@@ -6,12 +6,14 @@ import { GLBufferAttribute } from '../../core/GLBufferAttribute.js';
 export class WebGLAttributes {
     constructor(gl: WebGLRenderingContext | WebGL2RenderingContext, capabilities: WebGLCapabilities);
 
-    get(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute): {
-        buffer: WebGLBuffer;
-        type: number;
-        bytesPerElement: number;
-        version: number;
-    };
+    get(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute):
+        | {
+              buffer: WebGLBuffer;
+              type: number;
+              bytesPerElement: number;
+              version: number;
+          }
+        | undefined;
 
     remove(attribute: BufferAttribute | InterleavedBufferAttribute | GLBufferAttribute): void;
 

--- a/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
+++ b/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
@@ -7,6 +7,7 @@ export class WebGLCapabilities {
     constructor(gl: WebGLRenderingContext, extensions: any, parameters: WebGLCapabilitiesParameters);
 
     readonly isWebGL2: boolean;
+    readonly drawBuffers: boolean;
     precision: string;
     logarithmicDepthBuffer: boolean;
     maxTextures: number;

--- a/types/three/src/renderers/webgl/WebGLState.d.ts
+++ b/types/three/src/renderers/webgl/WebGLState.d.ts
@@ -10,6 +10,7 @@ import { WebGLCapabilities } from './WebGLCapabilities.js';
 import { WebGLExtensions } from './WebGLExtensions.js';
 import { Material } from '../../materials/Material.js';
 import { Vector4 } from '../../math/Vector4.js';
+import { WebGLRenderTarget } from '../WebGLRenderTarget.js';
 
 export class WebGLColorBuffer {
     constructor();
@@ -55,6 +56,7 @@ export class WebGLState {
     enable(id: number): void;
     disable(id: number): void;
     bindFramebuffer(target: number, framebuffer: WebGLFramebuffer | null): void;
+    drawBuffers(renderTarget: WebGLRenderTarget | null, framebuffer: WebGLFramebuffer | null): void;
     useProgram(program: any): boolean;
     setBlending(
         blending: Blending,


### PR DESCRIPTION
### What
`WebGLAttributes.get` method has chance to return undefined.
Add `drawBuffers` readonly property to  `WebGLCapabilities` class.
Add `drawBuffers` api to `WebGLState`.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [ ] Added myself to contributors table
-   [x] Ready to be merged

