### PR TITLE
Fix Typos in Type Definitions and Improve Documentation Comments

### DIFF
--- a/src-testing/changes.patch
+++ b/src-testing/changes.patch
@@ -3446,7 +3446,7 @@ index 6d8db4b1..9b14d8f7 100644
 +type AnyConstructors = Construtors<any, any, any, any>;
 +
 +/**
-+ * Returns all constructors where the first paramter is assignable to given "scope"
++ * Returns all constructors where the first parameter is assignable to given "scope"
 + */
 +// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 +type FilterConstructorsByScope<T extends AnyConstructors, S> = {
@@ -3465,7 +3465,7 @@ index 6d8db4b1..9b14d8f7 100644
 +    | Exclude<T['d'], undefined>;
 +
 +/**
-+ * Extract list of possible scopes - union of the first paramter
++ * Extract list of possible scopes - union of the first parameter
 + * of all constructors, should it be string
 + */
 +type ExtractScopes<T extends AnyConstructors> =

--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -302,7 +302,7 @@ export class Color {
     getHex(colorSpace?: string): number;
 
     /**
-     * Returns the string formated hexadecimal value of this color.
+     * Returns the string formatted hexadecimal value of this color.
      */
     getHexString(colorSpace?: string): string;
 


### PR DESCRIPTION


Description:  
This pull request addresses several minor issues in the codebase:
- Corrects typos in documentation comments, such as "paramter" to "parameter" and "formated" to "formatted".
- Enhances the clarity of type documentation for constructors and scope extraction.
