### PR TITLE
Add missing CapsuleGeometry parameter

### DIFF
--- a/types/three/src/geometries/CapsuleGeometry.d.ts
+++ b/types/three/src/geometries/CapsuleGeometry.d.ts
@@ -48,6 +48,7 @@ export class CapsuleGeometry extends BufferGeometry {
         readonly height: number;
         readonly capSegments: number;
         readonly radialSegments: number;
+        readonly heightSegments: number;
     };
 
     /** @internal */


### PR DESCRIPTION
Missing parameter.

See:
https://github.com/mrdoob/three.js/blob/r176/src/geometries/CapsuleGeometry.js#L46