### PR TITLE
Add missing boolean readonly props to lights and materials

### DIFF
--- a/examples-testing/changes.patch
+++ b/examples-testing/changes.patch
@@ -1142,7 +1142,7 @@ index fdd35d4..1b12050 100644
      const link = document.createElement('a');
  
 diff --git a/examples-testing/examples/misc_exporter_gltf.ts b/examples-testing/examples/misc_exporter_gltf.ts
-index ceb964b..2b7de4d 100644
+index ceb964b..4a8e2be 100644
 --- a/examples-testing/examples/misc_exporter_gltf.ts
 +++ b/examples-testing/examples/misc_exporter_gltf.ts
 @@ -6,7 +6,7 @@ import { KTX2Loader } from 'three/addons/loaders/KTX2Loader.js';
@@ -1185,7 +1185,7 @@ index ceb964b..2b7de4d 100644
 +let camera: THREE.PerspectiveCamera,
 +    object: THREE.Object3D,
 +    object2: THREE.Mesh,
-+    material: THREE.MeshBasicMaterial | THREE.MeshStandardMaterial,
++    material: THREE.MeshBasicMaterial | THREE.MeshLambertMaterial | THREE.MeshStandardMaterial,
 +    geometry: THREE.BufferGeometry,
 +    scene1: THREE.Scene,
 +    scene2: THREE.Scene,
