### PR TITLE
Allow Loaders to require onLoad parameter

### DIFF
--- a/types/three/examples/jsm/loaders/DRACOLoader.d.ts
+++ b/types/three/examples/jsm/loaders/DRACOLoader.d.ts
@@ -6,6 +6,14 @@ export class DRACOLoader extends Loader<BufferGeometry> {
     setDecoderPath(path: string): DRACOLoader;
     setDecoderConfig(config: object): DRACOLoader;
     setWorkerLimit(workerLimit: number): DRACOLoader;
+
+    load(
+        url: string,
+        onLoad?: (data: BufferGeometry) => void,
+        onProgress?: (event: ProgressEvent) => void,
+        onError?: (err: unknown) => void,
+    ): void;
+
     preload(): DRACOLoader;
     dispose(): DRACOLoader;
 }

--- a/types/three/examples/jsm/loaders/FontLoader.d.ts
+++ b/types/three/examples/jsm/loaders/FontLoader.d.ts
@@ -3,6 +3,13 @@ import { Shape, Loader, LoadingManager } from '../../../src/Three.js';
 export class FontLoader extends Loader<Font> {
     constructor(manager?: LoadingManager);
 
+    load(
+        url: string,
+        onLoad?: (data: Font) => void,
+        onProgress?: (event: ProgressEvent) => void,
+        onError?: (err: unknown) => void,
+    ): void;
+
     parse(json: any): Font;
 }
 

--- a/types/three/src/loaders/FileLoader.d.ts
+++ b/types/three/src/loaders/FileLoader.d.ts
@@ -4,6 +4,13 @@ import { LoadingManager } from './LoadingManager.js';
 export class FileLoader extends Loader<string | ArrayBuffer> {
     constructor(manager?: LoadingManager);
 
+    load(
+        url: string,
+        onLoad?: (data: string | ArrayBuffer) => void,
+        onProgress?: (event: ProgressEvent) => void,
+        onError?: (err: unknown) => void,
+    ): void;
+
     mimeType: undefined | MimeType;
     responseType: undefined | string;
 

--- a/types/three/src/loaders/ImageBitmapLoader.d.ts
+++ b/types/three/src/loaders/ImageBitmapLoader.d.ts
@@ -4,6 +4,13 @@ import { LoadingManager } from './LoadingManager.js';
 export class ImageBitmapLoader extends Loader<ImageBitmap> {
     constructor(manager?: LoadingManager);
 
+    load(
+        url: string,
+        onLoad?: (data: ImageBitmap) => void,
+        onProgress?: (event: ProgressEvent) => void,
+        onError?: (err: unknown) => void,
+    ): void;
+
     /**
      * @default { premultiplyAlpha: 'none' }
      */

--- a/types/three/src/loaders/Loader.d.ts
+++ b/types/three/src/loaders/Loader.d.ts
@@ -34,7 +34,7 @@ export class Loader<TData = unknown, TUrl = string> {
 
     load(
         url: TUrl,
-        onLoad?: (data: TData) => void,
+        onLoad: (data: TData) => void,
         onProgress?: (event: ProgressEvent) => void,
         onError?: (err: unknown) => void,
     ): void;

--- a/types/three/src/loaders/ObjectLoader.d.ts
+++ b/types/three/src/loaders/ObjectLoader.d.ts
@@ -11,6 +11,13 @@ import { Source } from '../textures/Source.js';
 export class ObjectLoader extends Loader<Object3D> {
     constructor(manager?: LoadingManager);
 
+    load(
+        url: string,
+        onLoad?: (data: Object3D) => void,
+        onProgress?: (event: ProgressEvent) => void,
+        onError?: (err: unknown) => void,
+    ): void;
+
     parse(json: unknown, onLoad?: (object: Object3D) => void): Object3D;
     parseAsync(json: unknown): Promise<Object3D>;
     parseGeometries(json: unknown): { [key: string]: InstancedBufferGeometry | BufferGeometry };


### PR DESCRIPTION
### Why

Some `Loader`s check to see if `onLoad` is `undefined` before calling it, some just call it without an `undefined` check. With the changes in https://github.com/three-types/three-ts-types/pull/570, it was impossible to define a `Loader` where the `onLoad` parameter was required since the base `Loader` class required it be optional.

This came up in practice because the loader types defined by `three-stdlib` have some required `onLoad` parameters that were causing type errors. After further investigation, this seemed like the best solution both for @types/three and three-stdlib.

### What

This PR allows for either required or optional `onLoad` parameters by making the `onLoad` parameter required in the base `Loader` class and then overloading the `load` method in any derived classes that want to make `onLoad` optional.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Added myself to contributors table
-   [x] Ready to be merged
