### PR TITLE
feat (Nodes): type `tslFn` and several functions that use tslFn

### DIFF
--- a/types/three/examples/jsm/nodes/display/BlendModeNode.d.ts
+++ b/types/three/examples/jsm/nodes/display/BlendModeNode.d.ts
@@ -1,14 +1,15 @@
 import TempNode from '../core/TempNode.js';
 import Node from '../core/Node.js';
 import { NodeRepresentation, ShaderNode, ShaderNodeObject } from '../shadernode/ShaderNode.js';
+import { JoinNode } from '../Nodes.js';
 
-export const BurnNode: ShaderNode<{ base: Node; blendNode: Node }>;
+export const BurnNode: (args: { base: Node; blend: Node }) => ShaderNodeObject<JoinNode>;
 
-export const DodgeNode: ShaderNode<{ base: Node; blendNode: Node }>;
+export const DodgeNode: (args: { base: Node; blend: Node }) => ShaderNodeObject<JoinNode>;
 
-export const ScreenNode: ShaderNode<{ base: Node; blendNode: Node }>;
+export const ScreenNode: (args: { base: Node; blend: Node }) => ShaderNodeObject<JoinNode>;
 
-export const OverlayNode: ShaderNode<{ base: Node; blendNode: Node }>;
+export const OverlayNode: (args: { base: Node; blend: Node }) => ShaderNodeObject<JoinNode>;
 
 export type BlendMode =
     | typeof BlendModeNode.BURN

--- a/types/three/examples/jsm/nodes/functions/BSDF/BRDF_GGX.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/BRDF_GGX.d.ts
@@ -1,6 +1,13 @@
-import { ShaderNode } from '../../shadernode/ShaderNode.js';
+import { ShaderNodeObject } from '../../shadernode/ShaderNode.js';
 import Node from '../../core/Node.js';
+import OperatorNode from '../../math/OperatorNode.js';
 
-declare const BRDF_GGX: ShaderNode<{ lightDirection: Node; f0: Node; f90: Node; roughness: Node }>;
+declare const BRDF_GGX: (args: {
+  lightDirection: Node;
+  f0: Node;
+  f90: Node;
+  roughness: Node;
+  iridescenceFresnel?: Node;
+}) => ShaderNodeObject<OperatorNode>;
 
 export default BRDF_GGX;

--- a/types/three/examples/jsm/nodes/functions/BSDF/BRDF_GGX.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/BRDF_GGX.d.ts
@@ -3,11 +3,11 @@ import Node from '../../core/Node.js';
 import OperatorNode from '../../math/OperatorNode.js';
 
 declare const BRDF_GGX: (args: {
-  lightDirection: Node;
-  f0: Node;
-  f90: Node;
-  roughness: Node;
-  iridescenceFresnel?: Node;
+    lightDirection: Node;
+    f0: Node;
+    f90: Node;
+    roughness: Node;
+    iridescenceFresnel?: Node;
 }) => ShaderNodeObject<OperatorNode>;
 
 export default BRDF_GGX;

--- a/types/three/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.d.ts
@@ -2,8 +2,6 @@ import { ShaderNodeObject } from '../../shadernode/ShaderNode.js';
 import Node from '../../core/Node.js';
 import OperatorNode from '../../math/OperatorNode.js';
 
-declare const BRDF_Sheen: (args: {
-  lightDirection: Node;
-}) => ShaderNodeObject<OperatorNode>;
+declare const BRDF_Sheen: (args: { lightDirection: Node }) => ShaderNodeObject<OperatorNode>;
 
 export default BRDF_Sheen;

--- a/types/three/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.d.ts
@@ -2,6 +2,8 @@ import { ShaderNodeObject } from '../../shadernode/ShaderNode.js';
 import Node from '../../core/Node.js';
 import OperatorNode from '../../math/OperatorNode.js';
 
-declare const BRDF_Lambert: (args: { diffuseColor: Node }) => ShaderNodeObject<OperatorNode>;
+declare const BRDF_Sheen: (args: {
+  lightDirection: Node;
+}) => ShaderNodeObject<OperatorNode>;
 
-export default BRDF_Lambert;
+export default BRDF_Sheen;

