### PR TITLE
LutPass: no params is a valid constructor

### DIFF
--- a/types/three/examples/jsm/postprocessing/LUTPass.d.ts
+++ b/types/three/examples/jsm/postprocessing/LUTPass.d.ts
@@ -9,5 +9,5 @@ export interface LUTPassParameters {
 export class LUTPass extends ShaderPass {
     lut?: DataTexture | Data3DTexture;
     intensity?: number;
-    constructor(params: LUTPassParameters);
+    constructor(params?: LUTPassParameters);
 }


### PR DESCRIPTION
See here : https://github.com/mrdoob/three.js/blob/35b0fbc461520006769514eece8c3b371a79257c/examples/jsm/postprocessing/LUTPass.js#L76

We can use no arguments in the constructor and still instantiate a LutPass.