### PR TITLE
ComputeNode: `workgroupSize` optional

### DIFF
--- a/types/three/src/nodes/gpgpu/ComputeNode.d.ts
+++ b/types/three/src/nodes/gpgpu/ComputeNode.d.ts
@@ -19,7 +19,7 @@ export default class ComputeNode extends Node {
 export const compute: (
     node: NodeRepresentation,
     count: number,
-    workgroupSize: number[],
+    workgroupSize?: number[],
 ) => ShaderNodeObject<ComputeNode>;
 
 declare module "../tsl/TSLCore.js" {


### PR DESCRIPTION
Fix: #1448

![image](https://github.com/user-attachments/assets/2dec4d9d-c7ef-4022-bf4f-224c33d60c1b)

As the title says.