### PR TITLE
Update OrbitControls.d.ts - Removing domElement optionality

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -14,7 +14,7 @@ export interface OrbitControlsEventMap {
  * event listeners.
  */
 export class OrbitControls extends EventDispatcher<OrbitControlsEventMap> {
-    constructor(object: Camera, domElement?: HTMLElement);
+    constructor(object: Camera, domElement: HTMLElement);
 
     /**
      * The camera being controlled.


### PR DESCRIPTION
domElement has not been optional since r110

[Code](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/controls/OrbitControls.js#L36)

Copying PR here at the request of @Methuselah96 [Comment here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69107#pullrequestreview-1953716906)