### PR TITLE
add missing export

### DIFF
--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -204,6 +204,7 @@ export * from "./textures/DepthTexture.js";
 export * from "./textures/FramebufferTexture.js";
 export * from "./textures/Source.js";
 export * from "./textures/Texture.js";
+export * from "./textures/types.js";
 export * from "./textures/VideoTexture.js";
 export * from "./Three.Legacy.js";
 export { createCanvasElement } from "./utils.js";


### PR DESCRIPTION
Else a deep import is necessary
from "three/src/textures/types"