### PR TITLE
Fix: change `Color.set()` override order to set ColorRepresentation function signature

### DIFF
--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -204,8 +204,8 @@ export class Color {
      */
     b: number;
 
-    set(color: ColorRepresentation): this;
     set(r: number, g: number, b: number): this;
+    set(color: ColorRepresentation): this;
 
     /**
      * Sets this color's {@link r}, {@link g} and {@link b} components from the x, y, and z components of the specified


### PR DESCRIPTION
### Why

Since r153 Typescript will throw errors when setting the Color property in a [Threlte](https://threlte.xyz) application, because Threlte will use the `Parameters` of `set()` to determine types.

### What

It was suggested in [this three-ts-types discussion](https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/66812) to change override order to fix this issue.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
