### PR TITLE
Remove ambient namespace THREE

### DIFF
--- a/types/three/build/three.d.cts
+++ b/types/three/build/three.d.cts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/build/three.module.d.ts
+++ b/types/three/build/three.module.d.ts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/build/three.module.min.d.ts
+++ b/types/three/build/three.module.min.d.ts
@@ -1,2 +1,1 @@
 export * from "../src/Three.js";
-export as namespace THREE;

--- a/types/three/examples/jsm/loaders/USDZLoader.d.ts
+++ b/types/three/examples/jsm/loaders/USDZLoader.d.ts
@@ -1,4 +1,4 @@
-import { Loader, LoadingManager, Mesh } from "three";
+import { Group, Loader, LoadingManager, Mesh } from "three";
 
 export class USDAParser {
     parse(text: string): object;
@@ -7,5 +7,5 @@ export class USDAParser {
 export class USDZLoader extends Loader<Mesh> {
     constructor(manager?: LoadingManager);
 
-    parse(buffer: ArrayBuffer | string): THREE.Group;
+    parse(buffer: ArrayBuffer | string): Group;
 }

--- a/types/three/examples/jsm/renderers/common/Renderer.d.ts
+++ b/types/three/examples/jsm/renderers/common/Renderer.d.ts
@@ -11,6 +11,7 @@ import {
     Plane,
     RenderTarget,
     Scene,
+    ShadowMapType,
     ToneMapping,
     Vector2,
     Vector4,
@@ -97,7 +98,7 @@ export default class Renderer {
 
     info: Info;
 
-    shadowMap: { enabled: boolean; type: THREE.ShadowMapType };
+    shadowMap: { enabled: boolean; type: ShadowMapType };
 
     xr: { enabled: boolean };
 

--- a/types/three/examples/jsm/webxr/XRPlanes.d.ts
+++ b/types/three/examples/jsm/webxr/XRPlanes.d.ts
@@ -1,5 +1,5 @@
-import { Object3D } from "three";
+import { Object3D, WebGLRenderer } from "three";
 
 export class XRPlanes extends Object3D {
-    constructor(renderer: THREE.WebGLRenderer);
+    constructor(renderer: WebGLRenderer);
 }

--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -4,5 +4,3 @@
 // and released in the @types/three npm package.
 
 export * from "./src/Three";
-
-export as namespace THREE;


### PR DESCRIPTION
three.js no longer has a UMD build, so exporting as an ambient namespace is no longer applicable.

Second attempt at https://github.com/three-types/three-ts-types/pull/805, which was reverted in https://github.com/three-types/three-ts-types/pull/813. The CI should work now that https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68668 is merged.