### PR TITLE
Fix: Correct typo in `ColorAdjustment.ts

### DIFF
--- a/types/three/test/unit/src/nodes/display/ColorAdjustment.ts
+++ b/types/three/test/unit/src/nodes/display/ColorAdjustment.ts
@@ -1,5 +1,5 @@
 /**
- * A copy of ColorAdjustmentNode.js coverted to typescript
+ * A copy of ColorAdjustmentNode.js converted to typescript
  *
  * It was chosen because it is short and nicely shows interaction
  * between ShaderNode a normal node.


### PR DESCRIPTION


A small correction to a typo in a comment within `types/three/test/unit/src/nodes/display/ColorAdjustment.ts`.

- Before: `coverted`
- After: `converted`