### PR TITLE
fix: expose addNodeMaterial and createNodeMaterialFromType

### DIFF
--- a/types/three/src/nodes/materials/Materials.d.ts
+++ b/types/three/src/nodes/materials/Materials.d.ts
@@ -8,7 +8,7 @@ export { default as MeshPhysicalNodeMaterial } from "./MeshPhysicalNodeMaterial.
 export { default as MeshSSSPhysicalNodeMaterial } from "./MeshSSSNodeMaterial.js";
 export { default as MeshStandardNodeMaterial } from "./MeshStandardNodeMaterial.js";
 export { default as MeshToonNodeMaterial } from "./MeshToonNodeMaterial.js";
-export { default as NodeMaterial } from "./NodeMaterial.js";
+export { default as NodeMaterial, addNodeMaterial, createNodeMaterialFromType } from "./NodeMaterial.js";
 export { default as PointsNodeMaterial } from "./PointsNodeMaterial.js";
 export { default as ShadowNodeMaterial } from "./ShadowNodeMaterial.js";
 export { default as SpriteNodeMaterial } from "./SpriteNodeMaterial.js";

--- a/types/three/src/nodes/materials/Materials.d.ts
+++ b/types/three/src/nodes/materials/Materials.d.ts
@@ -8,7 +8,7 @@ export { default as MeshPhysicalNodeMaterial } from "./MeshPhysicalNodeMaterial.
 export { default as MeshSSSPhysicalNodeMaterial } from "./MeshSSSNodeMaterial.js";
 export { default as MeshStandardNodeMaterial } from "./MeshStandardNodeMaterial.js";
 export { default as MeshToonNodeMaterial } from "./MeshToonNodeMaterial.js";
-export { default as NodeMaterial, addNodeMaterial, createNodeMaterialFromType } from "./NodeMaterial.js";
+export { addNodeMaterial, createNodeMaterialFromType, default as NodeMaterial } from "./NodeMaterial.js";
 export { default as PointsNodeMaterial } from "./PointsNodeMaterial.js";
 export { default as ShadowNodeMaterial } from "./ShadowNodeMaterial.js";
 export { default as SpriteNodeMaterial } from "./SpriteNodeMaterial.js";

--- a/types/three/src/nodes/materials/NodeMaterial.d.ts
+++ b/types/three/src/nodes/materials/NodeMaterial.d.ts
@@ -117,5 +117,5 @@ export default class NodeMaterial extends Material {
     static fromMaterial(material: Material): NodeMaterial;
 }
 
-export const addNodeMaterial: (type: string, nodeMaterial: typeof NodeMaterial) => void;
-export const createNodeMaterialFromType: (type: string) => NodeMaterial;
+export function addNodeMaterial(type: string, nodeMaterial: typeof NodeMaterial): void;
+export function createNodeMaterialFromType(type: string): NodeMaterial;

--- a/types/three/src/nodes/materials/NodeMaterial.d.ts
+++ b/types/three/src/nodes/materials/NodeMaterial.d.ts
@@ -116,3 +116,6 @@ export default class NodeMaterial extends Material {
     static fromMaterial(material: NodeMaterial): NodeMaterial;
     static fromMaterial(material: Material): NodeMaterial;
 }
+
+export const addNodeMaterial: (type: string, nodeMaterial: typeof NodeMaterial) => void;
+export const createNodeMaterialFromType: (type: string) => NodeMaterial;


### PR DESCRIPTION
these functions are now exposed.

- See: https://github.com/mrdoob/three.js/blob/a00f79b32274975d5bd5c0f3d83ac8c31efec64d/src/nodes/materials/Materials.js#L3
- See: https://github.com/mrdoob/three.js/blob/a00f79b32274975d5bd5c0f3d83ac8c31efec64d/src/nodes/Nodes.js#L200