### PR TITLE
#1222-DRACOLoader.d.ts-add-parse-function

### DIFF
--- a/types/three/examples/jsm/loaders/DRACOLoader.d.ts
+++ b/types/three/examples/jsm/loaders/DRACOLoader.d.ts
@@ -14,6 +14,12 @@ export class DRACOLoader extends Loader<BufferGeometry> {
         onError?: (err: unknown) => void,
     ): void;
 
+    parse(
+        buffer: ArrayBuffer,
+        onLoad?: (geometry: BufferGeometry) => void,
+        onError?: (err: unknown) => void,
+    ): void;
+
     preload(): DRACOLoader;
     dispose(): DRACOLoader;
 }


### PR DESCRIPTION
1. parse function was called by load func(load from url, then parse)
2. In my case, my draco contents are transferred through other ways, load function is useless
3. Exposing parse function