### PR TITLE
Adds typed uniforms to ShaderMaterial and RawShaderMaterial

### DIFF
--- a/types/three/src/materials/RawShaderMaterial.d.ts
+++ b/types/three/src/materials/RawShaderMaterial.d.ts
@@ -1,7 +1,9 @@
 import { ShaderMaterial, ShaderMaterialParameters } from "./ShaderMaterial.js";
 
-export class RawShaderMaterial extends ShaderMaterial {
-    constructor(parameters?: ShaderMaterialParameters);
+export class RawShaderMaterial<T extends Record<string, IUniform<any>> = any> extends ShaderMaterial {
+    declare uniforms: T;
+    
+    constructor(parameters?: Omit<ShaderMaterialParameters, 'uniforms'> & { uniforms: T });
 
     /**
      * Read-only flag to check if a given object is of type {@link RawShaderMaterial}.

--- a/types/three/src/materials/RawShaderMaterial.d.ts
+++ b/types/three/src/materials/RawShaderMaterial.d.ts
@@ -1,6 +1,6 @@
 import { ShaderMaterial, ShaderMaterialParameters } from "./ShaderMaterial.js";
 
-export class RawShaderMaterial<T extends Record<string, IUniform<any>> = any> extends ShaderMaterial {
+export class RawShaderMaterial<T extends Record<string, IUniform> = any> extends ShaderMaterial {
     declare uniforms: T;
     
     constructor(parameters?: Omit<ShaderMaterialParameters, 'uniforms'> & { uniforms: T });

--- a/types/three/src/materials/ShaderMaterial.d.ts
+++ b/types/three/src/materials/ShaderMaterial.d.ts
@@ -69,8 +69,8 @@ export interface ShaderMaterialJSON extends MaterialJSON {
     extensions?: Record<string, boolean>;
 }
 
-export class ShaderMaterial extends Material {
-    constructor(parameters?: ShaderMaterialParameters);
+export class ShaderMaterial<T extends Record<string, IUniform> = any> extends Material {
+    constructor(parameters?: Omit<ShaderMaterialParameters, 'uniforms'> & { uniforms: T });
 
     /**
      * Read-only flag to check if a given object is of type {@link ShaderMaterial}.
@@ -87,7 +87,7 @@ export class ShaderMaterial extends Material {
     /**
      * @default {}
      */
-    uniforms: { [uniform: string]: IUniform };
+    uniforms: T;
 
     uniformsGroups: UniformsGroup[];
 


### PR DESCRIPTION
I've been using this for years in my own projects where I use custom shaders often. Typing uniforms makes working with these classes much nicer

```ts
let shader = new ShaderMaterial({ uniforms: { example: new Uniform(3), ... }, ... });

// typed correctly!
shader.uniforms.example.value = 4
```

This does not change the behaviour of existing code because uniform types default to `any`