--- a/types/three/examples/jsm/nodes/functions/BSDF/DFGApprox.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/DFGApprox.d.ts
@@ -6,6 +6,6 @@ import OperatorNode from '../../math/OperatorNode.js';
 // split-sum approximation used in indirect specular lighting.
 // via 'environmentBRDF' from "Physically Based Shading on Mobile"
 // https://www.unrealengine.com/blog/physically-based-shading-on-mobile
-declare const DFGApprox: (args: { roughness: Node, dotNV: Node }) => ShaderNodeObject<OperatorNode>;
+declare const DFGApprox: (args: { roughness: Node; dotNV: Node }) => ShaderNodeObject<OperatorNode>;
 
 export default DFGApprox;

--- a/types/three/examples/jsm/nodes/functions/BSDF/DFGApprox.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/DFGApprox.d.ts
@@ -1,10 +1,11 @@
-import { ShaderNode } from '../../shadernode/ShaderNode.js';
+import { ShaderNodeObject } from '../../shadernode/ShaderNode.js';
 import Node from '../../core/Node.js';
+import OperatorNode from '../../math/OperatorNode.js';
 
 // Analytical approximation of the DFG LUT, one half of the
 // split-sum approximation used in indirect specular lighting.
 // via 'environmentBRDF' from "Physically Based Shading on Mobile"
 // https://www.unrealengine.com/blog/physically-based-shading-on-mobile
-declare const DFGApprox: ShaderNode<{ roughness: Node }>;
+declare const DFGApprox: (args: { roughness: Node, dotNV: Node }) => ShaderNodeObject<OperatorNode>;
 
 export default DFGApprox;

--- a/types/three/examples/jsm/nodes/functions/BSDF/D_GGX.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/D_GGX.d.ts
@@ -5,6 +5,6 @@ import OperatorNode from '../../math/OperatorNode.js';
 // Microfacet Models for Refraction through Rough Surfaces - equation (33)
 // http://graphicrants.blogspot.com/2013/08/specular-brdf-reference.html
 // alpha is "roughness squared" in Disney’s reparameterization
-declare const D_GGX: (args: { alpha: Node, dotNH: Node }) => ShaderNodeObject<OperatorNode>;
+declare const D_GGX: (args: { alpha: Node; dotNH: Node }) => ShaderNodeObject<OperatorNode>;
 
 export default D_GGX;

--- a/types/three/examples/jsm/nodes/functions/BSDF/D_GGX.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/D_GGX.d.ts
@@ -1,9 +1,10 @@
-import { ShaderNode } from '../../shadernode/ShaderNode.js';
+import { ShaderNodeObject } from '../../shadernode/ShaderNode.js';
 import Node from '../../core/Node.js';
+import OperatorNode from '../../math/OperatorNode.js';
 
 // Microfacet Models for Refraction through Rough Surfaces - equation (33)
 // http://graphicrants.blogspot.com/2013/08/specular-brdf-reference.html
 // alpha is "roughness squared" in Disney’s reparameterization
-declare const D_GGX: ShaderNode<{ alpha: Node; dotNH: Node }>;
+declare const D_GGX: (args: { alpha: Node, dotNH: Node }) => ShaderNodeObject<OperatorNode>;
 
 export default D_GGX;

--- a/types/three/examples/jsm/nodes/functions/BSDF/F_Schlick.d.ts
+++ b/types/three/examples/jsm/nodes/functions/BSDF/F_Schlick.d.ts
@@ -1,6 +1,7 @@
-import { ShaderNode } from '../../shadernode/ShaderNode.js';
+import { ShaderNodeObject } from '../../shadernode/ShaderNode.js';
 import Node from '../../core/Node.js';
+import OperatorNode from '../../math/OperatorNode.js';
 
-declare const F_Schlick: ShaderNode<{ f0: Node; f90: Node; dotVH: Node }>;
+declare const F_Schlick: (args: { f0: Node; f90: Node; dotVH: Node }) => ShaderNodeObject<OperatorNode>;
 
 export default F_Schlick;

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -164,10 +164,8 @@ export function nodeImmutable<T>(
 ): ShaderNodeObject<ConstructedNode<T>>;
 
 export function tslFn<T, R extends Node = ShaderNodeObject<Node>>(
-    jsFunc: (args: T) => R
-): T extends AnyObject
-    ? (args: T) => R
-    : () => R;
+    jsFunc: (args: T) => R,
+): T extends AnyObject ? (args: T) => R : () => R;
 
 export function append(node: Node): Node;
 

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -1,5 +1,5 @@
 import Node from '../core/Node.js';
