### PR TITLE
Skinning Shaders: Remove need skinning texture size uniform by using textureSize function

### DIFF
--- a/types/three/src/objects/Skeleton.d.ts
+++ b/types/three/src/objects/Skeleton.d.ts
@@ -61,12 +61,6 @@ export class Skeleton {
      */
     boneTexture: null | DataTexture;
 
-    /**
-     * The size of the {@link boneTexture | .boneTexture}.
-     * @remarks Expects a `Integer`
-     */
-    boneTextureSize: number;
-
     frame: number;
 
     init(): void;


### PR DESCRIPTION
Type changes from https://github.com/mrdoob/three.js/pull/27117 and https://github.com/mrdoob/three.js/pull/27127.