### PR TITLE
LightingModel: Refactor indirect lighting (2)

### DIFF
--- a/types/three/src/nodes/core/LightingModel.d.ts
+++ b/types/three/src/nodes/core/LightingModel.d.ts
@@ -42,5 +42,4 @@ export default class LightingModel {
     direct(input: LightingModelDirectInput, stack: StackNode, builder: NodeBuilder): void;
     directRectArea(input: LightingModelDirectRectAreaInput, stack: StackNode, builder: NodeBuilder): void;
     indirect(input: LightingModelIndirectInput, stack: StackNode, builder: NodeBuilder): void;
-    ambientOcclusion(input: LightingModelIndirectInput, stack: StackNode, builder: NodeBuilder): void;
 }


### PR DESCRIPTION
`.ambientOcclusion` also integrated into `.indirect`

Sequel of 9724d5985707e7a81cae478e52fed0682a52d007

See: https://github.com/mrdoob/three.js/pull/28824