### PR TITLE
EXRExporter: implements support for DataTexture export

### DIFF
--- a/types/three/examples/jsm/exporters/EXRExporter.d.ts
+++ b/types/three/examples/jsm/exporters/EXRExporter.d.ts
@@ -5,7 +5,7 @@
  * https://www.openexr.com/documentation/openexrfilelayout.pdf
  */
 
-import { WebGLRenderer, WebGLRenderTarget, TextureDataType } from '../../../src/Three.js';
+import { DataTexture, TextureDataType, WebGLRenderer, WebGLRenderTarget } from '../../../src/Three.js';
 
 export const NO_COMPRESSION: 0;
 export const ZIPS_COMPRESSION: 2;
@@ -18,4 +18,5 @@ export interface EXRExporterParseOptions {
 
 export class EXRExporter {
     parse(renderer: WebGLRenderer, renderTarget: WebGLRenderTarget, options?: EXRExporterParseOptions): Uint8Array;
+    parse(dataTexture: DataTexture, options?: EXRExporterParseOptions): Uint8Array;
 }


### PR DESCRIPTION
### Why

r157

### What

Type changes corresponding to https://github.com/mrdoob/three.js/pull/26810.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
