### PR TITLE
feat (Nodes): Improve NodeElements + tangential changes

### DIFF
--- a/types/three/examples/jsm/nodes/Nodes.d.ts
+++ b/types/three/examples/jsm/nodes/Nodes.d.ts
@@ -269,7 +269,14 @@ export {
     luminance,
     ColorAdjustmentMethod,
 } from './display/ColorAdjustmentNode.js';
-export { default as ColorSpaceNode, ColorSpaceNodeMethod, linearTosRGB, sRGBToLinear, linearToColorSpace, colorSpaceToLinear } from './display/ColorSpaceNode.js';
+export {
+    default as ColorSpaceNode,
+    ColorSpaceNodeMethod,
+    linearTosRGB,
+    sRGBToLinear,
+    linearToColorSpace,
+    colorSpaceToLinear,
+} from './display/ColorSpaceNode.js';
 export { default as FrontFacingNode, frontFacing, faceDirection } from './display/FrontFacingNode.js';
 export { default as NormalMapNode, normalMap, TBNViewMatrix } from './display/NormalMapNode.js';
 export { default as PosterizeNode, posterize } from './display/PosterizeNode.js';

--- a/types/three/examples/jsm/nodes/Nodes.d.ts
+++ b/types/three/examples/jsm/nodes/Nodes.d.ts
@@ -271,11 +271,11 @@ export {
 } from './display/ColorAdjustmentNode.js';
 export {
     default as ColorSpaceNode,
-    ColorSpaceNodeMethod,
-    linearTosRGB,
-    sRGBToLinear,
     linearToColorSpace,
     colorSpaceToLinear,
+    linearTosRGB,
+    sRGBToLinear,
+    ColorSpaceNodeMethod,
 } from './display/ColorSpaceNode.js';
 export { default as FrontFacingNode, frontFacing, faceDirection } from './display/FrontFacingNode.js';
 export { default as NormalMapNode, normalMap, TBNViewMatrix } from './display/NormalMapNode.js';

--- a/types/three/examples/jsm/nodes/Nodes.d.ts
+++ b/types/three/examples/jsm/nodes/Nodes.d.ts
@@ -3,11 +3,12 @@ export * from './core/constants.js';
 
 // core
 export { default as ArrayUniformNode } from './core/ArrayUniformNode.js';
+export { default as AssignNode, assign } from './core/AssignNode.js';
 export { default as AttributeNode, attribute } from './core/AttributeNode.js';
 export { default as BypassNode, bypass } from './core/BypassNode.js';
-export { default as CacheNode, cache } from './core/CacheNode.js';
+export { default as CacheNode, cache, globalCache } from './core/CacheNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
-export { default as ContextNode, context } from './core/ContextNode.js';
+export { default as ContextNode, context, label } from './core/ContextNode.js';
 export { default as Node } from './core/Node.js';
 export { default as NodeAttribute } from './core/NodeAttribute.js';
 export { default as NodeBuilder } from './core/NodeBuilder.js';
