### PR TITLE
Core: WebGLRenderTarget extends RenderTarget

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -41,6 +41,7 @@ export * from './cameras/Camera.js';
 /**
  * Core
  */
+export * from './core/RenderTarget.js';
 export * from './core/Uniform.js';
 export * from './core/UniformsGroup.js';
 export * from './core/InstancedBufferGeometry.js';

--- a/types/three/src/core/RenderTarget.d.ts
+++ b/types/three/src/core/RenderTarget.d.ts
@@ -1,0 +1,78 @@
+import { Vector4 } from '../math/Vector4.js';
+import { Texture } from '../textures/Texture.js';
+import { DepthTexture } from '../textures/DepthTexture.js';
+import { EventDispatcher } from './EventDispatcher.js';
+import {
+    Wrapping,
+    TextureDataType,
+    TextureEncoding,
+    MinificationTextureFilter,
+    MagnificationTextureFilter,
+    ColorSpace,
+} from '../constants.js';
+
+export interface RenderTargetOptions {
+    wrapS?: Wrapping | undefined;
+    wrapT?: Wrapping | undefined;
+    magFilter?: MagnificationTextureFilter | undefined;
+    minFilter?: MinificationTextureFilter | undefined;
+    generateMipmaps?: boolean | undefined; // true;
+    format?: number | undefined; // RGBAFormat;
+    type?: TextureDataType | undefined; // UnsignedByteType;
+    anisotropy?: number | undefined; // 1;
+    colorSpace?: ColorSpace | undefined;
+    depthBuffer?: boolean | undefined; // true;
+    stencilBuffer?: boolean | undefined; // false;
+    depthTexture?: DepthTexture | undefined;
+    /**
+     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
+     * @default 0
+     */
+    samples?: number;
+    /** @deprecated Use 'colorSpace' in three.js r152+. */
+    encoding?: TextureEncoding | undefined;
+}
+
+export class RenderTarget<TTexture extends Texture | Texture[] = Texture> extends EventDispatcher {
+    constructor(width?: number, height?: number, options?: RenderTargetOptions);
+
+    readonly isRenderTarget: true;
+
+    width: number;
+    height: number;
+    depth: number;
+
+    scissor: Vector4;
+    /**
+     * @default false
+     */
+    scissorTest: boolean;
+    viewport: Vector4;
+    texture: TTexture;
+
+    /**
+     * @default true
+     */
+    depthBuffer: boolean;
+
+    /**
+     * @default true
+     */
+    stencilBuffer: boolean;
+
+    /**
+     * @default null
+     */
+    depthTexture: DepthTexture;
+
+    /**
+     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
+     * @default 0
+     */
+    samples: number;
+
+    setSize(width: number, height: number, depth?: number): void;
+    clone(): this;
+    copy(source: RenderTarget): this;
+    dispose(): void;
+}

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -1,78 +1,8 @@
-import { Vector4 } from '../math/Vector4.js';
 import { Texture } from '../textures/Texture.js';
-import { DepthTexture } from '../textures/DepthTexture.js';
-import { EventDispatcher } from '../core/EventDispatcher.js';
-import {
-    Wrapping,
-    TextureDataType,
-    TextureEncoding,
-    MinificationTextureFilter,
-    MagnificationTextureFilter,
-    ColorSpace,
-} from '../constants.js';
+import { RenderTarget, RenderTargetOptions } from '../core/RenderTarget.js';
 
-export interface WebGLRenderTargetOptions {
-    wrapS?: Wrapping | undefined;
-    wrapT?: Wrapping | undefined;
-    magFilter?: MagnificationTextureFilter | undefined;
-    minFilter?: MinificationTextureFilter | undefined;
-    generateMipmaps?: boolean | undefined; // true;
-    format?: number | undefined; // RGBAFormat;
-    type?: TextureDataType | undefined; // UnsignedByteType;
-    anisotropy?: number | undefined; // 1;
-    colorSpace?: ColorSpace | undefined;
-    depthBuffer?: boolean | undefined; // true;
-    stencilBuffer?: boolean | undefined; // false;
-    depthTexture?: DepthTexture | undefined;
-    /**
-     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
-     * @default 0
-     */
-    samples?: number;
-    /** @deprecated Use 'colorSpace' in three.js r152+. */
-    encoding?: TextureEncoding | undefined;
-}
-
-export class WebGLRenderTarget<TTexture extends Texture | Texture[] = Texture> extends EventDispatcher {
-    constructor(width?: number, height?: number, options?: WebGLRenderTargetOptions);
+export class WebGLRenderTarget<TTexture extends Texture | Texture[] = Texture> extends RenderTarget<TTexture> {
+    constructor(width?: number, height?: number, options?: RenderTargetOptions);
 
     readonly isWebGLRenderTarget: true;
-
-    width: number;
-    height: number;
-    depth: number;
-
-    scissor: Vector4;
-    /**
-     * @default false
-     */
-    scissorTest: boolean;
-    viewport: Vector4;
-    texture: TTexture;
-
-    /**
-     * @default true
-     */
-    depthBuffer: boolean;
-
-    /**
-     * @default true
-     */
-    stencilBuffer: boolean;
-
-    /**
-     * @default null
-     */
-    depthTexture: DepthTexture;
-
-    /**
-     * Defines the count of MSAA samples. Can only be used with WebGL 2. Default is **0**.
-     * @default 0
-     */
-    samples: number;
-
-    setSize(width: number, height: number, depth?: number): void;
-    clone(): this;
-    copy(source: WebGLRenderTarget): this;
-    dispose(): void;
 }

--- a/types/three/src/renderers/WebGLRenderTarget.d.ts
+++ b/types/three/src/renderers/WebGLRenderTarget.d.ts
@@ -1,6 +1,9 @@
 import { Texture } from '../textures/Texture.js';
 import { RenderTarget, RenderTargetOptions } from '../core/RenderTarget.js';
 
+// tslint:disable-next-line:no-empty-interface
+export interface WebGLRenderTargetOptions extends RenderTargetOptions {}
+
 export class WebGLRenderTarget<TTexture extends Texture | Texture[] = Texture> extends RenderTarget<TTexture> {
     constructor(width?: number, height?: number, options?: RenderTargetOptions);
 


### PR DESCRIPTION
### Why

Change in r155.

### What

https://github.com/mrdoob/three.js/pull/26468

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
