### PR TITLE
Fix type of `CompressedTexture.mipmaps`

### DIFF
--- a/types/three/src/textures/CompressedArrayTexture.d.ts
+++ b/types/three/src/textures/CompressedArrayTexture.d.ts
@@ -1,6 +1,5 @@
 import { CompressedPixelFormat, TextureDataType, Wrapping } from "../constants.js";
-import { CompressedTexture } from "./CompressedTexture.js";
-import { MipmapImageData } from "./types.js";
+import { CompressedTexture, CompressedTextureMipmap } from "./CompressedTexture.js";
 
 /**
  * Creates an texture 2D array based on data in compressed form, for example from a
@@ -38,8 +37,8 @@ export class CompressedArrayTexture extends CompressedTexture {
 
     /**
      * Create a new instance of {@link CompressedArrayTexture}
-     * @param mipmaps The mipmaps array should contain objects with data, width and height.
-     * The mipmaps should be of the correct {@link format} and {@link type}. See {@link THREE.mipmaps}.
+     * @param mipmaps The mipmaps array should contain objects with data, width and height. The mipmaps should be of the
+     * correct format and type.
      * @param width The width of the biggest mipmap.
      * @param height The height of the biggest mipmap.
      * @param depth The number of layers of the 2D array texture
@@ -47,7 +46,7 @@ export class CompressedArrayTexture extends CompressedTexture {
      * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
      */
     constructor(
-        mipmaps: MipmapImageData[],
+        mipmaps: CompressedTextureMipmap[],
         width: number,
         height: number,
         depth: number,

--- a/types/three/src/textures/CompressedArrayTexture.d.ts
+++ b/types/three/src/textures/CompressedArrayTexture.d.ts
@@ -1,5 +1,6 @@
 import { CompressedPixelFormat, TextureDataType, Wrapping } from "../constants.js";
 import { CompressedTexture } from "./CompressedTexture.js";
+import { MipmapImageData } from "./types.js";
 
 /**
  * Creates an texture 2D array based on data in compressed form, for example from a
@@ -46,7 +47,7 @@ export class CompressedArrayTexture extends CompressedTexture {
      * @param type See {@link Texture.type | .type}. Default {@link THREE.UnsignedByteType}
      */
     constructor(
-        mipmaps: ImageData[],
+        mipmaps: MipmapImageData[],
         width: number,
         height: number,
         depth: number,

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -8,6 +8,7 @@ import {
     Wrapping,
 } from "../constants.js";
 import { Texture } from "./Texture.js";
+import { MipmapImageData } from "./types.js";
 
 /**
  * Creates a texture based on data in compressed form, for example from a {@link https://en.wikipedia.org/wiki/DirectDraw_Surface | DDS} file.
@@ -33,7 +34,7 @@ export class CompressedTexture extends Texture {
      * @param colorSpace See {@link Texture.colorSpace .colorSpace}. Default {@link NoColorSpace}
      */
     constructor(
-        mipmaps: ImageData[],
+        mipmaps: MipmapImageData[],
         width: number,
         height: number,
         format: CompressedPixelFormat,
@@ -64,7 +65,7 @@ export class CompressedTexture extends Texture {
     /**
      *  The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct {@link format} and {@link type}.
      */
-    mipmaps: ImageData[];
+    mipmaps: MipmapImageData[];
 
     /**
      * @override

--- a/types/three/src/textures/CompressedTexture.d.ts
+++ b/types/three/src/textures/CompressedTexture.d.ts
@@ -7,8 +7,14 @@ import {
     TextureDataType,
     Wrapping,
 } from "../constants.js";
+import { TypedArray } from "../core/BufferAttribute.js";
 import { Texture } from "./Texture.js";
-import { MipmapImageData } from "./types.js";
+
+export interface CompressedTextureMipmap {
+    data: TypedArray;
+    width: number;
+    height: number;
+}
 
 /**
  * Creates a texture based on data in compressed form, for example from a {@link https://en.wikipedia.org/wiki/DirectDraw_Surface | DDS} file.
@@ -19,8 +25,8 @@ import { MipmapImageData } from "./types.js";
 export class CompressedTexture extends Texture {
     /**
      * This creates a new {@link THREE.CompressedTexture | CompressedTexture} object.
-     * @param mipmaps The mipmaps array should contain objects with data, width and height.
-     * The mipmaps should be of the correct {@link format} and {@link type}. See {@link THREE.mipmaps}.
+     * @param mipmaps The mipmaps array should contain objects with data, width and height. The mipmaps should be of the
+     * correct format and type.
      * @param width The width of the biggest mipmap.
      * @param height The height of the biggest mipmap.
      * @param format The format used in the mipmaps. See {@link THREE.CompressedPixelFormat}.
@@ -34,7 +40,7 @@ export class CompressedTexture extends Texture {
      * @param colorSpace See {@link Texture.colorSpace .colorSpace}. Default {@link NoColorSpace}
      */
     constructor(
-        mipmaps: MipmapImageData[],
+        mipmaps: CompressedTextureMipmap[],
         width: number,
         height: number,
         format: CompressedPixelFormat,
@@ -63,9 +69,10 @@ export class CompressedTexture extends Texture {
     set image(value: { width: number; height: number });
 
     /**
-     *  The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct {@link format} and {@link type}.
+     *  The mipmaps array should contain objects with data, width and height. The mipmaps should be of the correct
+     *  format and type.
      */
-    mipmaps: MipmapImageData[];
+    mipmaps: CompressedTextureMipmap[];
 
     /**
      * @override

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -127,7 +127,7 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
      * Array of user-specified mipmaps
      * @defaultValue `[]`
      */
-    mipmaps: any[]; // ImageData[] for 2D textures and CubeTexture[] for cube textures;
+    mipmaps: any[]; // MipmapImageData[] for 2D textures and CubeTexture[] for cube textures;
 
     /**
      * How the image is applied to the object.

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -127,7 +127,7 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
      * Array of user-specified mipmaps
      * @defaultValue `[]`
      */
-    mipmaps: any[]; // MipmapImageData[] for 2D textures and CubeTexture[] for cube textures;
+    mipmaps: any[]; // CompressedTextureMipmap[] for 2D textures and CubeTexture[] for cube textures;
 
     /**
      * How the image is applied to the object.

--- a/types/three/src/textures/types.d.ts
+++ b/types/three/src/textures/types.d.ts
@@ -7,3 +7,18 @@ export interface TextureImageData {
 export interface Texture3DImageData extends TextureImageData {
     depth: number;
 }
+
+export interface MipmapImageData {
+    data:
+        | Int8Array
+        | Uint8Array
+        | Uint8ClampedArray
+        | Int16Array
+        | Uint16Array
+        | Int32Array
+        | Uint32Array
+        | Float32Array
+        | Float64Array;
+    height: number;
+    width: number;
+}

--- a/types/three/src/textures/types.d.ts
+++ b/types/three/src/textures/types.d.ts
@@ -7,18 +7,3 @@ export interface TextureImageData {
 export interface Texture3DImageData extends TextureImageData {
     depth: number;
 }
-
-export interface MipmapImageData {
-    data:
-        | Int8Array
-        | Uint8Array
-        | Uint8ClampedArray
-        | Int16Array
-        | Uint16Array
-        | Int32Array
-        | Uint32Array
-        | Float32Array
-        | Float64Array;
-    height: number;
-    width: number;
-}


### PR DESCRIPTION
Currently `CompressedTexture` and `CompressedArrayTexture` represent mipmaps using the browser's [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData). This is actually inaccurate to three.js's implementation in a few ways:

1. [`ImageData#colorSpace`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/colorSpace) is unused by three.js.
2. [`ImageData#data`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data) is the incorrect type. It is `Uint8ClampedArray` however, using `Uint8ClampedArray` will _sometimes_ cause runtime breakages in three.js (see below for details)

Of these two, (2) is the real problem. [`ImageData#data`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData/data) is defined as `Uint8ClampedArray`, however, mipmap data is [regularly used by threejs](https://github.com/mrdoob/three.js/blob/dev/src/renderers/webgl/WebGLTextures.js#L795) in [`texSubImage2D`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D) and [`compressedTexSubImage2D`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compressedTexSubImage2D) which both require that the source data array view matches the texture type. For example, if I have a texture using `RGIntegerFormat` with `FloatType` then `compressedTexSubImage2D` must be passed a `Float32Array`. As currently written, clients would be forced to use `Uint8ClampedArray` which will cause a runtime error due to misalignment between the source data and texture type. This is documented by [`texSubImage2D`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texSubImage2D) which specifies

> One of the following objects can be used as a pixel source for the texture:
> 
> - [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) (Must be used if type is gl.UNSIGNED_BYTE)
> - [Uint16Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array) (Must be used if type is either gl.UNSIGNED_SHORT_5_6_5, gl.UNSIGNED_SHORT_4_4_4_4, gl.UNSIGNED_SHORT_5_5_5_1, or ext.HALF_FLOAT_OES)
> - [Float32Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Float32Array) (Must be used if type is gl.FLOAT)

The fix here is to replace the current usage of `ImageData` with a new type `MipmapImageData` which better aligns to three.js's internal usage, and importantly allows the `data` field to be populated by any `TypedArray`.