@@ -43,7 +44,7 @@ export {
 export { default as StackNode } from './core/StackNode.js';
 export { default as TempNode } from './core/TempNode.js';
 export { default as UniformNode, uniform } from './core/UniformNode.js';
-export { default as VarNode, label, temp } from './core/VarNode.js';
+export { default as VarNode, temp } from './core/VarNode.js';
 export { default as VaryingNode, varying } from './core/VaryingNode.js';
 
 import * as NodeUtils from './core/NodeUtils.js';
@@ -121,7 +122,6 @@ export {
     div,
     remainder,
     equal,
-    assign,
     lessThan,
     greaterThan,
     lessThanEqual,
@@ -269,7 +269,7 @@ export {
     luminance,
     ColorAdjustmentMethod,
 } from './display/ColorAdjustmentNode.js';
-export { default as ColorSpaceNode, colorSpace, ColorSpaceNodeMethod } from './display/ColorSpaceNode.js';
+export { default as ColorSpaceNode, ColorSpaceNodeMethod, linearTosRGB, sRGBToLinear, linearToColorSpace, colorSpaceToLinear } from './display/ColorSpaceNode.js';
 export { default as FrontFacingNode, frontFacing, faceDirection } from './display/FrontFacingNode.js';
 export { default as NormalMapNode, normalMap, TBNViewMatrix } from './display/NormalMapNode.js';
 export { default as PosterizeNode, posterize } from './display/PosterizeNode.js';

--- a/types/three/examples/jsm/nodes/Nodes.d.ts
+++ b/types/three/examples/jsm/nodes/Nodes.d.ts
@@ -6,7 +6,7 @@ export { default as ArrayUniformNode } from './core/ArrayUniformNode.js';
 export { default as AssignNode, assign } from './core/AssignNode.js';
 export { default as AttributeNode, attribute } from './core/AttributeNode.js';
 export { default as BypassNode, bypass } from './core/BypassNode.js';
-export { default as CacheNode, cache, globalCache } from './core/CacheNode.js';
+export { default as CacheNode, cache } from './core/CacheNode.js';
 export { default as ConstNode } from './core/ConstNode.js';
 export { default as ContextNode, context, label } from './core/ContextNode.js';
 export { default as Node } from './core/Node.js';

--- a/types/three/examples/jsm/nodes/accessors/CubeTextureNode.d.ts
+++ b/types/three/examples/jsm/nodes/accessors/CubeTextureNode.d.ts
@@ -18,3 +18,9 @@ export const cubeTexture: (
     uvNode?: NodeRepresentation,
     levelNode?: NodeRepresentation,
 ) => ShaderNodeObject<CubeTextureNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        cubeTexture: typeof cubeTexture;
+    }
+}

--- a/types/three/examples/jsm/nodes/accessors/TextureNode.d.ts
+++ b/types/three/examples/jsm/nodes/accessors/TextureNode.d.ts
@@ -22,3 +22,9 @@ export const texture: (
     levelNode?: NodeRepresentation,
 ) => ShaderNodeObject<TextureNode>;
 export const sampler: (aTexture: Texture | TextureNode) => ShaderNodeObject<Node>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        texture: typeof texture;
+    }
+}

--- a/types/three/examples/jsm/nodes/code/FunctionCallNode.d.ts
+++ b/types/three/examples/jsm/nodes/code/FunctionCallNode.d.ts
@@ -17,3 +17,9 @@ export const call: <P extends FunctionNodeArguments>(
     functionNode?: FunctionNode<P>,
     parameters?: ProxiedObject<P>,
 ) => ShaderNodeObject<FunctionCallNode<P>>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        call: typeof call;
+    }
+}

--- a/types/three/examples/jsm/nodes/core/AssignNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/AssignNode.d.ts
@@ -8,7 +8,7 @@ export default class AssignNode extends TempNode {
     hasDependencies(): false;
 }
 
-export const assign: (targetNode: Node, sourceNode: Node) => ShaderNodeObject<AssignNode>;
+export const assign: (targetNode: NodeRepresentation, sourceNode: NodeRepresentation) => ShaderNodeObject<AssignNode>;
 
 declare module '../shadernode/ShaderNode.js' {
     interface NodeElements {

--- a/types/three/examples/jsm/nodes/core/AssignNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/AssignNode.d.ts
@@ -1,4 +1,4 @@
-import { ShaderNodeObject } from '../shadernode/ShaderNode.js';
+import { NodeRepresentation, ShaderNodeObject } from '../shadernode/ShaderNode.js';
 import Node from './Node.js';
 import TempNode from './TempNode.js';
 

--- a/types/three/examples/jsm/nodes/core/AssignNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/AssignNode.d.ts
@@ -1,0 +1,17 @@
+import { ShaderNodeObject } from '../shadernode/ShaderNode';
+import Node from './Node';
+import TempNode from './TempNode';
+
+export default class AssignNode extends TempNode {
+    constructor(targetNode: Node, sourceNode: Node);
+
+    hasDependencies(): false;
+}
+
+export const assign: (targetNode: Node, sourceNode: Node) => ShaderNodeObject<AssignNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        assign: typeof assign;
+    }
+}

