### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/types/three/examples/jsm/loaders/SVGLoader.d.ts
+++ b/types/three/examples/jsm/loaders/SVGLoader.d.ts
@@ -34,7 +34,7 @@ export class SVGLoader extends Loader<SVGResult> {
     ): StrokeStyle;
 
     /**
-     * Generates a stroke with some witdh around the given path.
+     * Generates a stroke with some width around the given path.
      * @remarks The path can be open or closed (last point equals to first point)
      * @param points  Array of Vector2D (the path). Minimum 2 points.
      * @param style  Object with SVG properties as returned by SVGLoader.getStrokeStyle(), or SVGLoader.parse() in the path.userData.style object

--- a/types/three/src/renderers/WebGLRenderer.d.ts
+++ b/types/three/src/renderers/WebGLRenderer.d.ts
@@ -463,7 +463,7 @@ export class WebGLRenderer {
      * position. The `depthTexture` and `texture` property of 3D render targets are supported as well.
      *
      * When using render target textures as `srcTexture` and `dstTexture`, you must make sure both render targets are
-     * intitialized e.g. via {@link .initRenderTarget}().
+     * initialized e.g. via {@link .initRenderTarget}().
      *
      * @param srcTexture Specifies the source texture.
      * @param dstTexture Specifies the destination texture.


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in documentation comments within the codebase. Specifically, it fixes the spelling of "width" and "initialized" in the following files:
- types/three/examples/jsm/loaders/SVGLoader.d.ts
- types/three/src/renderers/WebGLRenderer.d.ts