@@ -12362,7 +12362,7 @@ index c3f0207..c211b8a 100644
          if (morph.position.x > 2000) {
              morph.position.x = -1000 - Math.random() * 500;
 diff --git a/examples-testing/examples/webgl_shadowmap_pointlight.ts b/examples-testing/examples/webgl_shadowmap_pointlight.ts
-index f921519..cffc086 100644
+index f921519..d39eb4e 100644
 --- a/examples-testing/examples/webgl_shadowmap_pointlight.ts
 +++ b/examples-testing/examples/webgl_shadowmap_pointlight.ts
 @@ -4,8 +4,8 @@ import Stats from 'three/addons/libs/stats.module.js';
@@ -12385,6 +12385,18 @@ index f921519..cffc086 100644
          const intensity = 200;
  
          const light = new THREE.PointLight(color, intensity, 20);
+@@ -27,9 +27,9 @@ function init() {
+         light.shadow.bias = -0.005; // reduces self-shadowing on double-sided objects
+ 
+         let geometry = new THREE.SphereGeometry(0.3, 12, 6);
+-        let material = new THREE.MeshBasicMaterial({ color: color });
++        let material: THREE.MeshBasicMaterial | THREE.MeshPhongMaterial = new THREE.MeshBasicMaterial({ color: color });
+         material.color.multiplyScalar(intensity);
+-        let sphere = new THREE.Mesh(geometry, material);
++        let sphere = new THREE.Mesh<THREE.BufferGeometry, THREE.Material>(geometry, material);
+         light.add(sphere);
+ 
+         const texture = new THREE.CanvasTexture(generateTexture());
 @@ -107,7 +107,7 @@ function generateTexture() {
      canvas.width = 2;
      canvas.height = 2;
@@ -13941,7 +13953,7 @@ index a09b733..292719d 100644
      clock = new THREE.Clock();
  
 diff --git a/examples-testing/examples/webxr_vr_rollercoaster.ts b/examples-testing/examples/webxr_vr_rollercoaster.ts
-index b659652..a10b469 100644
+index b659652..06e3224 100644
 --- a/examples-testing/examples/webxr_vr_rollercoaster.ts
 +++ b/examples-testing/examples/webxr_vr_rollercoaster.ts
 @@ -9,7 +9,7 @@ import {
@@ -13949,7 +13961,7 @@ index b659652..a10b469 100644
  import { VRButton } from 'three/addons/webxr/VRButton.js';
  
 -let mesh, material, geometry;
-+let mesh: THREE.Mesh, material: THREE.MeshBasicMaterial, geometry: SkyGeometry;
++let mesh: THREE.Mesh, material: THREE.Material, geometry: SkyGeometry;
  
  const renderer = new THREE.WebGLRenderer({ antialias: true });
  renderer.setPixelRatio(window.devicePixelRatio);

--- a/types/three/src/lights/PointLight.d.ts
+++ b/types/three/src/lights/PointLight.d.ts
@@ -30,6 +30,13 @@ export class PointLight extends Light<PointLightShadow> {
     constructor(color?: ColorRepresentation, intensity?: number, distance?: number, decay?: number);
 
     /**
+     * Read-only flag to check if a given object is of type {@link PointLight}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isPointLight: true;
+
+    /**
      * @default 'PointLight'
      */
     type: string;

--- a/types/three/src/materials/LineBasicMaterial.d.ts
+++ b/types/three/src/materials/LineBasicMaterial.d.ts
@@ -14,6 +14,13 @@ export class LineBasicMaterial extends Material {
     constructor(parameters?: LineBasicMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link LineBasicMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isLineBasicMaterial: true;
+
+    /**
      * @default 'LineBasicMaterial'
      */
     type: string;

--- a/types/three/src/materials/LineDashedMaterial.d.ts
+++ b/types/three/src/materials/LineDashedMaterial.d.ts
@@ -10,6 +10,13 @@ export class LineDashedMaterial extends LineBasicMaterial {
     constructor(parameters?: LineDashedMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link LineDashedMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isLineDashedMaterial: true;
+
+    /**
      * @default 'LineDashedMaterial'
      */
     type: string;
@@ -28,7 +35,6 @@ export class LineDashedMaterial extends LineBasicMaterial {
      * @default 1
      */
     gapSize: number;
-    readonly isLineDashedMaterial: true;
 
     setValues(parameters: LineDashedMaterialParameters): void;
 }

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -70,6 +70,13 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
     constructor();
 
     /**
+     * Read-only flag to check if a given object is of type {@link Material}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMaterial: true;
+
+    /**
      * Enables alpha hashed transparency, an alternative to {@link .transparent} or {@link .alphaTest}. The material
      * will not be rendered if opacity is lower than a random threshold. Randomization introduces some grain or noise,
      * but approximates alpha blending without the associated problems of sorting. Using TAARenderPass can reduce the
@@ -255,12 +262,6 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
      * @default THREE.KeepStencilOp
      */
     stencilZPass: StencilOp;
-
-    /**
-     * Used to check whether this or derived classes are materials. Default is true.
-     * You should not change this, as it used internally for optimisation.
-     */
-    readonly isMaterial: true;
 
     /**
      * Material name. Default is an empty string.

--- a/types/three/src/materials/MeshBasicMaterial.d.ts
+++ b/types/three/src/materials/MeshBasicMaterial.d.ts
@@ -30,6 +30,13 @@ export class MeshBasicMaterial extends Material {
     constructor(parameters?: MeshBasicMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link MeshBasicMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshBasicMaterial: true;
+
+    /**
      * @default 'MeshBasicMaterial'
      */
     type: string;

--- a/types/three/src/materials/MeshDepthMaterial.d.ts
+++ b/types/three/src/materials/MeshDepthMaterial.d.ts
@@ -15,6 +15,12 @@ export interface MeshDepthMaterialParameters extends MaterialParameters {
 
 export class MeshDepthMaterial extends Material {
     constructor(parameters?: MeshDepthMaterialParameters);
+    /**
+     * Read-only flag to check if a given object is of type {@link MeshDepthMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshDepthMaterial: true;
 
     /**
      * @default 'MeshDepthMaterial'

--- a/types/three/src/materials/MeshDistanceMaterial.d.ts
+++ b/types/three/src/materials/MeshDistanceMaterial.d.ts
@@ -17,6 +17,13 @@ export class MeshDistanceMaterial extends Material {
     constructor(parameters?: MeshDistanceMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link MeshDistanceMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshDistanceMaterial: true;
+
+    /**
      * @default 'MeshDistanceMaterial'
      */
     type: string;

--- a/types/three/src/materials/MeshLambertMaterial.d.ts
+++ b/types/three/src/materials/MeshLambertMaterial.d.ts
@@ -39,6 +39,13 @@ export class MeshLambertMaterial extends Material {
     constructor(parameters?: MeshLambertMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link MeshLambertMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshLambertMaterial: true;
+
+    /**
      * @default 'MeshLambertMaterial'
      */
     type: string;

--- a/types/three/src/materials/MeshMatcapMaterial.d.ts
+++ b/types/three/src/materials/MeshMatcapMaterial.d.ts
@@ -25,6 +25,13 @@ export class MeshMatcapMaterial extends Material {
     constructor(parameters?: MeshMatcapMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link MeshMatcapMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshMatcapMaterial: true;
+
+    /**
      * @default 'MeshMatcapMaterial'
      */
     type: string;

--- a/types/three/src/materials/MeshNormalMaterial.d.ts
+++ b/types/three/src/materials/MeshNormalMaterial.d.ts
@@ -20,7 +20,7 @@ export interface MeshNormalMaterialParameters extends MaterialParameters {
 
 export class MeshNormalMaterial extends Material {
     constructor(parameters?: MeshNormalMaterialParameters);
-    
+
     /**
      * Read-only flag to check if a given object is of type {@link MeshNormalMaterial}.
      * @remarks This is a _constant_ value

--- a/types/three/src/materials/MeshNormalMaterial.d.ts
+++ b/types/three/src/materials/MeshNormalMaterial.d.ts
@@ -20,6 +20,13 @@ export interface MeshNormalMaterialParameters extends MaterialParameters {
 
 export class MeshNormalMaterial extends Material {
     constructor(parameters?: MeshNormalMaterialParameters);
+    
+    /**
+     * Read-only flag to check if a given object is of type {@link MeshNormalMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshNormalMaterial: true;
 
     /**
      * @default 'MeshNormalMaterial'

--- a/types/three/src/materials/MeshPhongMaterial.d.ts
+++ b/types/three/src/materials/MeshPhongMaterial.d.ts
@@ -44,6 +44,13 @@ export class MeshPhongMaterial extends Material {
     constructor(parameters?: MeshPhongMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link MeshPhongMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshPhongMaterial: true;
+
+    /**
      * @default 'MeshNormalMaterial'
      */
     type: string;

--- a/types/three/src/materials/MeshPhysicalMaterial.d.ts
+++ b/types/three/src/materials/MeshPhysicalMaterial.d.ts
@@ -48,7 +48,12 @@ export interface MeshPhysicalMaterialParameters extends MeshStandardMaterialPara
 export class MeshPhysicalMaterial extends MeshStandardMaterial {
     constructor(parameters?: MeshPhysicalMaterialParameters);
 
-    isMeshPhysicalMaterial: boolean;
+    /**
+     * Read-only flag to check if a given object is of type {@link MeshPhysicalMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshPhysicalMaterial: true;
 
     /**
      * @default 'MeshPhysicalMaterial'

--- a/types/three/src/materials/MeshStandardMaterial.d.ts
+++ b/types/three/src/materials/MeshStandardMaterial.d.ts
@@ -39,6 +39,13 @@ export class MeshStandardMaterial extends Material {
     constructor(parameters?: MeshStandardMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link MeshStandardMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshStandardMaterial: true;
+
+    /**
      * @default 'MeshStandardMaterial'
      */
     type: string;
@@ -199,8 +206,6 @@ export class MeshStandardMaterial extends Material {
      * @default fog
      */
     fog: boolean;
-
-    isMeshStandardMaterial: boolean;
 
     setValues(parameters: MeshStandardMaterialParameters): void;
 }

--- a/types/three/src/materials/MeshToonMaterial.d.ts
+++ b/types/three/src/materials/MeshToonMaterial.d.ts
@@ -35,7 +35,7 @@ export interface MeshToonMaterialParameters extends MaterialParameters {
 
 export class MeshToonMaterial extends Material {
     constructor(parameters?: MeshToonMaterialParameters);
-    
+
     /**
      * Read-only flag to check if a given object is of type {@link MeshToonMaterial}.
      * @remarks This is a _constant_ value

--- a/types/three/src/materials/MeshToonMaterial.d.ts
+++ b/types/three/src/materials/MeshToonMaterial.d.ts
@@ -35,6 +35,13 @@ export interface MeshToonMaterialParameters extends MaterialParameters {
 
 export class MeshToonMaterial extends Material {
     constructor(parameters?: MeshToonMaterialParameters);
+    
+    /**
+     * Read-only flag to check if a given object is of type {@link MeshToonMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isMeshToonMaterial: true;
 
     /**
      * @default 'MeshToonMaterial'

--- a/types/three/src/materials/PointsMaterial.d.ts
+++ b/types/three/src/materials/PointsMaterial.d.ts
@@ -15,6 +15,13 @@ export class PointsMaterial extends Material {
     constructor(parameters?: PointsMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link PointsMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isPointsMaterial: true;
+
+    /**
      * @default 'PointsMaterial'
      */
     type: string;

--- a/types/three/src/materials/RawShaderMaterial.d.ts
+++ b/types/three/src/materials/RawShaderMaterial.d.ts
@@ -2,4 +2,13 @@ import { ShaderMaterialParameters, ShaderMaterial } from './ShaderMaterial.js';
 
 export class RawShaderMaterial extends ShaderMaterial {
     constructor(parameters?: ShaderMaterialParameters);
+
+    /**
+     * Read-only flag to check if a given object is of type {@link RawShaderMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isRawShaderMaterial: true;
+
+    override readonly type: 'RawShaderMaterial';
 }

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -29,6 +29,13 @@ export class ShaderMaterial extends Material {
     constructor(parameters?: ShaderMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link ShaderMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isShaderMaterial: true;
+
+    /**
      * @default 'ShaderMaterial'
      */
     type: string;
@@ -113,8 +120,6 @@ export class ShaderMaterial extends Material {
      * @default null
      */
     glslVersion: GLSLVersion | null;
-
-    isShaderMaterial: boolean;
 
     setValues(parameters: ShaderMaterialParameters): void;
     toJSON(meta: any): any;

--- a/types/three/src/materials/ShadowMaterial.d.ts
+++ b/types/three/src/materials/ShadowMaterial.d.ts
@@ -10,6 +10,13 @@ export class ShadowMaterial extends Material {
     constructor(parameters?: ShadowMaterialParameters);
 
     /**
+     * Read-only flag to check if a given object is of type {@link ShadowMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isShadowMaterial: true;
+
+    /**
      * @default 'ShadowMaterial'
      */
     type: string;

--- a/types/three/src/materials/SpriteMaterial.d.ts
+++ b/types/three/src/materials/SpriteMaterial.d.ts
@@ -14,6 +14,13 @@ export interface SpriteMaterialParameters extends MaterialParameters {
 export class SpriteMaterial extends Material {
     constructor(parameters?: SpriteMaterialParameters);
     /**
+     * Read-only flag to check if a given object is of type {@link SpriteMaterial}.
+     * @remarks This is a _constant_ value
+     * @defaultValue `true`
+     */
+    readonly isSpriteMaterial: true;
+
+    /**
      * @default 'SpriteMaterial'
      */
     type: string;
@@ -53,8 +60,6 @@ export class SpriteMaterial extends Material {
      * @default fog
      */
     fog: boolean;
-
-    readonly isSpriteMaterial: true;
 
     setValues(parameters: SpriteMaterialParameters): void;
     copy(source: SpriteMaterial): this;


### PR DESCRIPTION
### Why
Currently it's difficult to type-narrow any class that does not have a typedef including an `is*` or `type` property that specifies a string constant as a value.

### What
This PR starts to address this problem by adding missing boolean readonly props to Lights and Materials.

### Checklist
- [x] Checked the target branch (current goes master, next goes dev)
- [ ] Added myself to contributors table
- [x] Ready to be merged