--- a/types/three/examples/jsm/nodes/core/AssignNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/AssignNode.d.ts
@@ -1,6 +1,6 @@
-import { ShaderNodeObject } from '../shadernode/ShaderNode';
-import Node from './Node';
-import TempNode from './TempNode';
+import { ShaderNodeObject } from '../shadernode/ShaderNode.js';
+import Node from './Node.js';
+import TempNode from './TempNode.js';
 
 export default class AssignNode extends TempNode {
     constructor(targetNode: Node, sourceNode: Node);

--- a/types/three/examples/jsm/nodes/core/BypassNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/BypassNode.d.ts
@@ -10,3 +10,9 @@ export default class BypassNode extends Node {
 }
 
 export const bypass: (returnNode: NodeRepresentation, callNode: NodeRepresentation) => ShaderNodeObject<BypassNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        bypass: typeof bypass;
+    }
+}

--- a/types/three/examples/jsm/nodes/core/CacheNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/CacheNode.d.ts
@@ -11,3 +11,11 @@ export default class CacheNode extends Node {
 }
 
 export const cache: (node: Node, cache?: NodeCache) => ShaderNodeObject<CacheNode>;
+export const globalCache: (node: Node) => ShaderNodeObject<CacheNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        cache: typeof cache;
+        globalCache: typeof globalCache;
+    }
+}

--- a/types/three/examples/jsm/nodes/core/ContextNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/ContextNode.d.ts
@@ -11,3 +11,11 @@ export default class ContextNode extends Node {
 }
 
 export const context: (node: NodeRepresentation, context: NodeBuilderContext) => ShaderNodeObject<ContextNode>;
+export const label: (node: NodeRepresentation, label: string) => ShaderNodeObject<ContextNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        context: typeof context;
+        label: typeof label;
+    }
+}

--- a/types/three/examples/jsm/nodes/core/VarNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/VarNode.d.ts
@@ -16,7 +16,6 @@ export default class VarNode extends Node {
     div(...params: Node[]): this;
 }
 
-export const label: (node: NodeRepresentation, name?: string | null) => ShaderNodeObject<VarNode>;
 export const temp: (node: NodeRepresentation, name?: string | null) => ShaderNodeObject<VarNode>;
 
 declare module '../shadernode/ShaderNode.js' {

--- a/types/three/examples/jsm/nodes/core/VaryingNode.d.ts
+++ b/types/three/examples/jsm/nodes/core/VaryingNode.d.ts
@@ -9,3 +9,9 @@ export default class VaryingNode extends Node {
 }
 
 export const varying: (node: NodeRepresentation, name?: string) => ShaderNodeObject<VaryingNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        varying: typeof varying;
+    }
+}

--- a/types/three/examples/jsm/nodes/display/ColorSpaceNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/ColorSpaceNode.d.ts
@@ -19,8 +19,8 @@ export default class ColorSpaceNode extends TempNode {
     constructor(method: ColorSpaceNodeMethod | null, node: Node);
 }
 
-export const linearToColorSpace: (node: NodeRepresentation, encoding: ColorSpace) => ShaderNodeObject<ColorSpaceNode>;
-export const colorSpaceToLinear: (node: NodeRepresentation, encoding: ColorSpace) => ShaderNodeObject<ColorSpaceNode>;
+export const linearToColorSpace: (node: NodeRepresentation, colorSpace: ColorSpace) => ShaderNodeObject<ColorSpaceNode>;
+export const colorSpaceToLinear: (node: NodeRepresentation, colorSpace: ColorSpace) => ShaderNodeObject<ColorSpaceNode>;
 
 export const linearTosRGB: (node: NodeRepresentation) => ShaderNodeObject<ColorSpaceNode>;
 export const sRGBToLinear: (node: NodeRepresentation) => ShaderNodeObject<ColorSpaceNode>;

