### PR TITLE
CanvasTexture: constructor canvas param can be undefined

### DIFF
--- a/types/three/src/textures/CanvasTexture.d.ts
+++ b/types/three/src/textures/CanvasTexture.d.ts
@@ -31,7 +31,7 @@ export class CanvasTexture extends Texture {
      * @param anisotropy See {@link Texture.anisotropy | .anisotropy}. Default {@link THREE.Texture.DEFAULT_ANISOTROPY}
      */
     constructor(
-        canvas: TexImageSource | OffscreenCanvas,
+        canvas?: TexImageSource | OffscreenCanvas,
         mapping?: Mapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,


### PR DESCRIPTION
As you can see here, the canvas constructor param can be undefined https://github.com/mrdoob/three.js/blob/a1358b4fa0822fe99498c11c1c24ff4a6e89f634/src/textures/CanvasTexture.js#L16