### PR TITLE
Add missing mode argument for TransformControls.d.ts events

### DIFF
--- a/types/three/examples/jsm/controls/TransformControls.d.ts
+++ b/types/three/examples/jsm/controls/TransformControls.d.ts
@@ -1,11 +1,11 @@
 import { Camera, Mesh, MOUSE, Object3D, Object3DEventMap, Quaternion, Raycaster, Vector3 } from "three";
 
-type TransformControlMode = "translate" | "rotate" | "scale";
+type TransformControlsMode = "translate" | "rotate" | "scale";
 
 export interface TransformControlsEventMap extends Object3DEventMap {
     change: {};
-    mouseDown: { mode: TransformControlMode };
-    mouseUp: { mode: TransformControlMode };
+    mouseDown: { mode: TransformControlsMode };
+    mouseUp: { mode: TransformControlsMode };
     objectChange: {};
     "camera-changed": { value: unknown };
     "object-changed": { value: unknown };
@@ -45,7 +45,7 @@ export class TransformControls extends Object3D<TransformControlsEventMap> {
     object: Object3D | undefined;
     enabled: boolean;
     axis: "X" | "Y" | "Z" | "E" | "XY" | "YZ" | "XZ" | "XYZ" | "XYZE" | null;
-    mode: TransformControlMode;
+    mode: TransformControlsMode;
     translationSnap: number | null;
     rotationSnap: number | null;
     space: "world" | "local";
@@ -69,9 +69,9 @@ export class TransformControls extends Object3D<TransformControlsEventMap> {
 
     attach(object: Object3D): this;
     detach(): this;
-    getMode(): TransformControlMode;
+    getMode(): TransformControlsMode;
     getRaycaster(): Raycaster;
-    setMode(mode: TransformControlMode): void;
+    setMode(mode: TransformControlsMode): void;
     setTranslationSnap(translationSnap: number | null): void;
     setRotationSnap(rotationSnap: number | null): void;
     setScaleSnap(scaleSnap: number | null): void;
@@ -110,7 +110,7 @@ export class TransformControlsPlane extends Mesh {
 
     constructor();
 
-    mode: TransformControlMode;
+    mode: TransformControlsMode;
 
     axis: "X" | "Y" | "Z" | "XY" | "YZ" | "XZ" | "XYZ" | "E";
 

--- a/types/three/examples/jsm/controls/TransformControls.d.ts
+++ b/types/three/examples/jsm/controls/TransformControls.d.ts
@@ -1,9 +1,11 @@
 import { Camera, Mesh, MOUSE, Object3D, Object3DEventMap, Quaternion, Raycaster, Vector3 } from "three";
 
+type TransformControlMode = "translate" | "rotate" | "scale";
+
 export interface TransformControlsEventMap extends Object3DEventMap {
     change: {};
-    mouseDown: {};
-    mouseUp: {};
+    mouseDown: { mode: TransformControlMode };
+    mouseUp: { mode: TransformControlMode };
     objectChange: {};
     "camera-changed": { value: unknown };
     "object-changed": { value: unknown };
@@ -43,7 +45,7 @@ export class TransformControls extends Object3D<TransformControlsEventMap> {
     object: Object3D | undefined;
     enabled: boolean;
     axis: "X" | "Y" | "Z" | "E" | "XY" | "YZ" | "XZ" | "XYZ" | "XYZE" | null;
-    mode: "translate" | "rotate" | "scale";
+    mode: TransformControlMode;
     translationSnap: number | null;
     rotationSnap: number | null;
     space: "world" | "local";
@@ -67,9 +69,9 @@ export class TransformControls extends Object3D<TransformControlsEventMap> {
 
     attach(object: Object3D): this;
     detach(): this;
-    getMode(): "translate" | "rotate" | "scale";
+    getMode(): TransformControlMode;
     getRaycaster(): Raycaster;
-    setMode(mode: "translate" | "rotate" | "scale"): void;
+    setMode(mode: TransformControlMode): void;
     setTranslationSnap(translationSnap: number | null): void;
     setRotationSnap(rotationSnap: number | null): void;
     setScaleSnap(scaleSnap: number | null): void;
@@ -108,7 +110,7 @@ export class TransformControlsPlane extends Mesh {
 
     constructor();
 
-    mode: "translate" | "scale" | "rotate";
+    mode: TransformControlMode;
 
     axis: "X" | "Y" | "Z" | "XY" | "YZ" | "XZ" | "XYZ" | "E";
 


### PR DESCRIPTION
The `TransformControls` actually returns the mode each time `mouseDown` and `mouseUp` events are triggered (same behaviour for older library versions).

See the full implementation here : https://github.com/mrdoob/three.js/blob/master/examples/jsm/controls/TransformControls.js