### PR TITLE
DecalGeometry: Support geometries without normals.

### DIFF
--- a/types/three/examples/jsm/geometries/DecalGeometry.d.ts
+++ b/types/three/examples/jsm/geometries/DecalGeometry.d.ts
@@ -1,10 +1,16 @@
 import { BufferGeometry, Euler, Mesh, Vector3 } from "three";
 
-export class DecalGeometry extends BufferGeometry {
+declare class DecalGeometry extends BufferGeometry {
     constructor(mesh: Mesh, position: Vector3, orientation: Euler, size: Vector3);
 }
 
-export class DecalVertex {
-    constructor(position: Vector3, normal: Vector3);
+declare class DecalVertex {
+    position: Vector3;
+    normal: Vector3 | null;
+
+    constructor(position: Vector3, normal?: Vector3 | null);
+
     clone(): this;
 }
+
+export { DecalGeometry, DecalVertex };


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/29536