--- a/types/three/examples/jsm/nodes/display/ColorSpaceNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/ColorSpaceNode.d.ts
@@ -1,4 +1,4 @@
-import { TextureEncoding } from '../../../../src/Three.js';
+import { ColorSpace } from '../../../../src/Three.js';
 import TempNode from '../core/TempNode.js';
 import Node from '../core/Node.js';
 import { NodeRepresentation, ShaderNodeObject } from '../shadernode/ShaderNode.js';
@@ -19,4 +19,17 @@ export default class ColorSpaceNode extends TempNode {
     constructor(method: ColorSpaceNodeMethod | null, node: Node);
 }
 
-export const colorSpace: (node: NodeRepresentation, encoding: TextureEncoding) => ShaderNodeObject<ColorSpaceNode>;
+export const linearToColorSpace: (node: NodeRepresentation, encoding: ColorSpace) => ShaderNodeObject<ColorSpaceNode>;
+export const colorSpaceToLinear: (node: NodeRepresentation, encoding: ColorSpace) => ShaderNodeObject<ColorSpaceNode>;
+
+export const linearTosRGB: (node: NodeRepresentation) => ShaderNodeObject<ColorSpaceNode>;
+export const sRGBToLinear: (node: NodeRepresentation) => ShaderNodeObject<ColorSpaceNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        linearTosRGB: typeof linearTosRGB;
+        sRGBToLinear: typeof sRGBToLinear;
+        linearToColorSpace: typeof linearToColorSpace;
+        colorSpaceToLinear: typeof colorSpaceToLinear;
+    }
+}

--- a/types/three/examples/jsm/nodes/display/NormalMapNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/NormalMapNode.d.ts
@@ -16,3 +16,9 @@ export default class NormalMapNode extends TempNode {
 export const normalMap: (node: Node, scaleNode?: Node) => ShaderNodeObject<NormalMapNode>;
 
 export const TBNViewMatrix: ShaderNodeObject<MathNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        normalMap: typeof normalMap;
+    }
+}

--- a/types/three/examples/jsm/nodes/display/ViewportSharedTextureNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/ViewportSharedTextureNode.d.ts
@@ -10,3 +10,9 @@ export const viewportSharedTexture: (
     uvNode?: Node,
     levelNode?: Node | null,
 ) => ShaderNodeObject<ViewportSharedTextureNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        viewportSharedTexture: typeof viewportSharedTexture;
+    }
+}

--- a/types/three/examples/jsm/nodes/display/ViewportTextureNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/ViewportTextureNode.d.ts
@@ -24,3 +24,10 @@ export const viewportMipTexture: (
     levelNode?: Node | null,
     framebufferTexture?: FramebufferTexture | null,
 ) => ShaderNodeObject<Node>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        viewportTexture: typeof viewportTexture;
+        viewportMipTexture: typeof viewportMipTexture;
+    }
+}

--- a/types/three/examples/jsm/nodes/fog/FogExp2Node.d.ts
+++ b/types/three/examples/jsm/nodes/fog/FogExp2Node.d.ts
@@ -10,3 +10,9 @@ export default class FogExp2Node extends FogNode {
 }
 
 export const densityFog: (colorNode: Node, densityNode: Node) => ShaderNodeObject<FogExp2Node>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        densityFog: typeof densityFog;
+    }
+}

--- a/types/three/examples/jsm/nodes/fog/FogNode.d.ts
+++ b/types/three/examples/jsm/nodes/fog/FogNode.d.ts
@@ -11,3 +11,9 @@ export default class FogNode extends Node {
 }
 
 export const fog: (colorNode: NodeRepresentation, factorNode: NodeRepresentation) => ShaderNodeObject<FogNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        fog: typeof fog;
+    }
+}

--- a/types/three/examples/jsm/nodes/fog/FogRangeNode.d.ts
+++ b/types/three/examples/jsm/nodes/fog/FogRangeNode.d.ts
@@ -11,3 +11,9 @@ export default class FogRangeNode extends FogNode {
 }
 
 export const rangeFog: (colorNode: Node, nearNode: Node, farNode: Node) => ShaderNodeObject<FogRangeNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        rangeFog: typeof rangeFog;
+    }
+}

