### PR TITLE
Add missing typo definition for DebugEnvironment

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -798,6 +798,14 @@
       "profile": "https://github.com/ddnn55",
       "contributions": [
         "doc"
+    },
+    {
+      "login": "skyclouds2001",
+      "name": "skyclouds2001",
+      "avatar_url": "https://avatars.githubusercontent.com/u/95597335?v=4",
+      "profile": "https://github.com/skyclouds2001",
+      "contributions": [
+        "code"
     }
   ],
   "skipCi": true,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -798,6 +798,7 @@
       "profile": "https://github.com/ddnn55",
       "contributions": [
         "doc"
+      ]
     },
     {
       "login": "skyclouds2001",
@@ -806,6 +807,7 @@
       "profile": "https://github.com/skyclouds2001",
       "contributions": [
         "code"
+      ]
     }
   ],
   "skipCi": true,

--- a/types/three/OTHER_FILES.txt
+++ b/types/three/OTHER_FILES.txt
@@ -24,6 +24,7 @@ examples/jsm/effects/AsciiEffect.d.ts
 examples/jsm/effects/ParallaxBarrierEffect.d.ts
 examples/jsm/effects/PeppersGhostEffect.d.ts
 examples/jsm/effects/StereoEffect.d.ts
+examples/jsm/environments/DebugEnvironment.d.ts
 examples/jsm/exporters/DRACOExporter.d.ts
 examples/jsm/exporters/EXRExporter.d.ts
 examples/jsm/exporters/GLTFExporter.d.ts

--- a/types/three/examples/jsm/environments/DebugEnvironment.d.ts
+++ b/types/three/examples/jsm/environments/DebugEnvironment.d.ts
@@ -1,11 +1,5 @@
-import {
-	Scene,
-} from 'three';
+import { Scene } from '../../../src/Three.js';
 
-class DebugEnvironment extends Scene {
-
-	constructor() {}
-
+export class DebugEnvironment extends Scene {
+    constructor();
 }
-
-export { DebugEnvironment };

--- a/types/three/examples/jsm/environments/DebugEnvironment.d.ts
+++ b/types/three/examples/jsm/environments/DebugEnvironment.d.ts
@@ -1,0 +1,11 @@
+import {
+	Scene,
+} from 'three';
+
+class DebugEnvironment extends Scene {
+
+	constructor() {}
+
+}
+
+export { DebugEnvironment };


### PR DESCRIPTION
### Why

add missing typo definition

### What

create DebugEnvironment.d.ts

See https://github.com/mrdoob/three.js/blob/master/examples/jsm/environments/DebugEnvironment.js

Also, fix the incorrect format in .all-contributorsrc file.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
