### PR TITLE
WebGLRenderer: sRGB decoding for VideoTexture emissiveMap.

### DIFF
--- a/types/three/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/types/three/src/renderers/webgl/WebGLPrograms.d.ts
@@ -182,6 +182,7 @@ export interface WebGLProgramParameters {
     toneMapping: ToneMapping;
 
     decodeVideoTexture: boolean;
+    decodeVideoTextureEmissive: boolean;
 
     premultipliedAlpha: boolean;
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/29657