### PR TITLE
GLTFLoader: GLTFParser.assignTexture () is missing the colorSpace parameter, the return value is incorrect.

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -3,6 +3,7 @@ import {
     BufferAttribute,
     BufferGeometry,
     Camera,
+    ColorSpace,
     FileLoader,
     Group,
     ImageBitmapLoader,
@@ -112,7 +113,8 @@ export class GLTFParser {
             texCoord?: number | undefined;
             extensions?: any;
         },
-    ) => Promise<void>;
+        colorSpace?: ColorSpace | undefined,
+    ) => Promise<Texture | null>;
     assignFinalMaterial: (object: Mesh) => void;
     getMaterialType: () => typeof MeshStandardMaterial;
     loadMaterial: (materialIndex: number) => Promise<Material>;


### PR DESCRIPTION
for GLTFLoader.js (https://github.com/mrdoob/three.js/blob/134ff886792734a75c0a9b30aa816d19270f8526/examples/jsm/loaders/GLTFLoader.js#L3345)

---

It needs to be emphasized that, I can't run `pnpm run test`. I don't know what I did wrong, but the content of this modification is at least not used in the second place in `three-ts-type`. I think it is no problem.

I would appreciate it if you could tell me anything about solving my inability to execute the test command.

<details><summary>Error messages</summary>
<p>



```shell
git clone git@github.com:IvanLi-CN/three-ts-types.git
git submodule update --init --recursive
pnpm i

node -v
v20.13.1
pnpm -v
9.1.1
```

```shell
pnpm run test

> @ test /Users/ivan/Projects/Ivan/three-ts-types
> node --require source-map-support/register node_modules/@definitelytyped/dtslint/ types/three

dtslint@0.2.21
Error: ENOENT: no such file or directory, open '/Users/ivan/Projects/Ivan/three-ts-types/notNeededPackages.json'
    at open (node:internal/fs/promises:636:25)
    at Object.readFile (node:internal/fs/promises:1246:14)
    at runTests (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+dtslint@0.2.21_typescript@5.4.5/node_modules/@definitelytyped/dtslint/src/index.ts:168:5)
    at main (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+dtslint@0.2.21_typescript@5.4.5/node_modules/@definitelytyped/dtslint/src/index.ts:103:22)
 ELIFECYCLE  Test failed. See above for more details.
```

```shell
pnpm run test-all

> @ test-all /Users/ivan/Projects/Ivan/three-ts-types
> node --require source-map-support/register node_modules/@definitelytyped/dtslint-runner/ --path .

dtslint-runner@0.1.24
Node version:  v20.13.1
Using local DefinitelyTyped at /Users/ivan/Projects/Ivan/three-ts-types
Error: ENOENT: no such file or directory, open '/Users/ivan/Projects/Ivan/three-ts-types/notNeededPackages.json'
    at Object.readFileSync (node:fs:448:20)
    at readFileSync (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+utils@0.1.6/node_modules/@definitelytyped/utils/src/io.ts:25:18)
    at readJsonSync (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+utils@0.1.6/node_modules/@definitelytyped/utils/src/io.ts:45:20)
    at DiskFS.readJson (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+utils@0.1.6/node_modules/@definitelytyped/utils/src/fs.ts:202:24)
    at readNotNeededPackages (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+definitions-parser@0.1.13_typescript@5.4.5/node_modules/@definitelytyped/definitions-parser/src/packages.ts:589:22)
    at Function.fromFS (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+definitions-parser@0.1.13_typescript@5.4.5/node_modules/@definitelytyped/definitions-parser/src/packages.ts:24:43)
    at prepareAffectedPackages (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+dtslint-runner@0.1.24_typescript@5.4.5/node_modules/@definitelytyped/dtslint-runner/src/prepareAffectedPackages.ts:20:35)
    at runDTSLint (/Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+dtslint-runner@0.1.24_typescript@5.4.5/node_modules/@definitelytyped/dtslint-runner/src/main.ts:49:7)
    at /Users/ivan/Projects/Ivan/three-ts-types/node_modules/.pnpm/@definitelytyped+dtslint-runner@0.1.24_typescript@5.4.5/node_modules/@definitelytyped/dtslint-runner/src/index.ts:134:22
```
</p>
</details> 