### PR TITLE
Add onBeforeCompile to MaterialParameters

### DIFF
--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -37,6 +37,7 @@ export interface MaterialParameters {
     depthTest?: boolean | undefined;
     depthWrite?: boolean | undefined;
     name?: string | undefined;
+    onBeforeCompile?: (parameters: WebGLProgramParametersWithUniforms, renderer: WebGLRenderer) => void;
     opacity?: number | undefined;
     polygonOffset?: boolean | undefined;
     polygonOffsetFactor?: number | undefined;


### PR DESCRIPTION
This PR includes the `onBeforeCompile` callback type to `MaterialParameters`.

Currently the type is valid if you create a material and call `onBeforeCompile` on it afterwards, but it can also be provided during creation (for which now the property type is unknown).

```
Object literal may only specify known properties, and 'onBeforeCompile' does not exist in type 'MeshDepthMaterialParameters'.
```
