### PR TITLE
Remove minimum TypeScript version

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -3,7 +3,6 @@
 // Definitions by: Josh Ellis <https://github.com/joshuaellis>
 //                 Nathan Bierema <https://github.com/Methuselah96>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.4
 
 // To update three.js type definition, please make changes to the repository at:
 // https://github.com/three-types/three-ts-types.


### PR DESCRIPTION
### Why

No longer necessary.

### What

Remove minimum TypeScript version

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
