### PR TITLE
Widen controls mouse/touch types

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -206,13 +206,17 @@ export class OrbitControls extends EventDispatcher<OrbitControlsEventMap> {
      * This object contains references to the mouse actions used
      * by the controls.
      */
-    mouseButtons: Partial<{ LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE }>;
+    mouseButtons: {
+        LEFT?: MOUSE | null | undefined;
+        MIDDLE?: MOUSE | null | undefined;
+        RIGHT?: MOUSE | null | undefined;
+    };
 
     /**
      * This object contains references to the touch actions used by
      * the controls.
      */
-    touches: Partial<{ ONE: TOUCH; TWO: TOUCH }>;
+    touches: { ONE?: TOUCH | null | undefined; TWO?: TOUCH | null | undefined };
 
     /**
      * Used internally by the .saveState and .reset methods.

--- a/types/three/examples/jsm/controls/TrackballControls.d.ts
+++ b/types/three/examples/jsm/controls/TrackballControls.d.ts
@@ -29,7 +29,11 @@ export class TrackballControls extends EventDispatcher<TrackballControlsEventMap
     minZoom: number;
     maxZoom: number;
     keys: string[];
-    mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
+    mouseButtons: {
+        LEFT?: MOUSE | null | undefined;
+        MIDDLE?: MOUSE | null | undefined;
+        RIGHT?: MOUSE | null | undefined;
+    };
 
     target: Vector3;
     position0: Vector3;

--- a/types/three/examples/jsm/controls/TransformControls.d.ts
+++ b/types/three/examples/jsm/controls/TransformControls.d.ts
@@ -54,7 +54,11 @@ export class TransformControls extends Object3D<TransformControlsEventMap> {
     showZ: boolean;
 
     readonly isTransformControls: true;
-    mouseButtons: { LEFT: MOUSE; MIDDLE: MOUSE; RIGHT: MOUSE };
+    mouseButtons: {
+        LEFT?: MOUSE | null | undefined;
+        MIDDLE?: MOUSE | null | undefined;
+        RIGHT?: MOUSE | null | undefined;
+    };
 
     attach(object: Object3D): this;
     detach(): this;


### PR DESCRIPTION
### Why

Fixes #463.

While undocumented, it seems like people are passing `null`, `undefined`, or nothing to disable a mouse button or touch event.

### What

Widen controls mouse/touch mapping types

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
