### PR TITLE
WebGLRenderer: add reverse-z via EXT_clip_control

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -15,7 +15,7 @@ import { Scene } from "../scenes/Scene.js";
 import { Data3DTexture } from "../textures/Data3DTexture.js";
 import { DataArrayTexture } from "../textures/DataArrayTexture.js";
 import { OffscreenCanvas, Texture } from "../textures/Texture.js";
-import { WebGLCapabilities } from "./webgl/WebGLCapabilities.js";
+import { WebGLCapabilities, WebGLCapabilitiesParameters } from "./webgl/WebGLCapabilities.js";
 import { WebGLExtensions } from "./webgl/WebGLExtensions.js";
 import { WebGLInfo } from "./webgl/WebGLInfo.js";
 import { WebGLProgram } from "./webgl/WebGLProgram.js";
@@ -33,7 +33,7 @@ export interface Renderer {
     setSize(width: number, height: number, updateStyle?: boolean): void;
 }
 
-export interface WebGLRendererParameters {
+export interface WebGLRendererParameters extends WebGLCapabilitiesParameters {
     /**
      * A Canvas where the renderer draws its output.
      */
@@ -45,11 +45,6 @@ export interface WebGLRendererParameters {
      * Default is null
      */
     context?: WebGLRenderingContext | undefined;
-
-    /**
-     * shader precision. Can be "highp", "mediump" or "lowp".
-     */
-    precision?: string | undefined;
 
     /**
      * default is false.
@@ -77,11 +72,6 @@ export interface WebGLRendererParameters {
     preserveDrawingBuffer?: boolean | undefined;
 
     /**
-     * default is false.
-     */
-    reverseDepthBuffer?: boolean | undefined;
-
-    /**
      * Can be "high-performance", "low-power" or "default"
      */
     powerPreference?: string | undefined;
@@ -90,11 +80,6 @@ export interface WebGLRendererParameters {
      * default is true.
      */
     depth?: boolean | undefined;
-
-    /**
-     * default is false.
-     */
-    logarithmicDepthBuffer?: boolean | undefined;
 
     /**
      * default is false.

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -77,6 +77,11 @@ export interface WebGLRendererParameters {
     preserveDrawingBuffer?: boolean | undefined;
 
     /**
+     * default is false.
+     */
+    reverseDepthBuffer?: boolean | undefined;
+
+    /**
      * Can be "high-performance", "low-power" or "default"
      */
     powerPreference?: string | undefined;

--- a/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
+++ b/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
@@ -1,8 +1,20 @@
 import { PixelFormat, TextureDataType } from "../../constants.js";
 
 export interface WebGLCapabilitiesParameters {
+    /**
+     * shader precision. Can be "highp", "mediump" or "lowp".
+     */
     precision?: string | undefined;
+
+    /**
+     * default is false.
+     */
     logarithmicDepthBuffer?: boolean | undefined;
+
+    /**
+     * default is false.
+     */
+    reverseDepthBuffer?: boolean | undefined;
 }
 
 export class WebGLCapabilities {

--- a/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
+++ b/types/three/src/renderers/webgl/WebGLCapabilities.d.ts
@@ -18,6 +18,7 @@ export class WebGLCapabilities {
 
     precision: string;
     logarithmicDepthBuffer: boolean;
+    reverseDepthBuffer: boolean;
 
     maxTextures: number;
     maxVertexTextures: number;


### PR DESCRIPTION
Implements `reverseDepthBuffer` from https://github.com/mrdoob/three.js/pull/29445.