### PR TITLE
Add ShapeJSON support to Object3D and Shape types

### DIFF
--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -1,5 +1,6 @@
 import { AnimationClip, AnimationClipJSON } from "../animation/AnimationClip.js";
 import { Camera } from "../cameras/Camera.js";
+import { ShapeJSON } from "../extras/core/Shape.js";
 import { Material } from "../materials/Material.js";
 import { Euler } from "../math/Euler.js";
 import { Matrix3 } from "../math/Matrix3.js";
@@ -16,7 +17,6 @@ import { BufferGeometry, BufferGeometryJSON } from "./BufferGeometry.js";
 import { EventDispatcher } from "./EventDispatcher.js";
 import { Layers } from "./Layers.js";
 import { Intersection, Raycaster } from "./Raycaster.js";
-import { ShapeJSON } from "../extras/core/Shape.js"
 
 export interface Object3DJSONObject {
     uuid: string;

--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -16,6 +16,7 @@ import { BufferGeometry, BufferGeometryJSON } from "./BufferGeometry.js";
 import { EventDispatcher } from "./EventDispatcher.js";
 import { Layers } from "./Layers.js";
 import { Intersection, Raycaster } from "./Raycaster.js";
+import { ShapeJSON } from "../extras/core/Shape.js"
 
 export interface Object3DJSONObject {
     uuid: string;
@@ -52,7 +53,7 @@ export interface JSONMeta {
     materials: Record<string, unknown>;
     textures: Record<string, TextureJSON>;
     images: Record<string, SourceJSON>;
-    shapes: Record<string, unknown>;
+    shapes: Record<string, ShapeJSON>;
     skeletons: Record<string, SkeletonJSON>;
     animations: Record<string, AnimationClipJSON>;
     nodes: Record<string, unknown>;

--- a/types/three/src/extras/core/Shape.d.ts
+++ b/types/three/src/extras/core/Shape.d.ts
@@ -1,5 +1,13 @@
 import { Vector2 } from "../../math/Vector2.js";
-import { Path } from "./Path.js";
+import { Path, PathJSON } from "./Path.js";
+
+export interface ShapeJSON extends PathJSON {
+
+    uuid: string;
+
+    holes: PathJSON[]
+
+}
 
 /**
  * Defines an arbitrary 2d {@link Shape} plane using paths with optional holes
@@ -75,4 +83,7 @@ export class Shape extends Path {
      * @param divisions The fineness of the result. Expects a `Integer`
      */
     getPointsHoles(divisions: number): Vector2[][];
+
+    toJSON(): ShapeJSON;
+    fromJSON(json: ShapeJSON): this;
 }

--- a/types/three/src/extras/core/Shape.d.ts
+++ b/types/three/src/extras/core/Shape.d.ts
@@ -3,7 +3,6 @@ import { Path, PathJSON } from "./Path.js";
 
 export interface ShapeJSON extends PathJSON {
     uuid: string;
-
     holes: PathJSON[];
 }
 

--- a/types/three/src/extras/core/Shape.d.ts
+++ b/types/three/src/extras/core/Shape.d.ts
@@ -2,11 +2,9 @@ import { Vector2 } from "../../math/Vector2.js";
 import { Path, PathJSON } from "./Path.js";
 
 export interface ShapeJSON extends PathJSON {
-
     uuid: string;
 
-    holes: PathJSON[]
-
+    holes: PathJSON[];
 }
 
 /**


### PR DESCRIPTION
Added ShapeJSON support to Object3D's shapes record and updated Shape type with JSON conversion functions. This enhancement allows for easier handling and storage of 2D shapes with holes as JSON data. By integrating ShapeJSON in these types, it enables seamless import/export of complex 3D scenes with intricate shapes in a more efficient manner, improving overall compatibility and versatility.