### PR TITLE
WebGLRenderer: Add MRT support to readRenderTargetPixels().

### DIFF
--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -406,6 +406,7 @@ export class WebGLRenderer {
         height: number,
         buffer: TypedArray,
         activeCubeFaceIndex?: number,
+        textureIndex?: number,
     ): void;
 
     readRenderTargetPixelsAsync(
@@ -416,6 +417,7 @@ export class WebGLRenderer {
         height: number,
         buffer: TypedArray,
         activeCubeFaceIndex?: number,
+        textureIndex?: number,
     ): Promise<TypedArray>;
 
     /**


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/31204