### PR TITLE
Fix PerspectiveCamera.getViewSize()

### DIFF
--- a/types/three/src/cameras/PerspectiveCamera.d.ts
+++ b/types/three/src/cameras/PerspectiveCamera.d.ts
@@ -159,7 +159,7 @@ export class PerspectiveCamera extends Camera {
      * Computes the width and height of the camera's viewable rectangle at a given distance along the viewing direction.
      * Copies the result into the target Vector2, where x is width and y is height.
      */
-    getViewSize(distance: number, minTarget: Vector2, maxTarget: Vector2): void;
+    getViewSize(distance: number, target: Vector2): Vector2;
 
     /**
      * Sets an offset in a larger frustum.


### PR DESCRIPTION
Fixes a copy-paste error where `getViewSize()` was copy-pasted from `getViewBounds()`.

Fixes https://github.com/three-types/three-ts-types/pull/777#discussion_r1474245960.