### PR TITLE
Change values parameter in KeyframeTrack class constructor to be optional

### DIFF
--- a/types/three/src/animation/KeyframeTrack.d.ts
+++ b/types/three/src/animation/KeyframeTrack.d.ts
@@ -8,10 +8,10 @@ export class KeyframeTrack {
     /**
      * @param name
      * @param times
-     * @param values
+     * @param [values]
      * @param [interpolation=THREE.InterpolateLinear]
      */
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<any>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<any>, interpolation?: InterpolationModes);
 
     name: string;
     times: Float32Array;

--- a/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/BooleanKeyframeTrack.d.ts
@@ -1,7 +1,7 @@
 import { KeyframeTrack } from './../KeyframeTrack.js';
 
 export class BooleanKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<any>);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<any>);
 
     /**
      * @default 'bool'

--- a/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/ColorKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack.js';
 import { InterpolationModes } from '../../constants.js';
 
 export class ColorKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'color'

--- a/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/NumberKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack.js';
 import { InterpolationModes } from '../../constants.js';
 
 export class NumberKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'number'

--- a/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack.js';
 import { InterpolationModes } from '../../constants.js';
 
 export class QuaternionKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'quaternion'

--- a/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/StringKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack.js';
 import { InterpolationModes } from '../../constants.js';
 
 export class StringKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<any>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<any>, interpolation?: InterpolationModes);
 
     /**
      * @default 'string'

--- a/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
+++ b/types/three/src/animation/tracks/VectorKeyframeTrack.d.ts
@@ -2,7 +2,7 @@ import { KeyframeTrack } from './../KeyframeTrack.js';
 import { InterpolationModes } from '../../constants.js';
 
 export class VectorKeyframeTrack extends KeyframeTrack {
-    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
+    constructor(name: string, times: ArrayLike<number>, values?: ArrayLike<number>, interpolation?: InterpolationModes);
 
     /**
      * @default 'vector'


### PR DESCRIPTION
### Why

Change values parameter in KeyframeTrack class constructor to be optional

### What

As metioned in the documentation of BooleanKeyframeTrack, parameter name and times are marked as a required parameter, while parameter values is marked as a optional parameter.

```markdown
## Constructor
#### BooleanKeyframeTrack( name : String, times : Array, values : Array )
name - (required) identifier for the KeyframeTrack.
times - (required) array of keyframe times.
values - values for the keyframes at the times specified.
```

Although in the documentation of KeyframeTrack, the requirement is not mentioned in the documentation, but it is the same with the documentation of BooleanKeyframeTrack.

And, in the source code of KeyframeTrack, passing undefined to parameter name and times will throw an error, while passing undefined to parameter values will not happen anything.

see https://threejs.org/docs/index.html#api/en/animation/KeyframeTrack
also see https://github.com/mrdoob/three.js/blob/master/src/animation/KeyframeTrack.js
see https://threejs.org/docs/index.html#api/en/animation/tracks/BooleanKeyframeTrack
also see https://github.com/mrdoob/three.js/blob/master/src/animation/tracks/BooleanKeyframeTrack.js
......

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