-import { NodeTypeOption, SwizzleOption } from '../core/constants.js';
+import { AnyObject, NodeTypeOption, SwizzleOption } from '../core/constants.js';
 import ConstNode from '../core/ConstNode.js';
 import NodeBuilder from '../core/NodeBuilder.js';
 
@@ -162,6 +162,12 @@ export function nodeImmutable<T>(
     nodeClass: T,
     ...params: ProxiedTuple<GetConstructors<T>>
 ): ShaderNodeObject<ConstructedNode<T>>;
+
+export function tslFn<T, R extends Node = ShaderNodeObject<Node>>(
+    jsFunc: (args: T) => R
+): T extends AnyObject
+    ? (args: T) => R
+    : () => R;
 
 export function append(node: Node): Node;
 

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -163,9 +163,7 @@ export function nodeImmutable<T>(
     ...params: ProxiedTuple<GetConstructors<T>>
 ): ShaderNodeObject<ConstructedNode<T>>;
 
-export function tslFn<R extends Node = ShaderNodeObject<Node>>(
-    jsFunc: () => R,
-): () => R;
+export function tslFn<R extends Node = ShaderNodeObject<Node>>(jsFunc: () => R): () => R;
 export function tslFn<T extends AnyObject, R extends Node = ShaderNodeObject<Node>>(
     jsFunc: (args: T) => R,
 ): (args: T) => R;

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -163,9 +163,12 @@ export function nodeImmutable<T>(
     ...params: ProxiedTuple<GetConstructors<T>>
 ): ShaderNodeObject<ConstructedNode<T>>;
 
-export function tslFn<T, R extends Node = ShaderNodeObject<Node>>(
+export function tslFn<R extends Node = ShaderNodeObject<Node>>(
+    jsFunc: () => R,
+): () => R;
+export function tslFn<T extends AnyObject, R extends Node = ShaderNodeObject<Node>>(
     jsFunc: (args: T) => R,
-): T extends AnyObject ? (args: T) => R : () => R;
+): (args: T) => R;
 
 export function append(node: Node): Node;
 

--- a/types/three/test/unit/examples/jsm/nodes/ShaderNode/ShaderNode.ts
+++ b/types/three/test/unit/examples/jsm/nodes/ShaderNode/ShaderNode.ts
@@ -17,7 +17,7 @@ import {
     ConstNode,
 } from 'three/examples/jsm/nodes/Nodes';
 
-import { color, Swizzable } from 'three/examples/jsm/nodes/shadernode/ShaderNode';
+import { color, ShaderNodeObject, Swizzable, tslFn, vec3 } from 'three/examples/jsm/nodes/shadernode/ShaderNode';
 
 // just to type check
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics
@@ -67,3 +67,9 @@ const shader = new ShaderNode<{ a: Node; b: Node }>(params => {
     return params.a;
 });
 assertSwizzable<Node>(shader.call({ a: s, b: new ConstNode(1) }));
+
+const fnWithoutArgs = tslFn(() => vec3(1, 2, 3));
+assertSwizzable<Node>(fnWithoutArgs());
+
+const fnWithArgs = tslFn(({ a, b }: { a: ShaderNodeObject<Node>; b: ShaderNodeObject<Node> }) => a.add(b));
+assertSwizzable<Node>(fnWithArgs({ a: color(0, 0.5, 0), b: color(1, 0.5, 0) }));


### PR DESCRIPTION
### What

Type `tslFn` and several functions that use tslFn.

Not exhaustive.
Have very low confidence whether the typing direction is correct.

- `tslFn`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/shadernode/ShaderNode.js#L485-L520
- `BlendModeNode.js`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/display/BlendModeNode.js
- `BRDF_GGX`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/functions/BSDF/BRDF_GGX.js
- `BRDF_Lambert`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/functions/BSDF/BRDF_Lambert.js
- `BRDF_Sheen`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/functions/BSDF/BRDF_Sheen.js
- `D_GGX`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/functions/BSDF/D_GGX.js
- `DFGApprox`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/functions/BSDF/DFGApprox.js
- `F_Schlick`: https://github.com/mrdoob/three.js/blob/r160/examples/jsm/nodes/functions/BSDF/F_Schlick.js
