### PR TITLE
fix: Now `Else` node don't require a `Node` object anymore.

### DIFF
--- a/types/three/src/nodes/core/StackNode.d.ts
+++ b/types/three/src/nodes/core/StackNode.d.ts
@@ -11,17 +11,17 @@ export default class StackNode extends Node {
 
     If(boolNode: Node, method: () => void): this;
 
-    ElseIf(node: Node, method: () => void): this;
+    ElseIf(boolNode: Node, method: () => void): this;
 
-    Else(node: Node, method: () => void): this;
+    Else(method: () => void): this;
 
     /**
      * @deprecated Use {@link StackNode#ElseIf Else()} instead.
      */
-    elseif(node: Node, method: () => void): this;
+    elseif(boolNode: Node, method: () => void): this;
 
     /**
      * @deprecated Use {@link StackNode#Else Else()} instead.
      */
-    else(node: Node, method: () => void): this;
+    else(method: () => void): this;
 }


### PR DESCRIPTION
This is clearly some TYPO.

https://github.com/mrdoob/three.js/blob/1360b249b6fab26c92c2e467f57368faa69fd01b/src/nodes/core/StackNode.js#L63