### PR TITLE
Object3D: Fix onBeforeShadow and onAfterShadow

### DIFF
--- a/types/three/src/core/Object3D.d.ts
+++ b/types/three/src/core/Object3D.d.ts
@@ -299,6 +299,7 @@ export class Object3D<TEventMap extends Object3DEventMap = Object3DEventMap> ext
     onBeforeShadow(
         renderer: WebGLRenderer,
         scene: Scene,
+        camera: Camera,
         shadowCamera: Camera,
         geometry: BufferGeometry,
         depthMaterial: Material,
@@ -317,6 +318,7 @@ export class Object3D<TEventMap extends Object3DEventMap = Object3DEventMap> ext
     onAfterShadow(
         renderer: WebGLRenderer,
         scene: Scene,
+        camera: Camera,
         shadowCamera: Camera,
         geometry: BufferGeometry,
         depthMaterial: Material,


### PR DESCRIPTION
The `onBeforeShadow` and `onAfterShadow` callbacks are called [here](https://github.com/mrdoob/three.js/blob/8eb3ef239eb80d56bce1d2ce67773e257487ddd7/src/renderers/webgl/WebGLShadowMap.js#L359-L363) and [here](https://github.com/mrdoob/three.js/blob/8eb3ef239eb80d56bce1d2ce67773e257487ddd7/src/renderers/webgl/WebGLShadowMap.js#L373-L377) in `WebGLShadowMap` with the parameters `renderer, scene, camera, shadowCamera, geometry, material, group` which is also stated in the respective doc comments.

The `camera` parameter is currently missing in the type declarations.
