### PR TITLE
Fix KTX2Loader TS type to match the JS code

### DIFF
--- a/types/three/examples/jsm/loaders/KTX2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/KTX2Loader.d.ts
@@ -1,7 +1,7 @@
-import { LoadingManager, CompressedTextureLoader, CompressedTexture, WebGLRenderer } from '../../../src/Three.js';
+import { LoadingManager, Loader, CompressedTexture, WebGLRenderer } from '../../../src/Three.js';
 import WebGPURenderer from '../renderers/webgpu/WebGPURenderer.js';
 
-export class KTX2Loader extends CompressedTextureLoader {
+export class KTX2Loader extends Loader {
     constructor(manager?: LoadingManager);
 
     setTranscoderPath(path: string): KTX2Loader;
@@ -9,9 +9,10 @@ export class KTX2Loader extends CompressedTextureLoader {
     detectSupport(renderer: WebGLRenderer | WebGPURenderer): KTX2Loader;
     dispose(): KTX2Loader;
 
-    parse(
-        buffer: ArrayBuffer,
+    load(
+        url: string,
         onLoad: (texture: CompressedTexture) => void,
+        onProgress?: (event: ProgressEvent) => void,
         onError?: (event: ErrorEvent) => void,
-    ): KTX2Loader;
+    ): CompressedTexture;
 }

--- a/types/three/examples/jsm/loaders/KTX2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/KTX2Loader.d.ts
@@ -8,11 +8,4 @@ export class KTX2Loader extends Loader<CompressedTexture> {
     setWorkerLimit(limit: number): KTX2Loader;
     detectSupport(renderer: WebGLRenderer | WebGPURenderer): KTX2Loader;
     dispose(): KTX2Loader;
-
-    load(
-        url: string,
-        onLoad: (texture: CompressedTexture) => void,
-        onProgress?: (event: ProgressEvent) => void,
-        onError?: (event: ErrorEvent) => void,
-    ): CompressedTexture;
 }

--- a/types/three/examples/jsm/loaders/KTX2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/KTX2Loader.d.ts
@@ -1,7 +1,7 @@
 import { LoadingManager, Loader, CompressedTexture, WebGLRenderer } from '../../../src/Three.js';
 import WebGPURenderer from '../renderers/webgpu/WebGPURenderer.js';
 
-export class KTX2Loader extends Loader {
+export class KTX2Loader extends Loader<CompressedTexture> {
     constructor(manager?: LoadingManager);
 
     setTranscoderPath(path: string): KTX2Loader;


### PR DESCRIPTION
KTX2Loader TS type derives from CompresssedTextureLoader, and overrides its parse method. The actual JS code derives KTX2Loader from Loader and overrides its load method. This change will fix this mismatch.