### PR TITLE
KTX2Loader: Support transcoding UASTC HDR to BC6H and RGBA16

### DIFF
--- a/types/three/examples/jsm/loaders/KTX2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/KTX2Loader.d.ts
@@ -4,6 +4,7 @@ import { WorkerPool } from "../utils/WorkerPool.js";
 
 export interface KTX2LoaderWorkerConfig {
     astcSupported: boolean;
+    astcHDRSupported: boolean;
     etc1Supported: boolean;
     etc2Supported: boolean;
     dxtSupported: boolean;


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/29730