### PR TITLE
WebGPURenderer: Add types for WebGPUAttributeUtils and WebGPUBindingUtils.

### DIFF
--- a/types/three/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.d.ts
+++ b/types/three/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.d.ts
@@ -1,4 +1,4 @@
-import { BufferAttribute } from "three/src/Three.js";
+import { BufferAttribute } from "three";
 import Backend from "../../common/Backend";
 import RenderObject from "../../common/RenderObject";
 
@@ -8,7 +8,7 @@ export default class WebGPUAttributeUtiils {
     constructor(backend: Backend);
     createAttribute(attribute: BufferAttribute, usage: number);
     updateAttribute(attribute: BufferAttribute);
-    createShaderVertexBuffers(renderObject: RenderObject);
+    // createShaderVertexBuffers(renderObject: RenderObject): GPUVertexBufferLayout[];
     destroyAttribute(attribute: BufferAttribute);
-    getArrayBufferAsync(attribute: BufferAttribute);
+    getArrayBufferAsync(attribute: BufferAttribute): ArrayBuffer;
 }

--- a/types/three/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.d.ts
+++ b/types/three/examples/jsm/renderers/webgpu/utils/WebGPUAttributeUtils.d.ts
@@ -1,0 +1,14 @@
+import { BufferAttribute } from "three/src/Three.js";
+import Backend from "../../common/Backend";
+import RenderObject from "../../common/RenderObject";
+
+export default class WebGPUAttributeUtiils {
+    backend: Backend;
+
+    constructor(backend: Backend);
+    createAttribute(attribute: BufferAttribute, usage: number);
+    updateAttribute(attribute: BufferAttribute);
+    createShaderVertexBuffers(renderObject: RenderObject);
+    destroyAttribute(attribute: BufferAttribute);
+    getArrayBufferAsync(attribute: BufferAttribute);
+}

--- a/types/three/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.d.ts
+++ b/types/three/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.d.ts
@@ -5,7 +5,7 @@ export default class WebGPUBindingUtils {
     backend: Backend;
 
     constructor(backend: Backend);
-    createBindingsLayout(bindings: Binding[]);
+    // createBindingsLayout(bindings: Binding[]): GPUBindGroupLayout;
     createBindings(bindings: Binding[]);
     updateBinding(binding: Binding);
     // createBindGroup(bindings: Binding[], layoutGPU: GPUBindGroupLayout): GPUBindGroup;

--- a/types/three/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.d.ts
+++ b/types/three/examples/jsm/renderers/webgpu/utils/WebGPUBindingUtils.d.ts
@@ -1,0 +1,12 @@
+import Backend from "../../common/Backend";
+import Binding from "../../common/Binding";
+
+export default class WebGPUBindingUtils {
+    backend: Backend;
+
+    constructor(backend: Backend);
+    createBindingsLayout(bindings: Binding[]);
+    createBindings(bindings: Binding[]);
+    updateBinding(binding: Binding);
+    // createBindGroup(bindings: Binding[], layoutGPU: GPUBindGroupLayout): GPUBindGroup;
+}


### PR DESCRIPTION
Add types for WebGPUAttributeUtils and WebGPUBindingUtils, both of which can mostly be typed without explicit access to WebGPU types from the webgpu/types library.