### PR TITLE
feat: update the type of BufferGeometry.morphAttributes

### DIFF
--- a/types/three/src/core/BufferGeometry.d.ts
+++ b/types/three/src/core/BufferGeometry.d.ts
@@ -172,9 +172,7 @@ export class BufferGeometry<
      * You will have to call {@link dispose | .dispose}(), and create a new instance of {@link THREE.BufferGeometry | BufferGeometry}.
      * @defaultValue `{}`
      */
-    morphAttributes: {
-        [name: string]: Array<BufferAttribute | InterleavedBufferAttribute>; // TODO Replace for 'Record<>'
-    };
+    morphAttributes: Record<"position" | "normal" | "color", Array<BufferAttribute | InterleavedBufferAttribute>>;
 
     /**
      * Used to control the morph target behavior; when set to true, the morph target data is treated as relative offsets, rather than as absolute positions/normals.


### PR DESCRIPTION
## Description

The original type is right somehow but not accurate. From the page below you could see the new type definition's reason.

The original type is right but not strict. So I enhance it and also resolve a TODO.

About the new definition you could see:

[github.com/search?q=repo%3Amrdoob%2Fthree.js+morphAttributes+language%3AJavaScript&type=code&l=JavaScript](https://github.com/search?q=repo%3Amrdoob%2Fthree.js+morphAttributes+language%3AJavaScript&type=code&l=JavaScript&rgh-link-date=2025-03-05T13%3A54%3A29Z)

---
Reference: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72127