### PR TITLE
Capsule: Move and rename lineToLineClosestPoints function to Octree util

### DIFF
--- a/types/three/examples/jsm/math/Capsule.d.ts
+++ b/types/three/examples/jsm/math/Capsule.d.ts
@@ -23,5 +23,4 @@ export class Capsule {
         radius: number,
     ): boolean;
     intersectsBox(box: Box3): boolean;
-    lineLineMinimumPoints(line1: Line3, line2: Line3): Vector3[];
 }


### PR DESCRIPTION
### Why

r158

### What

Make type changes corresponding to https://github.com/mrdoob/three.js/pull/27044.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
