### PR TITLE
Change default type parameter for Mesh to a single Material

### DIFF
--- a/types/three/src/objects/BatchedMesh.d.ts
+++ b/types/three/src/objects/BatchedMesh.d.ts
@@ -33,7 +33,7 @@ import { Camera } from '../cameras/Camera.js';
  *
  * @also Example: {@link https://threejs.org/examples/#webgl_mesh_batch WebGL / mesh / batch}
  */
-declare class BatchedMesh extends Mesh<BufferGeometry, Material> {
+declare class BatchedMesh extends Mesh {
     /**
      * This bounding box encloses all instances of the {@link BatchedMesh}. Can be calculated with
      * {@link .computeBoundingBox()}.

--- a/types/three/src/objects/InstancedMesh.d.ts
+++ b/types/three/src/objects/InstancedMesh.d.ts
@@ -27,7 +27,7 @@ export interface InstancedMeshEventMap extends Object3DEventMap {
  */
 export class InstancedMesh<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
 > extends Mesh<TGeometry, TMaterial, InstancedMeshEventMap> {
     /**
      * Create a new instance of {@link InstancedMesh}

--- a/types/three/src/objects/Line.d.ts
+++ b/types/three/src/objects/Line.d.ts
@@ -26,7 +26,7 @@ import { BufferGeometry } from '../core/BufferGeometry.js';
  */
 export class Line<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
 > extends Object3D {
     /**
      * Create a new instance of {@link Line}

--- a/types/three/src/objects/LineLoop.d.ts
+++ b/types/three/src/objects/LineLoop.d.ts
@@ -14,7 +14,7 @@ import { BufferGeometry } from '../core/BufferGeometry.js';
  */
 export class LineLoop<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
 > extends Line<TGeometry, TMaterial> {
     /**
      * Create a new instance of {@link LineLoop}

--- a/types/three/src/objects/LineSegments.d.ts
+++ b/types/three/src/objects/LineSegments.d.ts
@@ -13,7 +13,7 @@ import { BufferGeometry } from '../core/BufferGeometry.js';
  */
 export class LineSegments<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
 > extends Line<TGeometry, TMaterial> {
     /**
      * Create a new instance of {@link LineSegments}

--- a/types/three/src/objects/Mesh.d.ts
+++ b/types/three/src/objects/Mesh.d.ts
@@ -21,7 +21,7 @@ import { Vector3 } from '../math/Vector3.js';
  */
 export class Mesh<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
     TEventMap extends Object3DEventMap = Object3DEventMap,
 > extends Object3D<TEventMap> {
     /**

--- a/types/three/src/objects/Points.d.ts
+++ b/types/three/src/objects/Points.d.ts
@@ -1,9 +1,6 @@
 import { Material } from '../materials/Material.js';
 import { Object3D } from '../core/Object3D.js';
 import { BufferGeometry, NormalOrGLBufferAttributes } from '../core/BufferGeometry.js';
-import { BufferAttribute } from '../core/BufferAttribute.js';
-import { InterleavedBufferAttribute } from '../core/InterleavedBufferAttribute.js';
-import { GLBufferAttribute } from '../core/GLBufferAttribute.js';
 
 /**
  * A class for displaying {@link Points}
@@ -14,7 +11,7 @@ import { GLBufferAttribute } from '../core/GLBufferAttribute.js';
  */
 export class Points<
     TGeometry extends BufferGeometry<NormalOrGLBufferAttributes> = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
 > extends Object3D {
     /**
      * Create a new instance of {@link Points}

--- a/types/three/src/objects/SkinnedMesh.d.ts
+++ b/types/three/src/objects/SkinnedMesh.d.ts
@@ -49,7 +49,7 @@ import { BindMode } from '../constants.js';
  */
 export class SkinnedMesh<
     TGeometry extends BufferGeometry = BufferGeometry,
-    TMaterial extends Material | Material[] = Material | Material[],
+    TMaterial extends Material | Material[] = Material,
 > extends Mesh<TGeometry, TMaterial> {
     /**
      * Create a new instance of {@link SkinnedMesh}


### PR DESCRIPTION
It's more common for a mesh to have a single material, and allows for less type annotations in those cases.