### PR TITLE
fix spelling of TextGeometryParameters.height jsdoc deprecated

### DIFF
--- a/types/three/examples/jsm/geometries/TextGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/TextGeometry.d.ts
@@ -16,7 +16,7 @@ export interface TextGeometryParameters extends ExtrudeGeometryOptions {
      * Thickness to extrude text.
      * Expects a `Float`.
      * @defaultValue `50`
-     * @deprecated THREE.TextGeometry: .height is now depreciated. Please use .depth instead
+     * @deprecated THREE.TextGeometry: .height is now deprecated. Please use .depth instead
      */
     height?: number | undefined;
 


### PR DESCRIPTION
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/69648