### PR TITLE
feat(EventDispatcher): expose protected listeners

### DIFF
--- a/types/three/src/core/EventDispatcher.d.ts
+++ b/types/three/src/core/EventDispatcher.d.ts
@@ -40,6 +40,27 @@ export type EventListener<TEventData, TEventType extends string, TTarget> = (
  */
 export class EventDispatcher<TEventMap extends {} = {}> {
     /**
+     * Maps event types to the list of their listeners.
+     * Only initialized when a listener is added.
+     * Event type entries are created when their first listener is added.
+     *
+     * @example
+     * ```typescript
+     * type MyDisp = EventDispatcher<{ a: { b: number }, c: { d: string } }>;
+     * const disp = new MyDisp();
+     * // typeof disp._listeners ==
+     * //     | undefined
+     * //     | {
+     * //         a?: EventListener<{ b: number }, 'a', this>[],
+     * //         c?: EventListener<{ d: string }, 'c', this>[],
+     * //     };
+     * ```
+     */
+    protected _listeners?: {
+        [Type in Extract<keyof TEventMap, string>]?: EventListener<TEventMap[Type], Type, this>[]
+    };
+
+    /**
      * Creates {@link THREE.EventDispatcher | EventDispatcher} object.
      */
     constructor();

--- a/types/three/src/core/EventDispatcher.d.ts
+++ b/types/three/src/core/EventDispatcher.d.ts
@@ -57,7 +57,7 @@ export class EventDispatcher<TEventMap extends {} = {}> {
      * ```
      */
     protected _listeners?: {
-        [Type in Extract<keyof TEventMap, string>]?: EventListener<TEventMap[Type], Type, this>[]
+        [Type in Extract<keyof TEventMap, string>]?: EventListener<TEventMap[Type], Type, this>[];
     };
 
     /**


### PR DESCRIPTION
Resolves #1374 

Exposes the `_listeners` storage as a protected field so extending classes can access it.
The testsuite only worked once then never again, skipping with a fetch error on attw that I couldn't find anywhere online. I'm assuming this is due to the proxy at my work, but either way I can't test this myself at the moment. Seems to work though and it shouldn't be a breaking change.