### PR TITLE
OrbitControls: Add 3D cursor and limit to orbit camera target.

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -45,6 +45,12 @@ export class OrbitControls extends EventDispatcher<OrbitControlsEventMap> {
     center: Vector3;
 
     /**
+     * The focus point of the {@link .minTargetRadius} and {@link .maxTargetRadius} limits. It can be updated manually
+     * at any point to change the center of interest for the {@link .target}.
+     */
+    cursor: Vector3;
+
+    /**
      * How far you can dolly in ( PerspectiveCamera only ).
      * @default 0
      */
@@ -67,6 +73,18 @@ export class OrbitControls extends EventDispatcher<OrbitControlsEventMap> {
      * @default Infinity
      */
     maxZoom: number;
+
+    /**
+     * How close you can get the target to the 3D {@link .cursor}.
+     * @default 0
+     */
+    minTargetRadius: number;
+
+    /**
+     * How far you can move the target from the 3D {@link .cursor}.
+     * @default Infinity
+     */
+    maxTargetRadius: number;
 
     /**
      * How far you can orbit vertically, lower limit.


### PR DESCRIPTION
### Why

r158

### What

Type changes corresponding to https://github.com/mrdoob/three.js/pull/26558.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
