### PR TITLE
Use "module": "node16"

### DIFF
--- a/types/three/index.d.ts
+++ b/types/three/index.d.ts
@@ -3,4 +3,4 @@
 // Periodically, the updates from the repository are pushed to DefinitelyTyped
 // and released in the @types/three npm package.
 
-export * from "./src/Three";
+export * from "./src/Three.js";

--- a/types/three/test/integration/lights-pointlights2.ts
+++ b/types/three/test/integration/lights-pointlights2.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { TrackballControls } from "three/examples/jsm/controls/TrackballControls";
+import { TrackballControls } from "three/addons/controls/TrackballControls.js";
 
 const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 1, 300);
 const scene = new THREE.Scene();

--- a/types/three/test/integration/loaders-gltfloader-plugin.ts
+++ b/types/three/test/integration/loaders-gltfloader-plugin.ts
@@ -1,7 +1,7 @@
 // An example that uses plugin system in GLTFLoader.
 
 import * as THREE from "three";
-import { GLTF, GLTFLoader, GLTFLoaderPlugin, GLTFParser } from "three/examples/jsm/loaders/GLTFLoader";
+import { GLTF, GLTFLoader, GLTFLoaderPlugin, GLTFParser } from "three/addons/loaders/GLTFLoader.js";
 
 // Assuming we are using duck.gltf
 // https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/Duck/glTF-Binary/Duck.glb

--- a/types/three/test/integration/materials-meshgouraud.ts
+++ b/types/three/test/integration/materials-meshgouraud.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { MeshGouraudMaterial } from "three/examples/jsm/materials/MeshGouraudMaterial";
+import { MeshGouraudMaterial } from "three/addons/materials/MeshGouraudMaterial.js";
 
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);

--- a/types/three/test/integration/nodes-webgl.ts
+++ b/types/three/test/integration/nodes-webgl.ts
@@ -2,13 +2,13 @@
  * Tests some webgl imports, and everything else that is not imported elsewhere.
  */
 
-import StorageBufferNode from "three/examples/jsm/nodes/accessors/StorageBufferNode";
-import * as NodeUtils from "three/examples/jsm/nodes/core/NodeUtils";
-import * as Nodes from "three/examples/jsm/nodes/Nodes";
-import SlotNode from "three/examples/jsm/renderers/webgl/nodes/SlotNode";
-import { WebGLNodeBuilder } from "three/examples/jsm/renderers/webgl/nodes/WebGLNodeBuilder";
-import { nodeFrame } from "three/examples/jsm/renderers/webgl/nodes/WebGLNodes";
-import { HemisphereLight, Object3D, PointLight, WebGLRenderer } from "three/src/Three";
+import { HemisphereLight, Object3D, PointLight, WebGLRenderer } from "three";
+import StorageBufferNode from "three/addons/nodes/accessors/StorageBufferNode.js";
+import * as NodeUtils from "three/addons/nodes/core/NodeUtils.js";
+import * as Nodes from "three/addons/nodes/Nodes.js";
+import SlotNode from "three/addons/renderers/webgl/nodes/SlotNode.js";
+import { WebGLNodeBuilder } from "three/addons/renderers/webgl/nodes/WebGLNodeBuilder.js";
+import { nodeFrame } from "three/addons/renderers/webgl/nodes/WebGLNodes.js";
 
 nodeFrame.update();
 new WebGLNodeBuilder(new Object3D(), new WebGLRenderer(), { uniforms: [], vertexShader: [], fragmentShader: [] });

--- a/types/three/test/integration/objects-reflector.ts
+++ b/types/three/test/integration/objects-reflector.ts
@@ -8,7 +8,7 @@ import {
     SphereGeometry,
     WebGLRenderer,
 } from "three";
-import { Reflector } from "three/examples/jsm/objects/Reflector";
+import { Reflector } from "three/addons/objects/Reflector.js";
 
 const renderer = new WebGLRenderer();
 

