### PR TITLE
WebGPURenderer: support mat2() and extend RotateNode to support vec2

### DIFF
--- a/types/three/examples/jsm/nodes/core/constants.d.ts
+++ b/types/three/examples/jsm/nodes/core/constants.d.ts
@@ -17,6 +17,7 @@ export enum NodeType {
     VECTOR2 = 'vec2',
     VECTOR3 = 'vec3',
     VECTOR4 = 'vec4',
+    MATRIX2 = 'mat2',
     MATRIX3 = 'mat3',
     MATRIX4 = 'mat4',
 }
@@ -28,6 +29,7 @@ export type NodeTypeOption =
     | 'vec2'
     | 'vec3'
     | 'vec4'
+    | 'mat2'
     | 'mat3'
     | 'mat4'
     | 'code' /* CodeNode */

--- a/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
+++ b/types/three/examples/jsm/nodes/shadernode/ShaderNode.d.ts
@@ -23,6 +23,10 @@ export interface NodeElements {
     ivec4: typeof ivec4;
     uvec4: typeof uvec4;
     bvec4: typeof bvec4;
+    mat2: typeof mat2;
+    imat2: typeof imat2;
+    umat2: typeof umat2;
+    bmat2: typeof bmat2;
     mat3: typeof mat3;
     imat3: typeof imat3;
     umat3: typeof umat3;
@@ -222,6 +226,11 @@ export const vec4: ConvertType;
 export const ivec4: ConvertType;
 export const uvec4: ConvertType;
 export const bvec4: ConvertType;
+
+export const mat2: ConvertType;
+export const imat2: ConvertType;
+export const umat2: ConvertType;
+export const bmat2: ConvertType;
 
 export const mat3: ConvertType;
 export const imat3: ConvertType;


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/27612