### PR TITLE
fix (Nodes): fix type of `clamp` and `saturate`

### DIFF
--- a/types/three/examples/jsm/nodes/math/MathNode.d.ts
+++ b/types/three/examples/jsm/nodes/math/MathNode.d.ts
@@ -183,7 +183,11 @@ export type Ternary = (
 ) => ShaderNodeObject<MathNode>;
 
 export const mix: Ternary;
-export const clamp: (a: NodeRepresentation, b: NodeRepresentation, c: NodeRepresentation) => ShaderNodeObject<MathNode>;
+export const clamp: (
+    a: NodeRepresentation,
+    b?: NodeRepresentation,
+    c?: NodeRepresentation,
+) => ShaderNodeObject<MathNode>;
 export const saturate: Unary;
 export const refract: Ternary;
 export const smoothstep: Ternary;

--- a/types/three/examples/jsm/nodes/math/MathNode.d.ts
+++ b/types/three/examples/jsm/nodes/math/MathNode.d.ts
@@ -182,9 +182,15 @@ export type Ternary = (
     c?: NodeRepresentation | null,
 ) => ShaderNodeObject<MathNode>;
 
+export type UnaryOrBinaryOrTernary = (
+    a: NodeRepresentation,
+    b?: NodeRepresentation,
+    c?: NodeRepresentation,
+) => ShaderNodeObject<MathNode>;
+
 export const mix: Ternary;
-export const clamp: Ternary;
-export const saturate: Ternary;
+export const clamp: UnaryOrBinaryOrTernary;
+export const saturate: Unary;
 export const refract: Ternary;
 export const smoothstep: Ternary;
 export const faceForward: Ternary;

--- a/types/three/examples/jsm/nodes/math/MathNode.d.ts
+++ b/types/three/examples/jsm/nodes/math/MathNode.d.ts
@@ -158,7 +158,7 @@ export const trunc: Unary;
 export const fwidth: Unary;
 export const bitcast: Unary;
 
-export type Binary = (a: NodeRepresentation, b?: NodeRepresentation | null) => ShaderNodeObject<MathNode>;
+export type Binary = (a: NodeRepresentation, b: NodeRepresentation) => ShaderNodeObject<MathNode>;
 
 export const atan2: Binary;
 export const min: Binary;
@@ -178,18 +178,12 @@ export const transformDirection: Binary;
 
 export type Ternary = (
     a: NodeRepresentation,
-    b?: NodeRepresentation | null,
-    c?: NodeRepresentation | null,
-) => ShaderNodeObject<MathNode>;
-
-export type UnaryOrBinaryOrTernary = (
-    a: NodeRepresentation,
-    b?: NodeRepresentation,
-    c?: NodeRepresentation,
+    b: NodeRepresentation,
+    c: NodeRepresentation,
 ) => ShaderNodeObject<MathNode>;
 
 export const mix: Ternary;
-export const clamp: UnaryOrBinaryOrTernary;
+export const clamp: (a: NodeRepresentation, b: NodeRepresentation, c: NodeRepresentation) => ShaderNodeObject<MathNode>;
 export const saturate: Unary;
 export const refract: Ternary;
 export const smoothstep: Ternary;


### PR DESCRIPTION
### What

- `clamp` can be unary or binary
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/math/MathNode.js#L301
  - I have no confidence of the type name `UnaryOrBinaryOrTernary`. Would you come up with a better name?
- `saturate` is unary
