### PR TITLE
[three] LineMaterial: fix incorrect type for color

### DIFF
--- a/types/three/examples/jsm/lines/LineMaterial.d.ts
+++ b/types/three/examples/jsm/lines/LineMaterial.d.ts
@@ -1,5 +1,4 @@
-import { Color, MaterialParameters, ShaderMaterial, Vector2 } from '../../../src/Three.js';
-import { ColorRepresentation } from '../../../src/math/Color.js';
+import { Color, ColorRepresentation, MaterialParameters, ShaderMaterial, Vector2 } from '../../../src/Three.js';
 
 export interface LineMaterialParameters extends MaterialParameters {
     alphaToCoverage?: boolean | undefined;

--- a/types/three/examples/jsm/lines/LineMaterial.d.ts
+++ b/types/three/examples/jsm/lines/LineMaterial.d.ts
@@ -1,8 +1,9 @@
 import { Color, MaterialParameters, ShaderMaterial, Vector2 } from '../../../src/Three.js';
+import { ColorRepresentation } from '../../../src/math/Color.js';
 
 export interface LineMaterialParameters extends MaterialParameters {
     alphaToCoverage?: boolean | undefined;
-    color?: number | undefined;
+    color?: ColorRepresentation | undefined;
     dashed?: boolean | undefined;
     dashScale?: number | undefined;
     dashSize?: number | undefined;

--- a/types/three/test/unit/examples/jsm/lines/LineMaterial.ts
+++ b/types/three/test/unit/examples/jsm/lines/LineMaterial.ts
@@ -1,0 +1,15 @@
+import * as THREE from 'three';
+
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial';
+
+const color1 = new LineMaterial({
+    color: new THREE.Color('blue'),
+});
+
+const color2 = new LineMaterial({
+    color: 'red',
+});
+
+const color3 = new LineMaterial({
+    color: 0xaabbcc,
+});

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -35,6 +35,7 @@
         "test/unit/examples/jsm/helpers/ViewHelper.ts",
         "test/unit/examples/jsm/libs/lil-gui.ts",
         "test/unit/examples/jsm/libs/tween.ts",
+        "test/unit/examples/jsm/lines/LineMaterial.ts",
         "test/unit/examples/jsm/nodes/core/FunctionNode.ts",
         "test/unit/examples/jsm/nodes/display/ColorAdjustmentNode.ts",
         "test/unit/examples/jsm/nodes/materials/lib/mx_noise.ts",


### PR DESCRIPTION
Changes the type of `color` in the constructor params from `number` to `ColorRepresentation`