### PR TITLE
Nomenclature: use `Depth`, not `Deep`

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -462,11 +462,11 @@ export type WebGL2PixelFormat =
 export type PixelFormat = WebGL1PixelFormat | WebGL2PixelFormat;
 
 /**
- * All Texture Pixel Formats Modes for {@link THREE.DeepTexture}.
+ * All Texture Pixel Formats Modes for {@link THREE.DepthTexture}.
  * @see {@link WebGLRenderingContext.texImage2D} for details.
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
  */
-export type DeepTexturePixelFormat = typeof DepthFormat | typeof DepthStencilFormat;
+export type DepthTexturePixelFormat = typeof DepthFormat | typeof DepthStencilFormat;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Compressed texture formats
@@ -649,10 +649,10 @@ export type CompressedPixelFormat =
  * All Possible Texture Pixel Formats Modes. For any Type or SubType of Textures.
  * @remarks Note that the texture must have the correct {@link THREE.Texture.type} set, as described in {@link TextureDataType}.
  * @see {@link WebGLRenderingContext.texImage2D} for details.
- * @see {@link PixelFormat} and {@link DeepTexturePixelFormat} and {@link CompressedPixelFormat}
+ * @see {@link PixelFormat} and {@link DepthTexturePixelFormat} and {@link CompressedPixelFormat}
  * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
  */
-export type AnyPixelFormat = PixelFormat | DeepTexturePixelFormat | CompressedPixelFormat;
+export type AnyPixelFormat = PixelFormat | DepthTexturePixelFormat | CompressedPixelFormat;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Loop styles for AnimationAction

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -3,7 +3,7 @@ import {
     Mapping,
     Wrapping,
     TextureDataType,
-    DeepTexturePixelFormat,
+    DepthTexturePixelFormat,
     MagnificationTextureFilter,
     MinificationTextureFilter,
     TextureComparisonFunction,
@@ -42,7 +42,7 @@ export class DepthTexture extends Texture {
         magFilter?: MagnificationTextureFilter,
         minFilter?: MinificationTextureFilter,
         anisotropy?: number,
-        format?: DeepTexturePixelFormat,
+        format?: DepthTexturePixelFormat,
     );
 
     /**
@@ -88,7 +88,7 @@ export class DepthTexture extends Texture {
      * @see {@link Texture.format | Texture.format}
      * @defaultValue {@link THREE.DepthFormat}.
      */
-    format: DeepTexturePixelFormat;
+    format: DepthTexturePixelFormat;
 
     /**
      * @override

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -201,8 +201,8 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
 
     /**
      * These define how elements of a 2D texture, or texels, are read by shaders.
-     * @remarks All {@link Texture} types except {@link THREE.DeepTexture} and {@link THREE.CompressedPixelFormat} expect the _values_ be {@link THREE.PixelFormat}
-     * @remarks {@link DeepTexture} expect the _values_ be {@link THREE.CubeTextureMapping}
+     * @remarks All {@link Texture} types except {@link THREE.DepthTexture} and {@link THREE.CompressedPixelFormat} expect the _values_ be {@link THREE.PixelFormat}
+     * @remarks {@link DepthTexture} expect the _values_ be {@link THREE.CubeTextureMapping}
      * @remarks {@link CompressedPixelFormat} expect the _values_ be {@link THREE.CubeTextureMapping}
      * @see {@link https://threejs.org/docs/index.html#api/en/constants/Textures | Texture Constants}
      * @see {@link THREE.PixelFormat}


### PR DESCRIPTION
This PR renames DeepTexture* to DepthTexture*

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