--- a/types/three/examples/jsm/nodes/gpgpu/ComputeNode.d.ts
+++ b/types/three/examples/jsm/nodes/gpgpu/ComputeNode.d.ts
@@ -16,3 +16,9 @@ export const compute: (
     count: number,
     workgroupSize: number[],
 ) => ShaderNodeObject<ComputeNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        compute: typeof compute;
+    }
+}

--- a/types/three/examples/jsm/nodes/lighting/LightingContextNode.d.ts
+++ b/types/three/examples/jsm/nodes/lighting/LightingContextNode.d.ts
@@ -18,3 +18,9 @@ export const lightingContext: (
     node: Node,
     lightingModelNode?: LightingModelNode,
 ) => ShaderNodeObject<LightingContextNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        lightingContext: typeof lightingContext;
+    }
+}

--- a/types/three/examples/jsm/nodes/math/OperatorNode.d.ts
+++ b/types/three/examples/jsm/nodes/math/OperatorNode.d.ts
@@ -3,7 +3,6 @@ import Node from '../core/Node.js';
 import { NodeRepresentation, ShaderNodeObject } from '../shadernode/ShaderNode.js';
 
 export type OperatorNodeOp =
-    | '='
     | '%'
     | '&'
     | '|'
@@ -43,7 +42,6 @@ export const mul: Operator;
 export const div: Operator;
 export const remainder: Operator;
 export const equal: Operator;
-export const assign: Operator;
 export const lessThan: Operator;
 export const greaterThan: Operator;
 export const lessThanEqual: Operator;
@@ -65,7 +63,6 @@ declare module '../shadernode/ShaderNode.js' {
         div: typeof div;
         remainder: typeof remainder;
         equal: typeof equal;
-        assign: typeof assign;
         lessThan: typeof lessThan;
         greaterThan: typeof greaterThan;
         lessThanEqual: typeof lessThanEqual;

--- a/types/three/examples/jsm/nodes/procedural/CheckerNode.d.ts
+++ b/types/three/examples/jsm/nodes/procedural/CheckerNode.d.ts
@@ -7,3 +7,9 @@ export default class CheckerNode extends TempNode {
 }
 
 export const checker: (uvNode?: NodeRepresentation) => ShaderNodeObject<CheckerNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        checker: typeof checker;
+    }
+}

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -5,6 +5,37 @@ import NodeBuilder from '../core/NodeBuilder.js';
 
 export interface NodeElements {
     append: typeof append;
+
+    color: typeof color;
+    float: typeof float;
+    int: typeof int;
+    uint: typeof uint;
+    bool: typeof bool;
+    vec2: typeof vec2;
+    ivec2: typeof ivec2;
+    uvec2: typeof uvec2;
+    bvec2: typeof bvec2;
+    vec3: typeof vec3;
+    ivec3: typeof ivec3;
+    uvec3: typeof uvec3;
+    bvec3: typeof bvec3;
+    vec4: typeof vec4;
+    ivec4: typeof ivec4;
+    uvec4: typeof uvec4;
+    bvec4: typeof bvec4;
+    mat3: typeof mat3;
+    imat3: typeof imat3;
+    umat3: typeof umat3;
+    bmat3: typeof bmat3;
+    mat4: typeof mat4;
+    imat4: typeof imat4;
+    umat4: typeof umat4;
+    bmat4: typeof bmat4;
+    string: typeof string;
+    arrayBuffer: typeof arrayBuffer;
+
+    element: typeof element;
+    convert: typeof convert;
 }
 
 export function addNodeElement(name: string, nodeElement: unknown): void;
@@ -196,6 +227,9 @@ export const mat4: ConvertType;
 export const imat4: ConvertType;
 export const umat4: ConvertType;
 export const bmat4: ConvertType;
+
+export const string: (value?: string) => ShaderNodeObject<ConstNode<string>>;
+export const arrayBuffer: (value: ArrayBuffer) => ShaderNodeObject<ConstNode<ArrayBuffer>>;
 
 export const element: (node: NodeRepresentation, indexNode: NodeRepresentation) => ShaderNodeObject<Node>;
 export const convert: (node: NodeRepresentation, types: NodeTypeOption) => ShaderNodeObject<Node>;

