### PR TITLE
Texture: Add setValues.

### DIFF
--- a/types/three/src/core/RenderTarget.d.ts
+++ b/types/three/src/core/RenderTarget.d.ts
@@ -1,26 +1,9 @@
-import {
-    MagnificationTextureFilter,
-    MinificationTextureFilter,
-    PixelFormatGPU,
-    TextureDataType,
-    Wrapping,
-} from "../constants.js";
 import { Vector4 } from "../math/Vector4.js";
 import { DepthTexture } from "../textures/DepthTexture.js";
-import { Texture } from "../textures/Texture.js";
+import { Texture, TextureParameters } from "../textures/Texture.js";
 import { EventDispatcher } from "./EventDispatcher.js";
 
-export interface RenderTargetOptions {
-    wrapS?: Wrapping | undefined;
-    wrapT?: Wrapping | undefined;
-    magFilter?: MagnificationTextureFilter | undefined;
-    minFilter?: MinificationTextureFilter | undefined;
-    generateMipmaps?: boolean | undefined; // true
-    format?: number | undefined; // RGBAFormat
-    type?: TextureDataType | undefined; // UnsignedByteType
-    anisotropy?: number | undefined; // 1
-    colorSpace?: string | undefined;
-    internalFormat?: PixelFormatGPU | null | undefined; // null
+export interface RenderTargetOptions extends TextureParameters {
     depthBuffer?: boolean | undefined; // true
     stencilBuffer?: boolean | undefined; // false
     resolveDepthBuffer?: boolean | undefined; // true

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -20,28 +20,28 @@ import { Source } from "./Source.js";
 
 // NOTE: DOM upload fields are not implemented where parameters are accepted.
 export interface TextureParameters {
-    mapping: AnyMapping | undefined;
-    // image: TexImageSource | OffscreenCanvas | undefined;
-    // channel: number | undefined;
+    mapping?: AnyMapping | undefined;
+    // image?: TexImageSource | OffscreenCanvas | undefined;
+    // channel?: number | undefined;
 
-    wrapS: Wrapping | undefined;
-    wrapT: Wrapping | undefined;
-    wrapR: Wrapping | undefined;
+    wrapS?: Wrapping | undefined;
+    wrapT?: Wrapping | undefined;
+    wrapR?: Wrapping | undefined;
 
-    format: PixelFormat | undefined;
-    internalFormat: PixelFormatGPU | null | undefined;
-    type: TextureDataType | undefined;
-    colorSpace: ColorSpace | undefined;
+    format?: PixelFormat | undefined;
+    internalFormat?: PixelFormatGPU | null | undefined;
+    type?: TextureDataType | undefined;
+    colorSpace?: ColorSpace | undefined;
 
-    magFilter: MinificationTextureFilter | undefined;
-    minFilter: MagnificationTextureFilter | undefined;
-    anisotropy: number | undefined;
+    magFilter?: MinificationTextureFilter | undefined;
+    minFilter?: MagnificationTextureFilter | undefined;
+    anisotropy?: number | undefined;
 
-    flipY: boolean | undefined;
+    flipY?: boolean | undefined;
 
-    generateMipmaps: boolean | undefined;
-    // premultiplyAlpha: boolean | undefined;
-    // unpackAlignment: number | undefined;
+    generateMipmaps?: boolean | undefined;
+    // premultiplyAlpha?: boolean | undefined;
+    // unpackAlignment?: number | undefined;
 }
 
 export interface TextureJSON {

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -532,7 +532,7 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
 
     /**
      * Sets this texture's properties based on `values`.
-     * @param {Object} values - A container with texture parameters.
+     * @param values - A container with texture parameters.
      */
     setValues(values: TextureParameters): void;
 

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -33,8 +33,8 @@ export interface TextureParameters {
     type?: TextureDataType | undefined;
     colorSpace?: ColorSpace | undefined;
 
-    magFilter?: MinificationTextureFilter | undefined;
-    minFilter?: MagnificationTextureFilter | undefined;
+    magFilter?: MagnificationTextureFilter | undefined;
+    minFilter?: MinificationTextureFilter | undefined;
     anisotropy?: number | undefined;
 
     flipY?: boolean | undefined;

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -1,6 +1,7 @@
 import {
     AnyMapping,
     AnyPixelFormat,
+    ColorSpace,
     MagnificationTextureFilter,
     Mapping,
     MinificationTextureFilter,
@@ -16,6 +17,32 @@ import { Vector2 } from "../math/Vector2.js";
 import { CompressedTextureMipmap } from "./CompressedTexture.js";
 import { CubeTexture } from "./CubeTexture.js";
 import { Source } from "./Source.js";
+
+// NOTE: DOM upload fields are not implemented where parameters are accepted.
+export interface TextureParameters {
+    mapping: AnyMapping | undefined;
+    // image: TexImageSource | OffscreenCanvas | undefined;
+    // channel: number | undefined;
+
+    wrapS: Wrapping | undefined;
+    wrapT: Wrapping | undefined;
+    wrapR: Wrapping | undefined;
+
+    format: PixelFormat | undefined;
+    internalFormat: PixelFormatGPU | null | undefined;
+    type: TextureDataType | undefined;
+    colorSpace: ColorSpace | undefined;
+
+    magFilter: MinificationTextureFilter | undefined;
+    minFilter: MagnificationTextureFilter | undefined;
+    anisotropy: number | undefined;
+
+    flipY: boolean | undefined;
+
+    generateMipmaps: boolean | undefined;
+    // premultiplyAlpha: boolean | undefined;
+    // unpackAlignment: number | undefined;
+}
 
 export interface TextureJSON {
     metadata: { version: number; type: string; generator: string };
@@ -99,7 +126,7 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
         format?: PixelFormat,
         type?: TextureDataType,
         anisotropy?: number,
-        colorSpace?: string,
+        colorSpace?: ColorSpace,
     );
 
     /**
@@ -502,6 +529,12 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
     clone(): this;
 
     copy(source: Texture): this;
+
+    /**
+     * Sets this texture's properties based on `values`.
+	 * @param {Object} values - A container with texture parameters.
+     */
+    setValues(values: TextureParameters): void;
 
     /**
      * Convert the texture to three.js {@link https://github.com/mrdoob/three.js/wiki/JSON-Object-Scene-format-4 | JSON Object/Scene format}.

--- a/types/three/src/textures/Texture.d.ts
+++ b/types/three/src/textures/Texture.d.ts
@@ -532,7 +532,7 @@ export class Texture extends EventDispatcher<{ dispose: {} }> {
 
     /**
      * Sets this texture's properties based on `values`.
-	 * @param {Object} values - A container with texture parameters.
+     * @param {Object} values - A container with texture parameters.
      */
     setValues(values: TextureParameters): void;
 


### PR DESCRIPTION
Adds types for https://github.com/mrdoob/three.js/pull/31087 which is used to ensure texture parameters are passed correctly from render target options (2D, 3D, array). I do use the word parameters for the interface, unsure if options is preferable even though the `Texture` constructor only has arguments.

See https://github.com/mrdoob/three.js/pull/31087/files#diff-3d1e11ad5043fb6ad5c8b8a55be022f7ba2e3228b34016a073524f32af2aec8cR205 for relevant diff to texture parameters.