### PR TITLE
Add remaining missing type exports

### DIFF
--- a/types/three/src/Three.WebGPU.d.ts
+++ b/types/three/src/Three.WebGPU.d.ts
@@ -157,6 +157,7 @@ export type {
     XRJointSpace,
     XRTargetRaySpace,
 } from "./renderers/webxr/WebXRController.js";
+export type { WebXRDepthSensing } from "./renderers/webxr/WebXRDepthSensing.js";
 export type {
     WebXRArrayCamera,
     WebXRCamera,

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -138,8 +138,37 @@ export * from "./renderers/shaders/ShaderChunk.js";
 export * from "./renderers/shaders/ShaderLib.js";
 export * from "./renderers/shaders/UniformsLib.js";
 export { UniformsUtils } from "./renderers/shaders/UniformsUtils.js";
-export type { WebGLProgramParameters, WebGLProgramParametersWithUniforms } from "./renderers/webgl/WebGLPrograms.js";
+export type { WebGLAttributes } from "./renderers/webgl/WebGLAttributes.js";
+export type { WebGLBindingStates } from "./renderers/webgl/WebGLBindingStates.js";
+export type { WebGLBufferRenderer } from "./renderers/webgl/WebGLBufferRenderer.js";
+export type { WebGLCapabilities, WebGLCapabilitiesParameters } from "./renderers/webgl/WebGLCapabilities.js";
+export type { WebGLClipping } from "./renderers/webgl/WebGLClipping.js";
+export type { WebGLCubeMaps } from "./renderers/webgl/WebGLCubeMaps.js";
+export type { WebGLCubeUVMaps } from "./renderers/webgl/WebGLCubeUVMaps.js";
+export type { WebGLExtensions } from "./renderers/webgl/WebGLExtensions.js";
+export type { WebGLGeometries } from "./renderers/webgl/WebGLGeometries.js";
+export type { WebGLIndexedBufferRenderer } from "./renderers/webgl/WebGLIndexedBufferRenderer.js";
+export type { WebGLInfo } from "./renderers/webgl/WebGLInfo.js";
+export type { WebGLLights, WebGLLightsState } from "./renderers/webgl/WebGLLights.js";
+export type { WebGLObjects } from "./renderers/webgl/WebGLObjects.js";
+export type { WebGLProgram } from "./renderers/webgl/WebGLProgram.js";
+export type {
+    WebGLProgramParameters,
+    WebGLProgramParametersWithUniforms,
+    WebGLPrograms,
+} from "./renderers/webgl/WebGLPrograms.js";
+export type { WebGLProperties } from "./renderers/webgl/WebGLProperties.js";
+export type { RenderItem, WebGLRenderList, WebGLRenderLists } from "./renderers/webgl/WebGLRenderLists.js";
+export type { WebGLShader } from "./renderers/webgl/WebGLShader.js";
 export type { WebGLShadowMap } from "./renderers/webgl/WebGLShadowMap.js";
+export type {
+    WebGLColorBuffer,
+    WebGLDepthBuffer,
+    WebGLState,
+    WebGLStencilBuffer,
+} from "./renderers/webgl/WebGLState.js";
+export type { WebGLTextures } from "./renderers/webgl/WebGLTextures.js";
+export type { WebGLUniforms } from "./renderers/webgl/WebGLUniforms.js";
 export * from "./renderers/webgl/WebGLUtils.js";
 export * from "./renderers/WebGL3DRenderTarget.js";
 export * from "./renderers/WebGLArrayRenderTarget.js";
@@ -157,6 +186,7 @@ export type {
     XRJointSpace,
     XRTargetRaySpace,
 } from "./renderers/webxr/WebXRController.js";
+export type { WebXRDepthSensing } from "./renderers/webxr/WebXRDepthSensing.js";
 export type {
     WebXRArrayCamera,
     WebXRCamera,

--- a/types/three/src/renderers/webxr/WebXRDepthSensing.d.ts
+++ b/types/three/src/renderers/webxr/WebXRDepthSensing.d.ts
@@ -3,13 +3,6 @@ import { Texture } from "../../textures/Texture.js";
 import { WebGLRenderer } from "../WebGLRenderer.js";
 import { WebXRArrayCamera } from "./WebXRManager.js";
 
-// FIXME Replace by XRWebGLDepthInformation when typed in @types/webxr
-interface XRWebGLDepthInformation {
-    readonly texture: WebGLTexture;
-    readonly depthNear: number;
-    readonly depthFar: number;
-}
-
 export class WebXRDepthSensing {
     texture: Texture | null;
     mesh: Mesh | null;

--- a/types/three/src/renderers/webxr/WebXRManager.d.ts
+++ b/types/three/src/renderers/webxr/WebXRManager.d.ts
@@ -1,5 +1,3 @@
-// https://threejs.org/docs/#api/en/renderers/webxr/WebXRManager
-
 /// <reference types="webxr" />
 
 import { ArrayCamera } from "../../cameras/ArrayCamera.js";


### PR DESCRIPTION
Fixes https://github.com/three-types/three-ts-types/issues/1142

This should be the rest of them (😅), I went file-by-file to make sure there weren't any other missing type exports