### PR TITLE
fix: add `WebXRManager` exports back

### DIFF
--- a/types/three/src/Three.WebGPU.d.ts
+++ b/types/three/src/Three.WebGPU.d.ts
@@ -157,6 +157,12 @@ export type {
     XRJointSpace,
     XRTargetRaySpace,
 } from "./renderers/webxr/WebXRController.js";
+export type {
+    WebXRArrayCamera,
+    WebXRCamera,
+    WebXRManager,
+    WebXRManagerEventMap,
+} from "./renderers/webxr/WebXRManager.js";
 export * from "./scenes/Fog.js";
 export * from "./scenes/FogExp2.js";
 export * from "./scenes/Scene.js";

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -157,6 +157,7 @@ export type {
     XRJointSpace,
     XRTargetRaySpace,
 } from "./renderers/webxr/WebXRController.js";
+export * from "./renderers/webxr/WebXRManager.js";
 export * from "./scenes/Fog.js";
 export * from "./scenes/FogExp2.js";
 export * from "./scenes/Scene.js";

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -157,7 +157,12 @@ export type {
     XRJointSpace,
     XRTargetRaySpace,
 } from "./renderers/webxr/WebXRController.js";
-export * from "./renderers/webxr/WebXRManager.js";
+export type {
+    WebXRArrayCamera,
+    WebXRCamera,
+    WebXRManager,
+    WebXRManagerEventMap,
+} from "./renderers/webxr/WebXRManager.js";
 export * from "./scenes/Fog.js";
 export * from "./scenes/FogExp2.js";
 export * from "./scenes/Scene.js";


### PR DESCRIPTION
This PR adds the `WebXRManager` export back in `Three.d.ts` which was inadvertently removed in PR #1079 and fixes Issue #1139.