### PR TITLE
SVGRenderer: Add .outputColorSpace=DisplayP3ColorSpace support

### DIFF
--- a/types/three/examples/jsm/renderers/SVGRenderer.d.ts
+++ b/types/three/examples/jsm/renderers/SVGRenderer.d.ts
@@ -1,4 +1,4 @@
-import { Object3D, Color, Scene, Camera } from '../../../src/Three.js';
+import { Object3D, Color, Scene, Camera, ColorSpace } from '../../../src/Three.js';
 
 export class SVGObject extends Object3D {
     constructor(node: SVGElement);
@@ -12,6 +12,7 @@ export class SVGRenderer {
     sortObjects: boolean;
     sortElements: boolean;
     overdraw: number;
+    outputColorSpace: ColorSpace;
     info: { render: { vertices: number; faces: number } };
 
     getSize(): { width: number; height: number };


### PR DESCRIPTION
### Why

r158

### What

Type changes corresponding to https://github.com/mrdoob/three.js/pull/26914.

### Checklist

-   [x] Checked the target branch (current goes `master`, next goes `dev`)
-   [x] Ready to be merged
