### PR TITLE
fix: Mark third argument of `materialReference` as nullable

### DIFF
--- a/types/three/examples/jsm/nodes/accessors/MaterialReferenceNode.d.ts
+++ b/types/three/examples/jsm/nodes/accessors/MaterialReferenceNode.d.ts
@@ -9,5 +9,5 @@ export default class MaterialReferenceNode extends ReferenceNode<Material | null
 export const materialReference: (
     name: string,
     nodeOrType: NodeOrType,
-    material: Material,
+    material?: Material,
 ) => ShaderNodeObject<MaterialReferenceNode>;

--- a/types/three/examples/jsm/nodes/accessors/MaterialReferenceNode.d.ts
+++ b/types/three/examples/jsm/nodes/accessors/MaterialReferenceNode.d.ts
@@ -9,5 +9,5 @@ export default class MaterialReferenceNode extends ReferenceNode<Material | null
 export const materialReference: (
     name: string,
     nodeOrType: NodeOrType,
-    material?: Material,
+    material?: Material | null,
 ) => ShaderNodeObject<MaterialReferenceNode>;


### PR DESCRIPTION
### What

The third argument of `materialReference` should be nullable.

The definition on Three.js: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/accessors/MaterialReferenceNode.js#L9
The actual use of `materialReference` without the third argument (and this is the only use of `materialReference` in the Three.js repository): https://github.com/mrdoob/three.js/blob/85b3ee713ae64ac1db20fd9dd29d2892d10fab3d/examples/jsm/nodes/accessors/MaterialNode.js#L25
