### PR TITLE
AnimationMixer: Add string as valid method input

### DIFF
--- a/types/three/src/animation/AnimationMixer.d.ts
+++ b/types/three/src/animation/AnimationMixer.d.ts
@@ -24,16 +24,22 @@ export class AnimationMixer extends EventDispatcher<AnimationMixerEventMap> {
     timeScale: number;
 
     clipAction(
-        clip: AnimationClip,
+        clip: AnimationClip | string,
         root?: Object3D | AnimationObjectGroup,
         blendMode?: AnimationBlendMode,
     ): AnimationAction;
-    existingAction(clip: AnimationClip, root?: Object3D | AnimationObjectGroup): AnimationAction | null;
+    existingAction(
+        clip: AnimationClip | string,
+        root?: Object3D | AnimationObjectGroup,
+    ): AnimationAction | null;
     stopAllAction(): AnimationMixer;
     update(deltaTime: number): AnimationMixer;
     setTime(timeInSeconds: number): AnimationMixer;
     getRoot(): Object3D | AnimationObjectGroup;
     uncacheClip(clip: AnimationClip): void;
     uncacheRoot(root: Object3D | AnimationObjectGroup): void;
-    uncacheAction(clip: AnimationClip, root?: Object3D | AnimationObjectGroup): void;
+    uncacheAction(
+        clip: AnimationClip | string,
+        root?: Object3D | AnimationObjectGroup,
+    ): void;
 }


### PR DESCRIPTION
Based over recent Jsdoc added, we can see that some methods accept a string as a valid parameter.

https://github.com/mrdoob/three.js/blob/dev/src/animation/AnimationMixer.js

