### PR TITLE
USDZExporter: Add ar and includeAnchoringProperties options

### DIFF
--- a/types/three/examples/jsm/exporters/USDZExporter.d.ts
+++ b/types/three/examples/jsm/exporters/USDZExporter.d.ts
@@ -1,6 +1,8 @@
 import { Object3D } from "three";
 
 export interface USDZExporterOptions {
+    ar?: { anchoring: { type: "plane" }; planeAnchoring: { alignment: "horizontal" | "vertical" | "any" } };
+    includeAnchoringProperties?: boolean;
     quickLookCompatible?: boolean;
     maxTextureSize?: number;
 }

--- a/types/three/examples/jsm/exporters/USDZExporter.d.ts
+++ b/types/three/examples/jsm/exporters/USDZExporter.d.ts
@@ -1,10 +1,10 @@
 import { Object3D } from "three";
 
 export interface USDZExporterOptions {
-    ar?: { anchoring: { type: "plane" }; planeAnchoring: { alignment: "horizontal" | "vertical" | "any" } };
-    includeAnchoringProperties?: boolean;
-    quickLookCompatible?: boolean;
-    maxTextureSize?: number;
+    ar?: { anchoring: { type: "plane" }; planeAnchoring: { alignment: "horizontal" | "vertical" | "any" } } | undefined;
+    includeAnchoringProperties?: boolean | undefined;
+    quickLookCompatible?: boolean | undefined;
+    maxTextureSize?: number | undefined;
 }
 
 export class USDZExporter {


### PR DESCRIPTION
The `includeAnchoringProperties` option is to be included in r165, see https://github.com/mrdoob/three.js/pull/28363