### PR TITLE
SelectionBox: add instance property

### DIFF
--- a/types/three/examples/jsm/interactive/SelectionBox.d.ts
+++ b/types/three/examples/jsm/interactive/SelectionBox.d.ts
@@ -8,7 +8,7 @@ export class SelectionBox {
     endPoint: Vector3;
     scene: Scene;
     startPoint: Vector3;
-    instances: {} | {[key:string]:number[]};
+    instances: Record<string, number[]>;
 
     select(startPoint?: Vector3, endPoint?: Vector3): Mesh[];
     updateFrustum(startPoint: Vector3, endPoint: Vector3): void;

--- a/types/three/examples/jsm/interactive/SelectionBox.d.ts
+++ b/types/three/examples/jsm/interactive/SelectionBox.d.ts
@@ -8,6 +8,7 @@ export class SelectionBox {
     endPoint: Vector3;
     scene: Scene;
     startPoint: Vector3;
+    instances: {} | {[key:string]:number[]};
 
     select(startPoint?: Vector3, endPoint?: Vector3): Mesh[];
     updateFrustum(startPoint: Vector3, endPoint: Vector3): void;


### PR DESCRIPTION
It looks like the SelectionBox class has an `instances` property that is missing in SelectionBox.d.ts

https://github.com/mrdoob/three.js/blob/dev/examples/jsm/interactive/SelectionBox.js

I'm relatively new to typescript so hopefully that type definition is correct!