### PR TITLE
Material: Allow `null` as value for `.clippingPlanes`

### DIFF
--- a/examples-testing/changes.patch
+++ b/examples-testing/changes.patch
@@ -3155,7 +3155,7 @@ index f0a18f3..754f7ce 100644
  init();
  animate();
 diff --git a/examples-testing/examples/webgl_clipping_advanced.ts b/examples-testing/examples/webgl_clipping_advanced.ts
-index d60532c..ccc98e6 100644
+index d60532c..75dba77 100644
 --- a/examples-testing/examples/webgl_clipping_advanced.ts
 +++ b/examples-testing/examples/webgl_clipping_advanced.ts
 @@ -5,7 +5,7 @@ import { GUI } from 'three/addons/libs/lil-gui.module.min.js';
@@ -3221,6 +3221,15 @@ index d60532c..ccc98e6 100644
  
  function init() {
      camera = new THREE.PerspectiveCamera(36, window.innerWidth / window.innerHeight, 0.25, 16);
+@@ -194,7 +202,7 @@ function init() {
+ 
+             // clip to the others to show the volume (wildly
+             // intersecting transparent planes look bad)
+-            clippingPlanes: clipMaterial.clippingPlanes.filter(function (_, j) {
++            clippingPlanes: clipMaterial.clippingPlanes!.filter(function (_, j) {
+                 return j !== i;
+             }),
+ 
 @@ -306,12 +314,12 @@ function onWindowResize() {
      renderer.setSize(window.innerWidth, window.innerHeight);
  }
@@ -3235,6 +3244,15 @@ index d60532c..ccc98e6 100644
 +    object.matrix.copy(parent!.matrixWorld).invert();
      object.applyMatrix4(matrix);
  }
+ 
+@@ -334,7 +342,7 @@ function animate() {
+     const bouncy = Math.cos(time * 0.5) * 0.5 + 0.7;
+     transform.multiply(tmpMatrix.makeScale(bouncy, bouncy, bouncy));
+ 
+-    assignTransformedPlanes(clipMaterial.clippingPlanes, Planes, transform);
++    assignTransformedPlanes(clipMaterial.clippingPlanes!, Planes, transform);
+ 
+     const planeMeshes = volumeVisualization.children;
  
 diff --git a/examples-testing/examples/webgl_clipping_intersection.ts b/examples-testing/examples/webgl_clipping_intersection.ts
 index 74022d7..6835776 100644

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -141,7 +141,7 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
      * See the WebGL / clipping /intersection example. Default is null.
      * @default null
      */
-    clippingPlanes: Plane[];
+    clippingPlanes: Plane[] | null;
 
     /**
      * Defines whether to clip shadows according to the clipping planes specified on this material. Default is false.


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
The default value of the property is `null`, so it should also be possible to assign `null` to it. 

Given that other properties of the `Material` class that default to `null` also allow this, it seems that this was simply an oversight. Previously, it was possible to assign `null` to it because the property was typed as `any` (until the typing was improved in [this commit](https://github.com/three-types/three-ts-types/commit/c7d06ae9cbeb8800008685dba371e4311fd39824)). 

### What

Adjust types to allow `null` as a possible value for the `clippingPlanes` property of `Material`

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

-   [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
