### PR TITLE
OrbitControls: Support frame rate independent autoRotate.

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -181,8 +181,9 @@ export class OrbitControls extends EventDispatcher<OrbitControlsEventMap> {
 
     /**
      * Set to true to automatically rotate around the target.
-     * Note that if this is enabled, you must call
-     * .update () in your animation loop.
+     * Note that if this is enabled, you must call .update() in your animation loop. If you want the auto-rotate speed
+     * to be independent of the frame rate (the refresh rate of the display), you must pass the time `deltaTime`, in
+     * seconds, to .update().
      */
     autoRotate: boolean;
 
@@ -229,11 +230,11 @@ export class OrbitControls extends EventDispatcher<OrbitControlsEventMap> {
     zoom0: number;
 
     /**
-     * Update the controls. Must be called after any manual changes
-     * to the camera's transform, or in the update loop if .autoRotate
-     * or .enableDamping are set.
+     * Update the controls. Must be called after any manual changes to the camera's transform, or in the update loop if
+     * .autoRotate or .enableDamping are set. `deltaTime`, in seconds, is optional, and is only required if you want the
+     * auto-rotate speed to be independent of the frame rate (the refresh rate of the display).
      */
-    update(): boolean;
+    update(deltaTime?: number): boolean;
 
     /**
      * Adds key event listeners to the given DOM element. `window`


### PR DESCRIPTION
### Why

Change for r156.

### What

Type and doc changes corresponding to https://github.com/mrdoob/three.js/pull/26472, https://github.com/mrdoob/three.js/pull/26541, and https://github.com/mrdoob/three.js/pull/26547.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
