### PR TITLE
Fix on*Render methods to be member functions instead of properties

### DIFF
--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -235,14 +235,14 @@ export class Object3D<TEventMap extends Object3DEventMap = Object3DEventMap> ext
      * are not renderable and thus this callback is not executed for such objects.
      * @defaultValue `() => {}`
      */
-    onBeforeRender: (
+    onBeforeRender(
         renderer: WebGLRenderer,
         scene: Scene,
         camera: Camera,
         geometry: BufferGeometry,
         material: Material,
         group: Group,
-    ) => void;
+    ): void;
 
     /**
      * An optional callback that is executed immediately after a 3D object is rendered.
@@ -254,14 +254,14 @@ export class Object3D<TEventMap extends Object3DEventMap = Object3DEventMap> ext
      * are not renderable and thus this callback is not executed for such objects.
      * @defaultValue `() => {}`
      */
-    onAfterRender: (
+    onAfterRender(
         renderer: WebGLRenderer,
         scene: Scene,
         camera: Camera,
         geometry: BufferGeometry,
         material: Material,
         group: Group,
-    ) => void;
+    ): void;
 
     /**
      * The default {@link up} direction for objects, also used as the default position for {@link THREE.DirectionalLight | DirectionalLight},


### PR DESCRIPTION
### Why

The methods can't be overridden properly unless they're functions like they are in three.js source. This causes an issues in three-stdlib's [BatchedMesh](https://github.com/pmndrs/three-stdlib/pull/307).

### What

Fix the on*Render methods to be member functions

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
