### PR TITLE
Replace Color with ColorRepresentation

### DIFF
--- a/types/three/src/helpers/AxesHelper.d.ts
+++ b/types/three/src/helpers/AxesHelper.d.ts
@@ -1,4 +1,4 @@
-import { Color } from '../math/Color.js';
+import { ColorRepresentation } from '../math/Color.js';
 import { LineSegments } from './../objects/LineSegments.js';
 
 /**
@@ -39,7 +39,7 @@ export class AxesHelper extends LineSegments {
      * @param yAxisColor
      * @param zAxisColor
      */
-    setColors(xAxisColor: Color, yAxisColor: Color, zAxisColor: Color): this;
+    setColors(xAxisColor: ColorRepresentation, yAxisColor: ColorRepresentation, zAxisColor: ColorRepresentation): this;
 
     /**
      * Frees the GPU-related resources allocated by this instance

--- a/types/three/src/helpers/Box3Helper.d.ts
+++ b/types/three/src/helpers/Box3Helper.d.ts
@@ -1,5 +1,5 @@
 import { Box3 } from './../math/Box3.js';
-import { Color } from './../math/Color.js';
+import { ColorRepresentation } from './../math/Color.js';
 import { LineSegments } from './../objects/LineSegments.js';
 
 /**
@@ -20,7 +20,7 @@ export class Box3Helper extends LineSegments {
      * @param box The Box3 to show.
      * @param color The box's color. Default `0xffff00`
      */
-    constructor(box: Box3, color?: Color);
+    constructor(box: Box3, color?: ColorRepresentation);
 
     /**
      * A Read-only _string_ to check if `this` object type.


### PR DESCRIPTION


> Box3Helper.js

```
class Box3Helper extends LineSegments {
    constructor( box, color = 0xffff00 ) { ... }
}
```



But ...

```
new Box3Helper(box3, 0xffff00)

//Error: Argument of type 'number' is not assignable to parameter of type 'Color'.
```



----



<br>

> Color.js

```
set( r, g, b) {
    if ( g === undefined && b === undefined ) {
        const value = r;
        if ( value && value.isColor ) { 
        } else if ( typeof value === 'number' ) {
        } else if ( typeof value === 'string' ) {
        }
    }
    ...
 }
```



<br>

AxesHelper.js

```
setColors( xAxisColor, yAxisColor, zAxisColor ) {
    const color = new Color();
    color.set( xAxisColor );
    ...
}
```



<br>

So... 

> AxesHelper.d.ts

```diff
- setColors(xAxisColor: Color ...)
+ setColors(xAxisColor: ColorRepresentation ...)
```

