### PR TITLE
Update Material type definitions: Add MaterialJSON format

### DIFF
--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -1,6 +1,6 @@
 import { AnimationClip, AnimationClipJSON } from "../animation/AnimationClip.js";
 import { Camera } from "../cameras/Camera.js";
-import { Material } from "../materials/Material.js";
+import { Material, MaterialJSON } from "../materials/Material.js";
 import { Euler } from "../math/Euler.js";
 import { Matrix3 } from "../math/Matrix3.js";
 import { Matrix4, Matrix4Tuple } from "../math/Matrix4.js";
@@ -49,7 +49,7 @@ export interface Object3DJSON {
 
 export interface JSONMeta {
     geometries: Record<string, BufferGeometryJSON>;
-    materials: Record<string, unknown>;
+    materials: Record<string, MaterialJSON>;
     textures: Record<string, TextureJSON>;
     images: Record<string, SourceJSON>;
     shapes: Record<string, unknown>;

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -1,7 +1,6 @@
 import { AnimationClip, AnimationClipJSON } from "../animation/AnimationClip.js";
 import { Camera } from "../cameras/Camera.js";
 import { Material, MaterialJSON } from "../materials/Material.js";
-import { ShaderMaterialJSON } from "../materials/ShaderMaterial.js";
 import { Euler } from "../math/Euler.js";
 import { Matrix3 } from "../math/Matrix3.js";
 import { Matrix4, Matrix4Tuple } from "../math/Matrix4.js";
@@ -50,7 +49,7 @@ export interface Object3DJSON {
 
 export interface JSONMeta {
     geometries: Record<string, BufferGeometryJSON>;
-    materials: Record<string, MaterialJSON | ShaderMaterialJSON>;
+    materials: Record<string, MaterialJSON>;
     textures: Record<string, TextureJSON>;
     images: Record<string, SourceJSON>;
     shapes: Record<string, unknown>;

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -1,6 +1,7 @@
 import { AnimationClip, AnimationClipJSON } from "../animation/AnimationClip.js";
 import { Camera } from "../cameras/Camera.js";
 import { Material, MaterialJSON } from "../materials/Material.js";
+import { ShaderMaterialJSON } from "../materials/ShaderMaterial.js";
 import { Euler } from "../math/Euler.js";
 import { Matrix3 } from "../math/Matrix3.js";
 import { Matrix4, Matrix4Tuple } from "../math/Matrix4.js";
@@ -49,7 +50,7 @@ export interface Object3DJSON {
 
 export interface JSONMeta {
     geometries: Record<string, BufferGeometryJSON>;
-    materials: Record<string, MaterialJSON>;
+    materials: Record<string, MaterialJSON | ShaderMaterialJSON>;
     textures: Record<string, TextureJSON>;
     images: Record<string, SourceJSON>;
     shapes: Record<string, unknown>;

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -12,13 +12,14 @@ import {
 } from "../constants.js";
 import { BufferGeometry } from "../core/BufferGeometry.js";
 import { EventDispatcher } from "../core/EventDispatcher.js";
-import { Object3D } from "../core/Object3D.js";
+import { JSONMeta, Object3D } from "../core/Object3D.js";
 import { Color, ColorRepresentation } from "../math/Color.js";
 import { Plane } from "../math/Plane.js";
 import { Group } from "../objects/Group.js";
 import { WebGLProgramParametersWithUniforms } from "../renderers/webgl/WebGLPrograms.js";
 import { WebGLRenderer } from "../renderers/WebGLRenderer.js";
 import { Scene } from "../scenes/Scene.js";
+import { SourceJSON, TextureJSON } from "../Three.js";
 
 export interface MaterialParameters {
     alphaHash?: boolean | undefined;
@@ -66,6 +67,179 @@ export interface MaterialParameters {
     stencilZFail?: StencilOp | undefined;
     stencilZPass?: StencilOp | undefined;
     userData?: Record<string, any> | undefined;
+}
+export class MaterialJSON {
+    metadata: {
+        version: number;
+        type: "Material";
+        generator: "Material.toJSON";
+    };
+
+    // standard Material serialization
+    uuid: string;
+    type: string;
+    name: string;
+
+    color?: number;
+    roughness?: number;
+    metalness?: number;
+
+    sheen?: number;
+    sheenColor?: number;
+    sheenRoughness?: number;
+
+    emissive?: number;
+    emissiveIntensity?: number;
+
+    specular?: number;
+    specularIntensity?: number;
+    specularColor?: number;
+
+    shininess?: number;
+
+    clearcoat?: number;
+    clearcoatRoughness?: number;
+    clearcoatMap?: string;
+    clearcoatRoughnessMap?: string;
+    clearcoatNormalMap?: string;
+    clearcoatNormalScale?: number[];
+
+    dispersion?: number;
+
+    iridescence?: number;
+    iridescenceIOR?: number;
+    iridescenceThicknessRange?: number;
+    iridescenceMap?: string;
+    iridescenceThicknessMap?: string;
+
+    anisotropy?: number;
+    anisotropyRotation?: number;
+    anisotropyMap?: string;
+
+    map?: string;
+
+    matcap?: string;
+
+    alphaMap?: string;
+
+    lightMap?: string;
+    lightMapIntensity?: number;
+
+    aoMap?: string;
+    aoMapIntensity?: number;
+
+    bumpMap?: string;
+    bumpScale?: number;
+
+    normalMap?: string;
+    normalMapType?: number;
+    normalScale?: number[];
+
+    displacementMap?: string;
+    displacementScale?: number;
+    displacementBias?: number;
+
+    roughnessMap?: string;
+
+    metalnessMap?: string;
+
+    emissiveMap?: string;
+
+    specularMap?: string;
+
+    specularIntensityMap?: string;
+    specularColorMap?: string;
+
+    envMap?: string;
+
+    combine?: number;
+
+    envMapRotation?: number[];
+    envMapIntensity?: number;
+
+    reflectivity?: number;
+    refractionRatio?: number;
+
+    gradientMap?: string;
+
+    transmission?: number;
+    transmissionMap?: string;
+
+    thickness?: number;
+    thicknessMap?: string;
+
+    attenuationDistance?: number;
+    attenuationColor?: number;
+
+    size?: number;
+    shadowSide?: number;
+    sizeAttenuation?: boolean;
+
+    blending?: number;
+    side?: number;
+    vertexColors?: boolean;
+    opacity?: number;
+    transparent?: boolean;
+
+    blendSrc?: BlendingSrcFactor;
+    blendDst?: number;
+    blendEquation?: number;
+    blendSrcAlpha?: number | null;
+    blendDstAlpha?: number | null;
+    blendEquationAlpha?: number | null;
+    blendColor?: number;
+    blendAlpha?: number;
+
+    depthFunc?: number;
+    depthTest?: boolean;
+    depthWrite?: boolean;
+    colorWrite?: boolean;
+
+    stencilWriteMask?: number;
+    stencilFunc?: StencilFunc;
+    stencilRef?: number;
+    stencilFuncMask?: number;
+    stencilFail?: number;
+    stencilZFail?: number;
+    stencilZPass?: number;
+    stencilWrite?: boolean;
+
+    rotation?: number;
+
+    polygonOffset?: boolean;
+    polygonOffsetFactor?: number;
+    polygonOffsetUnits?: number;
+
+    linewidth?: number;
+    dashSize?: number;
+    gapSize?: number;
+    scale?: number;
+    dithering?: boolean;
+
+    alphaTest?: number;
+    alphaHash?: boolean;
+    alphaToCoverage?: boolean;
+    premultipliedAlpha?: boolean;
+
+    forceSinglePass?: boolean;
+
+    wireframe?: boolean;
+    wireframeLinewidth?: number;
+    wireframeLinecap?: string;
+    wireframeLinejoin?: string;
+
+    flatShading?: boolean;
+    visible?: boolean;
+    toneMapped?: boolean;
+    fog?: boolean;
+
+    userData: Record<string, unknown>;
+}
+
+export interface MaterialJSONRoot extends MaterialJSON {
+    textures?: Omit<TextureJSON, "metadata">[];
+
+    images?: SourceJSON[];
 }
 
 /**
@@ -418,7 +592,8 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
      * Convert the material to three.js JSON format.
      * @param meta Object containing metadata such as textures or images for the material.
      */
-    toJSON(meta?: any): any;
+    toJSON(): MaterialJSON;
+    toJSON(meta: JSONMeta): MaterialJSONRoot;
 
     /**
      * Return a new material with the same parameters as this material.

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -237,7 +237,7 @@ export class MaterialJSON {
 }
 
 export interface MaterialJSONRoot extends MaterialJSON {
-    textures?: Omit<TextureJSON, "metadata">[];
+    textures?: Array<Omit<TextureJSON, "metadata">>;
 
     images?: SourceJSON[];
 }

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -102,7 +102,7 @@ export class MaterialJSON {
     clearcoatMap?: string;
     clearcoatRoughnessMap?: string;
     clearcoatNormalMap?: string;
-    clearcoatNormalScale?: Array<number>;
+    clearcoatNormalScale?: number[];
 
     dispersion?: number;
 
@@ -133,7 +133,7 @@ export class MaterialJSON {
 
     normalMap?: string;
     normalMapType?: number;
-    normalScale?: Array<number>;
+    normalScale?: number[];
 
     displacementMap?: string;
     displacementScale?: number;
@@ -154,7 +154,7 @@ export class MaterialJSON {
 
     combine?: number;
 
-    envMapRotation?: Array<number>;
+    envMapRotation?: number[];
     envMapIntensity?: number;
 
     reflectivity?: number;
@@ -237,9 +237,9 @@ export class MaterialJSON {
 }
 
 export interface MaterialJSONRoot extends MaterialJSON {
-    textures?: Array<Omit<TextureJSON, "metadata">>;
+    textures?: Omit<TextureJSON, "metadata">[];
 
-    images?: Array<SourceJSON>;
+    images?: SourceJSON[];
 }
 
 /**

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -102,7 +102,7 @@ export class MaterialJSON {
     clearcoatMap?: string;
     clearcoatRoughnessMap?: string;
     clearcoatNormalMap?: string;
-    clearcoatNormalScale?: number[];
+    clearcoatNormalScale?: Array<number>
 
     dispersion?: number;
 
@@ -133,7 +133,7 @@ export class MaterialJSON {
 
     normalMap?: string;
     normalMapType?: number;
-    normalScale?: number[];
+    normalScale?: Array<number>
 
     displacementMap?: string;
     displacementScale?: number;
@@ -154,7 +154,7 @@ export class MaterialJSON {
 
     combine?: number;
 
-    envMapRotation?: number[];
+    envMapRotation?: Array<number>
     envMapIntensity?: number;
 
     reflectivity?: number;
@@ -237,9 +237,9 @@ export class MaterialJSON {
 }
 
 export interface MaterialJSONRoot extends MaterialJSON {
-    textures?: Omit<TextureJSON, "metadata">[];
+    textures?: Array<Omit<TextureJSON, "metadata">>
 
-    images?: SourceJSON[];
+    images?: Array<SourceJSON>
 }
 
 /**

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -102,7 +102,7 @@ export class MaterialJSON {
     clearcoatMap?: string;
     clearcoatRoughnessMap?: string;
     clearcoatNormalMap?: string;
-    clearcoatNormalScale?: Array<number>
+    clearcoatNormalScale?: Array<number>;
 
     dispersion?: number;
 
@@ -133,7 +133,7 @@ export class MaterialJSON {
 
     normalMap?: string;
     normalMapType?: number;
-    normalScale?: Array<number>
+    normalScale?: Array<number>;
 
     displacementMap?: string;
     displacementScale?: number;
@@ -154,7 +154,7 @@ export class MaterialJSON {
 
     combine?: number;
 
-    envMapRotation?: Array<number>
+    envMapRotation?: Array<number>;
     envMapIntensity?: number;
 
     reflectivity?: number;
@@ -237,9 +237,9 @@ export class MaterialJSON {
 }
 
 export interface MaterialJSONRoot extends MaterialJSON {
-    textures?: Array<Omit<TextureJSON, "metadata">>
+    textures?: Array<Omit<TextureJSON, "metadata">>;
 
-    images?: Array<SourceJSON>
+    images?: Array<SourceJSON>;
 }
 
 /**
@@ -592,8 +592,8 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
      * Convert the material to three.js JSON format.
      * @param meta Object containing metadata such as textures or images for the material.
      */
-    toJSON(): MaterialJSON;
-    toJSON(meta: JSONMeta): MaterialJSONRoot;
+    toJSON(): MaterialJSONRoot;
+    toJSON(meta: JSONMeta): MaterialJSON;
 
     /**
      * Return a new material with the same parameters as this material.

--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -4,7 +4,9 @@ import {
     BlendingDstFactor,
     BlendingEquation,
     BlendingSrcFactor,
+    Combine,
     DepthModes,
+    NormalMapTypes,
     PixelFormat,
     Side,
     StencilFunc,
@@ -19,7 +21,7 @@ import { Group } from "../objects/Group.js";
 import { WebGLProgramParametersWithUniforms } from "../renderers/webgl/WebGLPrograms.js";
 import { WebGLRenderer } from "../renderers/WebGLRenderer.js";
 import { Scene } from "../scenes/Scene.js";
-import { SourceJSON, TextureJSON } from "../Three.js";
+import { EulerTuple, SourceJSON, TextureJSON, Vector2Tuple } from "../Three.js";
 
 export interface MaterialParameters {
     alphaHash?: boolean | undefined;
@@ -68,17 +70,14 @@ export interface MaterialParameters {
     stencilZPass?: StencilOp | undefined;
     userData?: Record<string, any> | undefined;
 }
-export class MaterialJSON {
-    metadata: {
-        version: number;
-        type: "Material";
-        generator: "Material.toJSON";
-    };
 
-    // standard Material serialization
+export interface MaterialJSON {
+    metadata: { version: number; type: string; generator: string };
+
     uuid: string;
     type: string;
-    name: string;
+
+    name?: string;
 
     color?: number;
     roughness?: number;
@@ -87,22 +86,19 @@ export class MaterialJSON {
     sheen?: number;
     sheenColor?: number;
     sheenRoughness?: number;
-
     emissive?: number;
     emissiveIntensity?: number;
 
     specular?: number;
     specularIntensity?: number;
     specularColor?: number;
-
     shininess?: number;
-
     clearcoat?: number;
     clearcoatRoughness?: number;
     clearcoatMap?: string;
     clearcoatRoughnessMap?: string;
     clearcoatNormalMap?: string;
-    clearcoatNormalScale?: number[];
+    clearcoatNormalScale?: Vector2Tuple;
 
     dispersion?: number;
 
@@ -117,9 +113,7 @@ export class MaterialJSON {
     anisotropyMap?: string;
 
     map?: string;
-
     matcap?: string;
-
     alphaMap?: string;
 
     lightMap?: string;
@@ -132,31 +126,26 @@ export class MaterialJSON {
     bumpScale?: number;
 
     normalMap?: string;
-    normalMapType?: number;
-    normalScale?: number[];
+    normalMapType?: NormalMapTypes;
+    normalScale?: Vector2Tuple;
 
     displacementMap?: string;
     displacementScale?: number;
     displacementBias?: number;
 
     roughnessMap?: string;
-
     metalnessMap?: string;
 
     emissiveMap?: string;
-
     specularMap?: string;
-
     specularIntensityMap?: string;
     specularColorMap?: string;
 
     envMap?: string;
+    combine?: Combine;
 
-    combine?: number;
-
-    envMapRotation?: number[];
+    envMapRotation?: EulerTuple;
     envMapIntensity?: number;
-
     reflectivity?: number;
     refractionRatio?: number;
 
@@ -164,10 +153,8 @@ export class MaterialJSON {
 
     transmission?: number;
     transmissionMap?: string;
-
     thickness?: number;
     thicknessMap?: string;
-
     attenuationDistance?: number;
     attenuationColor?: number;
 
@@ -175,22 +162,23 @@ export class MaterialJSON {
     shadowSide?: number;
     sizeAttenuation?: boolean;
 
-    blending?: number;
-    side?: number;
+    blending?: Blending;
+    side?: Side;
     vertexColors?: boolean;
+
     opacity?: number;
     transparent?: boolean;
 
     blendSrc?: BlendingSrcFactor;
-    blendDst?: number;
-    blendEquation?: number;
+    blendDst?: BlendingDstFactor;
+    blendEquation?: BlendingEquation;
     blendSrcAlpha?: number | null;
     blendDstAlpha?: number | null;
     blendEquationAlpha?: number | null;
     blendColor?: number;
     blendAlpha?: number;
 
-    depthFunc?: number;
+    depthFunc?: DepthModes;
     depthTest?: boolean;
     depthWrite?: boolean;
     colorWrite?: boolean;
@@ -199,9 +187,9 @@ export class MaterialJSON {
     stencilFunc?: StencilFunc;
     stencilRef?: number;
     stencilFuncMask?: number;
-    stencilFail?: number;
-    stencilZFail?: number;
-    stencilZPass?: number;
+    stencilFail?: StencilOp;
+    stencilZFail?: StencilOp;
+    stencilZPass?: StencilOp;
     stencilWrite?: boolean;
 
     rotation?: number;
@@ -214,13 +202,13 @@ export class MaterialJSON {
     dashSize?: number;
     gapSize?: number;
     scale?: number;
+
     dithering?: boolean;
 
     alphaTest?: number;
     alphaHash?: boolean;
     alphaToCoverage?: boolean;
     premultipliedAlpha?: boolean;
-
     forceSinglePass?: boolean;
 
     wireframe?: boolean;
@@ -229,16 +217,16 @@ export class MaterialJSON {
     wireframeLinejoin?: string;
 
     flatShading?: boolean;
+
     visible?: boolean;
+
     toneMapped?: boolean;
+
     fog?: boolean;
 
-    userData: Record<string, unknown>;
-}
+    userData?: Record<string, unknown>;
 
-export interface MaterialJSONRoot extends MaterialJSON {
     textures?: Array<Omit<TextureJSON, "metadata">>;
-
     images?: SourceJSON[];
 }
 
@@ -592,8 +580,7 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
      * Convert the material to three.js JSON format.
      * @param meta Object containing metadata such as textures or images for the material.
      */
-    toJSON(): MaterialJSONRoot;
-    toJSON(meta: JSONMeta): MaterialJSON;
+    toJSON(meta?: JSONMeta): MaterialJSON;
 
     /**
      * Return a new material with the same parameters as this material.

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -1,8 +1,8 @@
 import { GLSLVersion } from "../constants.js";
 import { JSONMeta } from "../core/Object3D.js";
 import { UniformsGroup } from "../core/UniformsGroup.js";
-import { Matrix3 } from "../math/Matrix3.js";
-import { Matrix4 } from "../math/Matrix4.js";
+import { Matrix3, Matrix3Tuple } from "../math/Matrix3.js";
+import { Matrix4, Matrix4Tuple } from "../math/Matrix4.js";
 import { Vector2Tuple } from "../math/Vector2.js";
 import { Vector3Tuple } from "../math/Vector3.js";
 import { Vector4Tuple } from "../math/Vector4.js";
@@ -46,16 +46,19 @@ export type ShaderMaterialUniformJSON = {
     value: Vector4Tuple;
 } | {
     type: "m3";
-    value: Matrix3;
+    value: Matrix3Tuple;
 } | {
     type: "m4";
-    value: Matrix4;
+    value: Matrix4Tuple;
 } | {
     value: unknown;
 };
 
 export interface ShaderMaterialJSON extends MaterialJSON {
     glslVersion: number | null;
+    uniforms: Record<string, ShaderMaterialUniformJSON>;
+
+    defines?: Record<string, unknown>;
 
     vertexShader: string;
     ragmentShader: string;
@@ -64,10 +67,6 @@ export interface ShaderMaterialJSON extends MaterialJSON {
     clipping: boolean;
 
     extensions?: Record<string, boolean>;
-
-    defines: Record<string, string | number | undefined>;
-
-    uniforms: Record<string, ShaderMaterialUniformJSON>;
 }
 
 export class ShaderMaterial extends Material {

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -1,7 +1,13 @@
 import { GLSLVersion } from "../constants.js";
+import { JSONMeta } from "../core/Object3D.js";
 import { UniformsGroup } from "../core/UniformsGroup.js";
+import { Matrix3 } from "../math/Matrix3.js";
+import { Matrix4 } from "../math/Matrix4.js";
+import { Vector2Tuple } from "../math/Vector2.js";
+import { Vector3Tuple } from "../math/Vector3.js";
+import { Vector4Tuple } from "../math/Vector4.js";
 import { IUniform } from "../renderers/shaders/UniformsLib.js";
-import { Material, MaterialParameters } from "./Material.js";
+import { Material, MaterialJSON, MaterialParameters } from "./Material.js";
 
 export interface ShaderMaterialParameters extends MaterialParameters {
     uniforms?: { [uniform: string]: IUniform } | undefined;
@@ -21,6 +27,47 @@ export interface ShaderMaterialParameters extends MaterialParameters {
         }
         | undefined;
     glslVersion?: GLSLVersion | undefined;
+}
+
+export type ShaderMaterialUniformJSON = {
+    type: "t";
+    value: string;
+} | {
+    type: "c";
+    value: number;
+} | {
+    type: "v2";
+    value: Vector2Tuple;
+} | {
+    type: "v3";
+    value: Vector3Tuple;
+} | {
+    type: "v4";
+    value: Vector4Tuple;
+} | {
+    type: "m3";
+    value: Matrix3;
+} | {
+    type: "m4";
+    value: Matrix4;
+} | {
+    value: unknown;
+};
+
+export interface ShaderMaterialJSON extends MaterialJSON {
+    glslVersion: number | null;
+
+    vertexShader: string;
+    ragmentShader: string;
+
+    lights: boolean;
+    clipping: boolean;
+
+    extensions?: Record<string, boolean>;
+
+    defines: Record<string, string | number | undefined>;
+
+    uniforms: Record<string, ShaderMaterialUniformJSON>;
 }
 
 export class ShaderMaterial extends Material {
@@ -116,5 +163,6 @@ export class ShaderMaterial extends Material {
     glslVersion: GLSLVersion | null;
 
     setValues(parameters: ShaderMaterialParameters): void;
-    toJSON(meta: any): any;
+
+    toJSON(meta?: JSONMeta): ShaderMaterialJSON;
 }


### PR DESCRIPTION
Introduces the MaterialJSON format in Three.js, which extends the Material interface. The new format includes serializable properties such as color, roughness, metallic, map, normalMap, and many more. This change enables better JSON parsing and handling of material configurations for Three.js applications.

Confirmed: Types and interfaces have been updated in Object3D.d.ts and Material.d.ts. The Material class has also been updated to include toJSON methods that return MaterialJSON or MaterialJSONRoot objects based on the provided meta data.

Reference(s):
#1071
#1070
#426