### PR TITLE
fix: Now `element` from `uniformArray` accept both a `number` and `ShaderNodeObject`

### DIFF
--- a/types/three/src/nodes/accessors/UniformArrayNode.d.ts
+++ b/types/three/src/nodes/accessors/UniformArrayNode.d.ts
@@ -1,5 +1,5 @@
 import Node from "../core/Node.js";
-import { ShaderNodeObject } from "../tsl/TSLCore.js";
+import { NodeRepresentation, ShaderNodeObject } from "../tsl/TSLCore.js";
 import ArrayElementNode from "../utils/ArrayElementNode.js";
 import BufferNode from "./BufferNode.js";
 
@@ -17,7 +17,7 @@ declare class UniformArrayNode extends BufferNode {
 
     getElementLength(): number;
 
-    element(indexNode: number | ShaderNodeObject<Node>): ShaderNodeObject<UniformArrayElementNode>;
+    element(indexNode: NodeRepresentation): ShaderNodeObject<UniformArrayElementNode>;
 }
 
 export default UniformArrayNode;

--- a/types/three/src/nodes/accessors/UniformArrayNode.d.ts
+++ b/types/three/src/nodes/accessors/UniformArrayNode.d.ts
@@ -17,7 +17,7 @@ declare class UniformArrayNode extends BufferNode {
 
     getElementLength(): number;
 
-    element(indexNode: number): ShaderNodeObject<UniformArrayElementNode>;
+    element(indexNode: number | ShaderNodeObject<Node>): ShaderNodeObject<UniformArrayElementNode>;
 }
 
 export default UniformArrayNode;


### PR DESCRIPTION
https://discourse.threejs.org/t/how-to-access-an-uniformarray-element-using-a-node-object/72803