### PR TITLE
loose events back

### DIFF
--- a/types/three/src/core/EventDispatcher.d.ts
+++ b/types/three/src/core/EventDispatcher.d.ts
@@ -53,6 +53,7 @@ export class EventDispatcher<TEventMap extends {} = {}> {
         type: T,
         listener: EventListener<TEventMap[T], T, this>,
     ): void;
+    addEventListener<T extends string>(type: T, listener: EventListener<{}, T, this>): void;
 
     /**
      * Checks if listener is added to an event type.
@@ -63,6 +64,7 @@ export class EventDispatcher<TEventMap extends {} = {}> {
         type: T,
         listener: EventListener<TEventMap[T], T, this>,
     ): boolean;
+    hasEventListener<T extends string>(type: T, listener: EventListener<{}, T, this>): boolean;
 
     /**
      * Removes a listener from an event type.
@@ -73,6 +75,7 @@ export class EventDispatcher<TEventMap extends {} = {}> {
         type: T,
         listener: EventListener<TEventMap[T], T, this>,
     ): void;
+    removeEventListener<T extends string>(type: T, listener: EventListener<{}, T, this>): void;
 
     /**
      * Fire an event type.

--- a/types/three/test/unit/src/core/EventDispatcher.ts
+++ b/types/three/test/unit/src/core/EventDispatcher.ts
@@ -42,8 +42,27 @@ eveDisForTestEvent.addEventListener("bar", e => {
     e.foo;
 });
 
-// @ts-expect-error
-eveDisForTestEvent.addEventListener("baz", e => {});
+// call addEventListener with an unknown event. The typing should allow you listen any unknown event.
+eveDisForTestEvent.addEventListener("baz", e => {
+    e.type; // $ExpectType "baz"
+    e.target; // $ExpectType EventDispatcher<TestEvent>
+    // @ts-expect-error
+    e.bar;
+    // @ts-expect-error
+    e.foo;
+    // @ts-expect-error
+    e.bar();
+});
+eveDisForTestEvent.addEventListener("NotRegistered", e => {
+    e.type; // $ExpectType "NotRegistered"
+    e.target; // $ExpectType EventDispatcher<TestEvent>
+    // @ts-expect-error
+    e.bar;
+    // @ts-expect-error
+    e.foo;
+    // @ts-expect-error
+    e.bar();
+});
 
 eveDisForTestEvent.dispatchEvent({ type: "foo", foo: 42 });
 eveDisForTestEvent.dispatchEvent({ type: "bar", bar: "42" });


### PR DESCRIPTION
#1145 introduced a breaking change on `EventDispatcher`, a class with an implementation that hasn't change in years.

The idea is great, but sadly it breaks a few things in `pmndrs` libraries as it makes backward compatibility really hard to keep.

I did try to fix it at `three-stdlib`, but I introduced more issues than solutions, also would prefer to avoid having to maintain in there a copy of `EventDispatcher` considering the real thing hasn't change in years.

I believe a much simpler solution that works for all is to just accept types to be a tiny bit looser.

With this we will still have types for `addEventListener` and so on, but is optional rather than required.