### PR TITLE
fix: `MimeType` has been deprecated. `three` simply uses the `string` type.

### DIFF
--- a/types/three/src/loaders/FileLoader.d.ts
+++ b/types/three/src/loaders/FileLoader.d.ts
@@ -11,8 +11,8 @@ export class FileLoader extends Loader<string | ArrayBuffer> {
         onError?: (err: unknown) => void,
     ): void;
 
-    mimeType: undefined | string;
-    responseType: undefined | string;
+    mimeType: string | undefined;
+    responseType: string | undefined;
 
     setMimeType(mimeType: string): FileLoader;
     setResponseType(responseType: string): FileLoader;

--- a/types/three/src/loaders/FileLoader.d.ts
+++ b/types/three/src/loaders/FileLoader.d.ts
@@ -11,9 +11,9 @@ export class FileLoader extends Loader<string | ArrayBuffer> {
         onError?: (err: unknown) => void,
     ): void;
 
-    mimeType: undefined | MimeType;
+    mimeType: undefined | string;
     responseType: undefined | string;
 
-    setMimeType(mimeType: MimeType): FileLoader;
+    setMimeType(mimeType: string): FileLoader;
     setResponseType(responseType: string): FileLoader;
 }


### PR DESCRIPTION
This is something that clearly has changed over the time.

https://threejs.org/docs/#api/en/loaders/FileLoader.setMimeType