### PR TITLE
Timer: add timestamp param and FixedTimer

### DIFF
--- a/types/three/examples/jsm/misc/Timer.d.ts
+++ b/types/three/examples/jsm/misc/Timer.d.ts
@@ -41,8 +41,6 @@ export class Timer {
 
     /**
      * Sets a time scale that scales the time delta in {@link .update()}.
-     *
-     * @param timescale
      */
     setTimescale(timescale: number): this;
 
@@ -72,7 +70,7 @@ export class FixedTimer extends Timer {
     /**
      * @param fps The desired fixed delta expressed in frames per second.
      */
-    constructor(fps: number);
+    constructor(fps?: number);
 
     /**
      * Updates the internal state of the timer. This method should be called once per simulation step and before you

--- a/types/three/examples/jsm/misc/Timer.d.ts
+++ b/types/three/examples/jsm/misc/Timer.d.ts
@@ -10,7 +10,7 @@
  * @example
  * const timer = new Timer();
  *
- * function animate() {
+ * function animate(timestamp) {
  *   requestAnimationFrame(animate);
  *   // timestamp is optional
  *   timer.update(timestamp);

--- a/types/three/examples/jsm/misc/Timer.d.ts
+++ b/types/three/examples/jsm/misc/Timer.d.ts
@@ -6,14 +6,14 @@
  *   {@link .getDelta()} and {@link .getElapsed()} multiple times per simulation step without getting different values.
  * - The class uses the Page Visibility API to avoid large time delta values when the app is inactive (e.g. tab switched
  *   or browser hidden).
- * - It's possible to configure a fixed time delta and a time scale value (similar to Unity's Time interface).
  *
  * @example
  * const timer = new Timer();
  *
  * function animate() {
  *   requestAnimationFrame(animate);
- *   timer.update();
+ *   // timestamp is optional
+ *   timer.update(timestamp);
  *   const delta = timer.getDelta();
  *   // do something with delta
  *   renderer.render(scene, camera);
@@ -23,21 +23,6 @@
  */
 export class Timer {
     constructor();
-
-    /**
-     * Disables the usage of a fixed delta time.
-     */
-    disableFixedDelta(): this;
-
-    /**
-     * Can be used to free all internal resources. Usually called when the timer instance isn't required anymore.
-     */
-    dispose(): this;
-
-    /**
-     * Enables the usage of a fixed delta time.
-     */
-    enableFixedDelta(): this;
 
     /**
      * Returns the time delta in seconds.
@@ -50,11 +35,16 @@ export class Timer {
     getElapsed(): number;
 
     /**
-     * Returns the fixed time delta that has been previously configured via {@link .setFixedDelta()}.
+     * Returns the time scale.
      */
-    getFixedDelta(): number;
-
     getTimescale(): number;
+
+    /**
+     * Sets a time scale that scales the time delta in {@link .update()}.
+     *
+     * @param timescale
+     */
+    setTimescale(timescale: number): this;
 
     /**
      * Resets the time computation for the current simulation step.
@@ -62,19 +52,31 @@ export class Timer {
     reset(): this;
 
     /**
-     * Defines a fixed time delta value which is used to update the timer per simulation step.
+     * Can be used to free all internal resources. Usually called when the timer instance isn't required anymore.
      */
-    setFixedDelta(fixedDelta: number): this;
-
-    /**
-     * Sets a time scale that scales the time delta in {@link .update()}.
-     * @param timescale
-     */
-    setTimescale(timescale: number): this;
+    dispose(): this;
 
     /**
      * Updates the internal state of the timer. This method should be called once per simulation step and before you
-     * perform queries against the timer (e.g. via {@link .getDelta()}).
+     * perform queries against the timer (e.g. via {@link getDelta()}).
+     *
+     * @param timescale (optional) The current time in milliseconds. Can be obtained from the {@link https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame | requestAnimationFrame} callback argument. If not provided, the current time will be determined with {@link https://developer.mozilla.org/en-US/docs/Web/API/Performance/now | performance.now}.
      */
-    update(): this;
+    update(timestamp?: number): this;
+}
+
+/**
+ * A timer that uses a fixed delta.
+ */
+export class FixedTimer extends Timer {
+    /**
+     * @param fps The desired fixed delta expressed in frames per second.
+     */
+    constructor(fps: number);
+
+    /**
+     * Updates the internal state of the timer. This method should be called once per simulation step and before you
+     * perform queries against the timer (e.g. via {@link getDelta()}).
+     */
+    override update(): this;
 }


### PR DESCRIPTION
This PR adds the optional `timestamp` parameter to the `update` method (https://github.com/mrdoob/three.js/pull/27421). The fixed delta logic has also been moved into a separate `FixedTimer` class (https://github.com/mrdoob/three.js/pull/27423).