--- a/types/three/test/integration/three-examples/webgl2_rendertarget_texture2darray.ts
+++ b/types/three/test/integration/three-examples/webgl2_rendertarget_texture2darray.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 
-import WEBGL from "three/examples/jsm/capabilities/WebGL";
-import { unzipSync } from "three/examples/jsm/libs/fflate.module";
+import WEBGL from "three/addons/capabilities/WebGL.js";
+import { unzipSync } from "three/addons/libs/fflate.module.js";
 
 const vertextPostProcessingShader = /* glsl */ `
 	out vec2 vUv;

--- a/types/three/test/integration/three-examples/webgl_camera_cinematic.ts
+++ b/types/three/test/integration/three-examples/webgl_camera_cinematic.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
 
-import { CinematicCamera } from "three/examples/jsm/cameras/CinematicCamera";
-import { BokehShaderUniforms } from "three/examples/jsm/shaders/BokehShader2";
+import { CinematicCamera } from "three/addons/cameras/CinematicCamera.js";
+import { BokehShaderUniforms } from "three/addons/shaders/BokehShader2.js";
 
 const camera = new CinematicCamera(60, window.innerWidth / window.innerHeight, 1, 1000);
 const scene = new THREE.Scene();

--- a/types/three/test/integration/three-examples/webgl_loader_ldraw.ts
+++ b/types/three/test/integration/three-examples/webgl_loader_ldraw.ts
@@ -1,10 +1,9 @@
 import * as THREE from "three";
 
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
-import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { RoomEnvironment } from "three/addons/environments/RoomEnvironment.js";
 
-import { LDrawLoader } from "three/examples/jsm/loaders/LDrawLoader";
-import { LDrawUtils } from "three/examples/jsm/utils/LDrawUtils";
+import { LDrawLoader } from "three/addons/loaders/LDrawLoader.js";
 
 let container: HTMLDivElement;
 let progressBarDiv: HTMLDivElement;

--- a/types/three/test/integration/three-examples/webgl_loader_mmd.ts
+++ b/types/three/test/integration/three-examples/webgl_loader_mmd.ts
@@ -1,11 +1,11 @@
 import * as THREE from "three";
 
-import { CCDIKHelper } from "three/examples/jsm/animation/CCDIKSolver";
-import { MMDAnimationHelper } from "three/examples/jsm/animation/MMDAnimationHelper";
-import { MMDPhysicsHelper } from "three/examples/jsm/animation/MMDPhysics";
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
-import { OutlineEffect } from "three/examples/jsm/effects/OutlineEffect";
-import { MMDLoader } from "three/examples/jsm/loaders/MMDLoader";
+import { CCDIKHelper } from "three/addons/animation/CCDIKSolver.js";
+import { MMDAnimationHelper } from "three/addons/animation/MMDAnimationHelper.js";
+import { MMDPhysicsHelper } from "three/addons/animation/MMDPhysics.js";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { OutlineEffect } from "three/addons/effects/OutlineEffect.js";
+import { MMDLoader } from "three/addons/loaders/MMDLoader.js";
 
 let mesh: THREE.SkinnedMesh;
 let camera: THREE.PerspectiveCamera;

--- a/types/three/test/integration/three-examples/webgl_materials_channels.ts
+++ b/types/three/test/integration/three-examples/webgl_materials_channels.ts
@@ -1,8 +1,8 @@
 import * as THREE from "three";
 
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
-import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader";
-import { VelocityShader } from "three/examples/jsm/shaders/VelocityShader";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { OBJLoader } from "three/addons/loaders/OBJLoader.js";
+import { VelocityShader } from "three/addons/shaders/VelocityShader.js";
 
 let camera: THREE.PerspectiveCamera | THREE.OrthographicCamera;
 let scene: THREE.Scene;

--- a/types/three/test/integration/three-examples/webxr_vr_handinput_cubes.ts
+++ b/types/three/test/integration/three-examples/webxr_vr_handinput_cubes.ts
@@ -1,9 +1,9 @@
 import * as THREE from "three";
 
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
-import { VRButton } from "three/examples/jsm/webxr/VRButton";
-import { XRControllerModelFactory } from "three/examples/jsm/webxr/XRControllerModelFactory";
-import { XRHandModelFactory } from "three/examples/jsm/webxr/XRHandModelFactory";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+import { VRButton } from "three/addons/webxr/VRButton.js";
+import { XRControllerModelFactory } from "three/addons/webxr/XRControllerModelFactory.js";
+import { XRHandModelFactory } from "three/addons/webxr/XRHandModelFactory.js";
 
 interface Hand extends THREE.Group {
     joints: { [key: string]: any };

--- a/types/three/test/integration/webxr-cube.ts
+++ b/types/three/test/integration/webxr-cube.ts
@@ -1,7 +1,6 @@
 // A simple WebXR VR example that just shows a cube.
 
 import * as THREE from "three";
-import { XRButton } from "three/examples/jsm/webxr/XRButton";
 
 const container = document.createElement("div");
 

--- a/types/three/test/unit/examples/jsm/exporters/PLYExporter.ts
+++ b/types/three/test/unit/examples/jsm/exporters/PLYExporter.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { PLYExporter } from "three/examples/jsm/exporters/PLYExporter";
+import { PLYExporter } from "three/addons/exporters/PLYExporter.js";
 
 const exporter = new PLYExporter();
 declare const mesh: THREE.Mesh;

--- a/types/three/test/unit/examples/jsm/exporters/STLExporter.ts
+++ b/types/three/test/unit/examples/jsm/exporters/STLExporter.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { STLExporter } from "three/examples/jsm/exporters/STLExporter";
+import { STLExporter } from "three/addons/exporters/STLExporter.js";
 
 const exporter = new STLExporter();
 declare const mesh: THREE.Mesh;

--- a/types/three/test/unit/examples/jsm/helpers/ViewHelper.ts
+++ b/types/three/test/unit/examples/jsm/helpers/ViewHelper.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { ViewHelper } from "three/examples/jsm/helpers/ViewHelper";
+import { ViewHelper } from "three/addons/helpers/ViewHelper.js";
 
 const camera = new THREE.PerspectiveCamera();
 const viewHelper = new ViewHelper(camera, document.body); // $ExpectType ViewHelper

--- a/types/three/test/unit/examples/jsm/libs/lil-gui.ts
+++ b/types/three/test/unit/examples/jsm/libs/lil-gui.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { GUI } from "three/examples/jsm/libs/lil-gui.module.min";
+import { GUI } from "three/addons/libs/lil-gui.module.min.js";
 
 const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 200);
 

--- a/types/three/test/unit/examples/jsm/libs/tween.ts
+++ b/types/three/test/unit/examples/jsm/libs/tween.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
-import TWEEN from "three/examples/jsm/libs/tween.module";
-import { CSS3DObject, CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRenderer";
+import TWEEN from "three/addons/libs/tween.module.js";
+import { CSS3DObject, CSS3DRenderer } from "three/addons/renderers/CSS3DRenderer.js";
 
 declare const camera: THREE.PerspectiveCamera;
 declare const scene: THREE.Scene;

--- a/types/three/test/unit/examples/jsm/lines/LineMaterial.ts
+++ b/types/three/test/unit/examples/jsm/lines/LineMaterial.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 
-import { LineMaterial } from "three/examples/jsm/lines/LineMaterial";
+import { LineMaterial } from "three/addons/lines/LineMaterial.js";
 
 const color1 = new LineMaterial({
     color: new THREE.Color("blue"),

--- a/types/three/test/unit/examples/jsm/nodes/ShaderNode/ShaderNode.ts
+++ b/types/three/test/unit/examples/jsm/nodes/ShaderNode/ShaderNode.ts
@@ -15,9 +15,9 @@ import {
     PropertyNode,
     RotateUVNode,
     ShaderNode,
-} from "three/examples/jsm/nodes/Nodes";
+} from "three/addons/nodes/Nodes.js";
 
-import { color, ShaderNodeObject, Swizzable, tslFn, vec3 } from "three/examples/jsm/nodes/shadernode/ShaderNode";
+import { color, ShaderNodeObject, Swizzable, tslFn, vec3 } from "three/addons/nodes/shadernode/ShaderNode.js";
 
 // just to type check
 // eslint-disable-next-line @definitelytyped/no-unnecessary-generics

--- a/types/three/test/unit/examples/jsm/nodes/core/FunctionNode.ts
+++ b/types/three/test/unit/examples/jsm/nodes/core/FunctionNode.ts
@@ -2,17 +2,7 @@
  * Various tests of func, fn and call
  */
 
-import {
-    call,
-    code,
-    fn,
-    func,
-    FunctionCallNode,
-    FunctionNode,
-    Node,
-    Swizzable,
-    uv,
-} from "three/addons/nodes/Nodes.js";
+import { call, code, fn, func, FunctionCallNode, FunctionNode, Node, Swizzable, uv } from "three/addons/nodes/Nodes.js";
 
 import { ProxiedObject } from "three/addons/nodes/shadernode/ShaderNode.js";
 

--- a/types/three/test/unit/examples/jsm/nodes/core/FunctionNode.ts
+++ b/types/three/test/unit/examples/jsm/nodes/core/FunctionNode.ts
@@ -12,9 +12,9 @@ import {
     Node,
     Swizzable,
     uv,
-} from "three/examples/jsm/nodes/Nodes";
+} from "three/addons/nodes/Nodes.js";
 
-import { ProxiedObject } from "three/examples/jsm/nodes/shadernode/ShaderNode";
+import { ProxiedObject } from "three/addons/nodes/shadernode/ShaderNode.js";
 
 export const mx_noise = code("whatever");
 const includes = [mx_noise];

--- a/types/three/test/unit/examples/jsm/nodes/display/ColorAdjustmentNode.ts
+++ b/types/three/test/unit/examples/jsm/nodes/display/ColorAdjustmentNode.ts
@@ -23,7 +23,7 @@ import {
     sub,
     TempNode,
     vec3,
-} from "three/examples/jsm/nodes/Nodes";
+} from "three/addons/nodes/Nodes.js";
 
 const luminanceNode = new ShaderNode<{ color: Node }>(({ color }) => {
     const LUMA = vec3(0.2125, 0.7154, 0.0721);

--- a/types/three/test/unit/examples/jsm/nodes/materials/lib/mx_noise.ts
+++ b/types/three/test/unit/examples/jsm/nodes/materials/lib/mx_noise.ts
@@ -3,9 +3,9 @@ import {
     mx_fractal_noise_float,
     mx_perlin_noise_float,
     mx_worley_noise_float,
-} from "three/examples/jsm/nodes/materialx/lib/mx_noise";
+} from "three/addons/nodes/materialx/lib/mx_noise.js";
 
-import { mx_hsvtorgb, mx_rgbtohsv } from "three/examples/jsm/nodes/materialx/MaterialXNodes";
+import { mx_hsvtorgb, mx_rgbtohsv } from "three/addons/nodes/materialx/MaterialXNodes.js";
 
 mx_perlin_noise_float(1);
 mx_cell_noise_float(1);

--- a/types/three/test/unit/examples/jsm/postprocessing/EffectComposer.ts
+++ b/types/three/test/unit/examples/jsm/postprocessing/EffectComposer.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { EffectComposer, FullScreenQuad, Pass } from "three/examples/jsm/postprocessing/EffectComposer";
+import { EffectComposer, FullScreenQuad, Pass } from "three/addons/postprocessing/EffectComposer.js";
 
 class FooPass extends Pass {
     fsQuad: FullScreenQuad;

--- a/types/three/test/unit/examples/jsm/postprocessing/SavePass.ts
+++ b/types/three/test/unit/examples/jsm/postprocessing/SavePass.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { SavePass } from "three/examples/jsm/postprocessing/SavePass";
+import { SavePass } from "three/addons/postprocessing/SavePass.js";
 
 let pass = new SavePass(); // $ExpectType SavePass
 let rt = pass.renderTarget; // $ExpectType WebGLRenderTarget<Texture>

--- a/types/three/test/unit/examples/jsm/shaders/ACESFilmicToneMappingShader.ts
+++ b/types/three/test/unit/examples/jsm/shaders/ACESFilmicToneMappingShader.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three";
-import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer";
-import { ShaderPass } from "three/examples/jsm/postprocessing/ShaderPass";
-import { ACESFilmicToneMappingShader } from "three/examples/jsm/shaders/ACESFilmicToneMappingShader";
+import { EffectComposer } from "three/addons/postprocessing/EffectComposer.js";
+import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
+import { ACESFilmicToneMappingShader } from "three/addons/shaders/ACESFilmicToneMappingShader.js";
 
 const renderer = new THREE.WebGLRenderer();
 const composer = new EffectComposer(renderer);

--- a/types/three/test/unit/src/extras/Earcut.ts
+++ b/types/three/test/unit/src/extras/Earcut.ts
@@ -1,3 +1,3 @@
-import { Earcut } from "three/src/extras/Earcut";
+import { Earcut } from "three/src/extras/Earcut.js";
 
 const triangles = Earcut.triangulate([0, 0, 1, 0, 1, 1, 0, 1]); // $ExpectType number[]

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "node16",
         "lib": [
             "es6",
             "dom"


### PR DESCRIPTION
Apparently `three` was listed as not working with `node16` in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/68529, which seems odd since we use `node16` in our examples testing. This PR is to figure out what's going on.