### PR TITLE
Remove namespaces

### DIFF
--- a/types/three/build/three.d.cts
+++ b/types/three/build/three.d.cts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/build/three.module.d.ts
+++ b/types/three/build/three.module.d.ts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/build/three.module.min.d.ts
+++ b/types/three/build/three.module.min.d.ts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/examples/jsm/loaders/USDZLoader.d.ts
+++ b/types/three/examples/jsm/loaders/USDZLoader.d.ts
@@ -1,4 +1,4 @@
-import { Loader, LoadingManager, Mesh } from "three";
+import { Group, Loader, LoadingManager, Mesh } from "three";
 
 export class USDAParser {
     parse(text: string): object;
@@ -7,5 +7,5 @@ export class USDAParser {
 export class USDZLoader extends Loader<Mesh> {
     constructor(manager?: LoadingManager);
 
-    parse(buffer: ArrayBuffer | string): THREE.Group;
+    parse(buffer: ArrayBuffer | string): Group;
 }

--- a/types/three/examples/jsm/webxr/XRPlanes.d.ts
+++ b/types/three/examples/jsm/webxr/XRPlanes.d.ts
@@ -1,5 +1,5 @@
-import { Object3D } from "three";
+import { Object3D, WebGLRenderer } from "three";
 
 export class XRPlanes extends Object3D {
-    constructor(renderer: THREE.WebGLRenderer);
+    constructor(renderer: WebGLRenderer);
 }

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -4,5 +4,3 @@
 // and released in the @types/three npm package.
 
 export * from "./src/Three";
-
-export as namespace THREE;


### PR DESCRIPTION
three.js no longer has a UMD build, so exporting as a namespace is no longer applicable.