### PR TITLE
Fixed wrong type in SSAOPass constructor

### DIFF
--- a/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/SSAOPass.d.ts
@@ -27,7 +27,7 @@ export class SSAOPass extends Pass {
     scene: Scene;
     camera: Camera;
     width: number;
-    height: boolean;
+    height: number;
     clear: boolean;
     kernelRadius: number;
     kernel: Vector3[];


### PR DESCRIPTION
Type for member 'height' is different than type defined in the constructor. 