### PR TITLE
fix: Quaternion fromArray and toArray signatures

### DIFF
--- a/types/three/src/math/Quaternion.d.ts
+++ b/types/three/src/math/Quaternion.d.ts
@@ -129,7 +129,7 @@ export class Quaternion {
      * @param array the source array or array-like.
      * @param offset (optional) offset into the array. Default is 0.
      */
-    fromArray(array: QuaternionTuple, offset?: number): this;
+    fromArray(array: number[] | ArrayLike<number>, offset?: number): this;
 
     /**
      * Returns an array [x, y, z, w], or copies x, y, z and w into the provided array.
@@ -138,6 +138,7 @@ export class Quaternion {
      * @return The created or provided array.
      */
     toArray(array?: number[], offset?: number): QuaternionTuple;
+    toArray(array?: QuaternionTuple, offset?: 0): QuaternionTuple;
 
     /**
      * Copies x, y, z and w into the provided array-like.
@@ -145,7 +146,7 @@ export class Quaternion {
      * @param offset (optional) optional offset into the array.
      * @return The provided array-like.
      */
-    toArray(array: ArrayLike<number>, offset?: number): QuaternionTuple;
+    toArray(array: ArrayLike<number>, offset?: number): ArrayLike<number>;
 
     /**
      * This method defines the serialization result of Quaternion.

--- a/types/three/src/math/Quaternion.d.ts
+++ b/types/three/src/math/Quaternion.d.ts
@@ -137,7 +137,7 @@ export class Quaternion {
      * @param offset (optional) optional offset into the array.
      * @return The created or provided array.
      */
-    toArray(array?: number[], offset?: number): QuaternionTuple;
+    toArray(array?: number[], offset?: number): number[];
     toArray(array?: QuaternionTuple, offset?: 0): QuaternionTuple;
 
     /**


### PR DESCRIPTION
Updates the Quaternion overloads for fromArray and toArray to align with Vector3's implementation as discussed here:
https://github.com/three-types/three-ts-types/pull/426#issuecomment-2357216535

Resolves #1229 

Per the [CONTRIBUTING guidelines](https://github.com/three-types/three-ts-types/blob/master/CONTRIBUTING.md#testing) I tried to run tests after my changes (and add tests of my own) but running `pnpm run test` for me fails with:

```
> @ test /Users/matt/Code/three-ts-types
> node --require source-map-support/register node_modules/@definitelytyped/dtslint/ types/three

dtslint@0.2.23
Error: ENOENT: no such file or directory, open '/Users/matt/Code/three-ts-types/notNeededPackages.json'
```

I don't see a `notNeededPackage.json` file in the repository despite its mention in the README, so maybe these instructions or testbed are out of date. If a maintainer could provide more instruction on how to run tests I'm happy to add some test cases.