### PR TITLE
Update AxesHelper generics

### DIFF
--- a/types/three/src/helpers/AxesHelper.d.ts
+++ b/types/three/src/helpers/AxesHelper.d.ts
@@ -1,5 +1,6 @@
 import { ColorRepresentation } from "../math/Color.js";
 import { LineSegments } from "../objects/LineSegments.js";
+import { BufferGeometry, LineBasicMaterial } from "../Three.Core.js";
 
 /**
  * An axis object to visualize the 3 axes in a simple way.
@@ -18,7 +19,7 @@ import { LineSegments } from "../objects/LineSegments.js";
  * @see {@link https://threejs.org/docs/index.html#api/en/helpers/AxesHelper | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/helpers/AxesHelper.js | Source}
  */
-export class AxesHelper extends LineSegments {
+export class AxesHelper extends LineSegments<BufferGeometry, LineBasicMaterial> {
     /**
      * Create a new instance of {@link AxesHelper}
      * @param size Size of the lines representing the axes. Default `1`

--- a/types/three/src/helpers/AxesHelper.d.ts
+++ b/types/three/src/helpers/AxesHelper.d.ts
@@ -1,6 +1,7 @@
+import { BufferGeometry } from "../core/BufferGeometry.js";
+import { LineBasicMaterial } from "../materials/LineBasicMaterial.js";
 import { ColorRepresentation } from "../math/Color.js";
 import { LineSegments } from "../objects/LineSegments.js";
-import { BufferGeometry, LineBasicMaterial } from "../Three.Core.js";
 
 /**
  * An axis object to visualize the 3 axes in a simple way.


### PR DESCRIPTION
### Examples
```ts
const axes = new THREE.AxesHelper();
axes.renderOrder = 1;
// missing in type definition, because the mateiral type is Material | Material []
axes.material.depthTest = false; 
```
### Changes
Narrows down the [AxesHelper](https://github.com/mrdoob/three.js/blob/dev/src/helpers/AxesHelper.js)'s type so the type correction works accurately. AxesHelper only uses `BufferGeomtry` and `LineBasicMaterial` inside the constructor. So I believe there are no reasons that the `Material []` type should be applied.

![image](https://github.com/user-attachments/assets/ebb8b4c7-78f9-4d21-9ac8-bc72bd3ce9c9)

