### PR TITLE
Make o property optional on font glyphs

### DIFF
--- a/types/three/examples/jsm/loaders/FontLoader.d.ts
+++ b/types/three/examples/jsm/loaders/FontLoader.d.ts
@@ -1,7 +1,7 @@
 import { Loader, LoadingManager, Shape } from "three";
 
 export interface FontData {
-    glyphs: Record<string, { ha: number; x_min: number; x_max: number; o: string }>;
+    glyphs: Record<string, { ha: number; x_min: number; x_max: number; o?: string | undefined }>;
     familyName: string;
     ascender: number;
     descender: number;


### PR DESCRIPTION
Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69506.

The `o` property is checked to make sure it exists before usage [here](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/loaders/FontLoader.js#L121).