### PR TITLE
fix: toCreasedNormals(): call toNonIndexed() only on non-indexed geometries

### DIFF
--- a/types/three/examples/jsm/utils/BufferGeometryUtils.d.ts
+++ b/types/three/examples/jsm/utils/BufferGeometryUtils.d.ts
@@ -28,7 +28,8 @@ export function deinterleaveAttribute(geometry: BufferGeometry): void;
 export function deinterleaveGeometry(geometry: BufferGeometry): void;
 
 /**
- * Creates a new, non-indexed geometry with smooth normals everywhere except faces that meet at an angle greater than the crease angle.
+ * Modifies the supplied geometry if it is non-indexed, otherwise creates a new, non-indexed geometry. Returns the
+ * geometry with smooth normals everywhere except faces that meet at an angle greater than the crease angle.
  *
  * @param geometry The input geometry.
  * @param creaseAngle The crease angle.

--- a/types/three/examples/jsm/utils/BufferGeometryUtils.d.ts
+++ b/types/three/examples/jsm/utils/BufferGeometryUtils.d.ts
@@ -32,7 +32,7 @@ export function deinterleaveGeometry(geometry: BufferGeometry): void;
  * geometry with smooth normals everywhere except faces that meet at an angle greater than the crease angle.
  *
  * @param geometry The input geometry.
- * @param creaseAngle The crease angle.
+ * @param creaseAngle The crease angle in radians.
  */
 export function toCreasedNormals(geometry: BufferGeometry, creaseAngle?: number): BufferGeometry;
 


### PR DESCRIPTION
### Why

Type changes for r155.

### What

Type changes corresponding to https://github.com/mrdoob/three.js/pull/26379.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