--- a/types/three/examples/jsm/nodes/utils/RotateUVNode.d.ts
+++ b/types/three/examples/jsm/nodes/utils/RotateUVNode.d.ts
@@ -11,3 +11,9 @@ export default class RotateUVNode extends TempNode {
 }
 
 export const rotateUV: (uvNode: Node, rotationNode: Node, centerNode?: Node) => ShaderNodeObject<RotateUVNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        rotateUV: typeof rotateUV;
+    }
+}

--- a/types/three/examples/jsm/nodes/utils/TriplanarTexturesNode.d.ts
+++ b/types/three/examples/jsm/nodes/utils/TriplanarTexturesNode.d.ts
@@ -35,3 +35,9 @@ export const triplanarTexture: (
     texture: NodeRepresentation,
     ...params: NodeRepresentation[]
 ) => ShaderNodeObject<TriplanarTexturesNode>;
+
+declare module '../shadernode/ShaderNode.js' {
+    interface NodeElements {
+        triplanarTexture: typeof triplanarTexture;
+    }
+}


### PR DESCRIPTION
@Methuselah96 I'm sorry if these changes overlap with what you are currently working on. 😓

### What

Improve NodeElements interface.

Search the whole three.js project by `addNodeElement(` to validate these changes.

- Nodes I added to `NodeElements`:
  - `CubeTextureNode.d.ts`: `cubeTexture`
  - `TextureNode.d.ts`: `texture`
  - `FunctionCallNode.d.ts`: `call`
  - `AssignNode.d.ts`: `assign`
  - `BypassNode.d.ts`: `bypass`
  - `CacheNode.d.ts`: `cache`, `globalCache`
  - `ContextNode.d.ts`: `context`, `label`
  - `VaryingNode.d.ts`: `varying`
  - `ColorSpaceNode.d.ts`: `linearTosRGB`, `sRGBToLinear`, `linearToColorSpace`, `colorSpaceToLinear`
  - `NormalMapNode.d.ts`: `normalMap`
  - `ViewportSharedTextureNode.d.ts`: `viewportSharedTexture`
  - `ViewportTextureNode.d.ts`: `viewportTexture`, `viewportMipTexture`
  - `FogExp2Node.d.ts`: `densityFog`
  - `FogNode.d.ts`: `fog`
  - `FogRangeNode.d.ts`: `rangeFog`
  - `ComputeNode.d.ts`: `compute`
  - `LightingContextNode.d.ts`: `lightingContext`
  - `CheckerNode.d.ts`: `checker`
  - `ShaderNode.d.ts`: `color`, `float`, `int`, ..., `bmat4`, `string`, `arrayBuffer`, `element`, `convert`
  - `RotateUVNode.d.ts`: `rotateUV`
  - `TriplanarTexturesNode.d.ts`: `triplanarTexture`
- Nodes I skipped since these definition are yet to exist in this repo:
  `toAttribute`, `textureSize`, `scriptable`, `scriptableValue`, `bumpMap`, `gaussianBlur`, `viewportDepthTexture`, `hash`, `discard`, `loop`, `directionToColor`, `colorToDirection`
- defined `globalCache`, a variant of CacheNode without cache scope
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/core/CacheNode.js#L44
- defined `label`, a variant of ContextNode that sets a label
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/core/ContextNode.js#L56
- `label` on `VarNode.d.ts` is removed instead
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/core/VarNode.js
- `colorSpace` has been removed, added `linearTosRGB`, `sRGBToLinear`, `linearToColorSpace`, `colorSpaceToLinear` instead
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/display/ColorSpaceNode.js#L97-L101
- `assign` has been moved from `OperatorNode` to `AssignNode` (new in this repo)
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/math/OperatorNode.js
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/core/AssignNode.js
- Add `string` and `arrayBuffer` to `ShaderNode.d.ts`
  - See: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/shadernode/ShaderNode.js#L587-L588

