### PR TITLE
fix(types): sync GLTFWriter and GLTFExporterPlugin types with impleme…

### DIFF
--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -87,7 +87,7 @@ declare class GLTFExporter {
      */
     parse(
         input: Object3D | Object3D[],
-        onDone: (gltf: ArrayBuffer | { [key: string]: any }) => void,
+        onDone: (gltf: ArrayBuffer | { [key: string]: unknown }) => void,
         onError: (error: ErrorEvent) => void,
         options?: GLTFExporterOptions,
     ): void;
@@ -101,13 +101,14 @@ declare class GLTFExporter {
     parseAsync(
         input: Object3D | Object3D[],
         options?: GLTFExporterOptions,
-    ): Promise<ArrayBuffer | { [key: string]: any }>;
+    ): Promise<ArrayBuffer | { [key: string]: unknown }>;
 }
 
 declare class GLTFWriter {
     textureUtils: TextureUtils | null;
 
-    extensionsUsed: { [key: string]: boolean };
+    extensionsUsed: { [name: string]: boolean };
+    extensionsRequired: { [name: string]: boolean };
 
     constructor();
 
@@ -126,7 +127,7 @@ declare class GLTFWriter {
      * Applies a texture transform, if present, to the map definition. Requires
      * the KHR_texture_transform extension.
      */
-    applyTextureTransform(mapDef: { [key: string]: any }, texture: Texture): void;
+    applyTextureTransform(mapDef: { [key: string]: unknown }, texture: Texture): void;
 
     /**
      * Parse scenes and generate GLTF output
@@ -137,16 +138,16 @@ declare class GLTFWriter {
      */
     writeAsync(
         input: Object3D | Object3D[],
-        onDone: (gltf: ArrayBuffer | { [key: string]: any }) => void,
+        onDone: (gltf: ArrayBuffer | { [key: string]: unknown }) => void,
         options?: GLTFExporterOptions,
     ): Promise<void>;
 }
 
 export interface GLTFExporterPlugin {
-    writeTexture?: (map: Texture, textureDef: { [key: string]: any }) => void;
-    writeMaterialAsync?: (material: Material, materialDef: { [key: string]: any }) => Promise<void>;
-    writeMesh?: (mesh: Mesh, meshDef: { [key: string]: any }) => void;
-    writeNode?: (object: Object3D, nodeDef: { [key: string]: any }) => void;
+    writeTexture?: (map: Texture, textureDef: { [key: string]: unknown }) => void;
+    writeMaterialAsync?: (material: Material, materialDef: { [key: string]: unknown }) => Promise<void>;
+    writeMesh?: (mesh: Mesh, meshDef: { [key: string]: unknown }) => void;
+    writeNode?: (object: Object3D, nodeDef: { [key: string]: unknown }) => void;
     beforeParse?: (input: Object3D | Object3D[]) => void;
     afterParse?: (input: Object3D | Object3D[]) => void;
 }

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -107,11 +107,26 @@ declare class GLTFExporter {
 declare class GLTFWriter {
     textureUtils: TextureUtils | null;
 
+    extensionsUsed: { [key: string]: boolean };
+
     constructor();
 
     setPlugins(plugins: GLTFExporterPlugin[]): void;
 
     setTextureUtils(utils: TextureUtils | null): this;
+
+    /**
+     * Process texture
+     * @param map Map to process
+     * @return Index of the processed texture in the "textures" array
+     */
+    processTextureAsync(map: Texture): Promise<number>
+
+    /**
+     * Applies a texture transform, if present, to the map definition. Requires
+     * the KHR_texture_transform extension.
+     */
+    applyTextureTransform(mapDef: { [key: string]: any }, texture: Texture): void
 
     /**
      * Parse scenes and generate GLTF output
@@ -129,7 +144,7 @@ declare class GLTFWriter {
 
 export interface GLTFExporterPlugin {
     writeTexture?: (map: Texture, textureDef: { [key: string]: any }) => void;
-    writeMaterial?: (material: Material, materialDef: { [key: string]: any }) => void;
+    writeMaterialAsync?: (material: Material, materialDef: { [key: string]: any }) => Promise<void>;
     writeMesh?: (mesh: Mesh, meshDef: { [key: string]: any }) => void;
     writeNode?: (object: Object3D, nodeDef: { [key: string]: any }) => void;
     beforeParse?: (input: Object3D | Object3D[]) => void;

--- a/types/three/examples/jsm/exporters/GLTFExporter.d.ts
+++ b/types/three/examples/jsm/exporters/GLTFExporter.d.ts
@@ -120,13 +120,13 @@ declare class GLTFWriter {
      * @param map Map to process
      * @return Index of the processed texture in the "textures" array
      */
-    processTextureAsync(map: Texture): Promise<number>
+    processTextureAsync(map: Texture): Promise<number>;
 
     /**
      * Applies a texture transform, if present, to the map definition. Requires
      * the KHR_texture_transform extension.
      */
-    applyTextureTransform(mapDef: { [key: string]: any }, texture: Texture): void
+    applyTextureTransform(mapDef: { [key: string]: any }, texture: Texture): void;
 
     /**
      * Parse scenes and generate GLTF output


### PR DESCRIPTION
These properties and methods are used in GLTF extensions but were missing from the type declarations, I've added them now.
- Add [extensionsUsed ](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/exporters/GLTFExporter.js#L506)property to GLTFWriter
- Add texture processing methods to GLTFWriter
  - [processTextureAsync](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/exporters/GLTFExporter.js#L1440)
  - [applyTextureTransform](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/exporters/GLTFExporter.js#L807)
- Fix writeMaterial type in GLTFExporterPlugin to match async implementation (writeMaterial -> [writeMaterialAsync](https://github.com/mrdoob/three.js/blob/dev/examples/jsm/exporters/GLTFExporter.js#L1647))

