### PR TITLE
Make Material.type mutable

### DIFF
--- a/types/three/src/materials/Material.d.ts
+++ b/types/three/src/materials/Material.d.ts
@@ -247,7 +247,7 @@ export class Material extends EventDispatcher<{ dispose: {} }> {
      * Value is the string 'Material'. This shouldn't be changed, and can be used to find all objects of this type in a
      * scene.
      */
-    readonly type: string;
+    type: string;
 
     /**
      * Enables alpha hashed transparency, an alternative to {@link .transparent} or {@link .alphaTest}. The material


### PR DESCRIPTION
Fixes #1399

TypeScript is weird in that it doesn't allow setting readonly property in subclass constructors, which is a clear use-case for the `type` property