### PR TITLE
fix: NodeMaterial, add missing `.fog` and `.lights`

### DIFF
--- a/types/three/src/nodes/materials/NodeMaterial.d.ts
+++ b/types/three/src/nodes/materials/NodeMaterial.d.ts
@@ -58,6 +58,8 @@ export interface NodeMaterialParameters extends MaterialParameters {
 export default class NodeMaterial extends Material {
     readonly isNodeMaterial: true;
 
+    fog: boolean;
+    lights: boolean;
     normals: boolean;
 
     lightsNode: LightsNode | null;


### PR DESCRIPTION
This PR adds missing `.fog` and `.lights` to NodeMaterial.

- `.fog` is used @ https://github.com/mrdoob/three.js/blob/a00f79b32274975d5bd5c0f3d83ac8c31efec64d/src/nodes/materials/NodeMaterial.js#L487
- `.lights` is used @ https://github.com/mrdoob/three.js/blob/a00f79b32274975d5bd5c0f3d83ac8c31efec64d/src/nodes/materials/NodeMaterial.js#L451

Both are defined @ https://github.com/mrdoob/three.js/blob/a00f79b32274975d5bd5c0f3d83ac8c31efec64d/src/nodes/materials/NodeMaterial.js#L43-L45

These members used to be declared when NodeMaterial extends ShaderMaterial.