### PR TITLE
[@type/three] Fixed import extension.

### DIFF
--- a/types/three/examples/jsm/renderers/common/Color4.d.ts
+++ b/types/three/examples/jsm/renderers/common/Color4.d.ts
@@ -1,4 +1,4 @@
-import { Color, ColorRepresentation } from "../../../../src/math/Color.ts";
+import { Color, ColorRepresentation } from "../../../../src/math/Color.js";
 
 export default class Color4 extends Color {
     constructor(r: number, g: number, b: number, a?: number);


### PR DESCRIPTION
Exception on import: An import path cannot end with a '.ts' extension. Consider importing `../../src/math/color.js instead.