### PR TITLE
Sprite - Add Sprite Node Material as valid constructor argument

### DIFF
--- a/types/three/src/objects/Sprite.d.ts
+++ b/types/three/src/objects/Sprite.d.ts
@@ -22,7 +22,7 @@ import { Vector2 } from "../math/Vector2.js";
 export class Sprite<TEventMap extends Object3DEventMap = Object3DEventMap> extends Object3D<TEventMap> {
     /**
      * Creates a new Sprite.
-     * @param material An instance of {@link THREE.SpriteMaterial | SpriteMaterial}. Default {@link THREE.SpriteMaterial | `new SpriteMaterial()`}, _with white color_.
+     * @param material An instance of {@link THREE.SpriteMaterial | SpriteMaterial | SpriteNodeMaterial}. Default {@link THREE.SpriteMaterial | `new SpriteMaterial()`}, _with white color_.
      */
     constructor(material?: SpriteMaterial | SpriteNodeMaterial);
 
@@ -51,10 +51,10 @@ export class Sprite<TEventMap extends Object3DEventMap = Object3DEventMap> exten
     geometry: BufferGeometry;
 
     /**
-     * An instance of {@link THREE.SpriteMaterial | SpriteMaterial}, defining the object's appearance.
+     * An instance of {@link THREE.SpriteMaterial | SpriteMaterial | SpriteNodeMaterial}, defining the object's appearance.
      * @defaultValue {@link THREE.SpriteMaterial | `new SpriteMaterial()`}, _with white color_.
      */
-    material: SpriteMaterial;
+    material: SpriteMaterial | SpriteNodeMaterial;
 
     /**
      * The sprite's anchor point, and the point around which the {@link Sprite} rotates.

--- a/types/three/src/objects/Sprite.d.ts
+++ b/types/three/src/objects/Sprite.d.ts
@@ -2,6 +2,7 @@ import { BufferGeometry } from "../core/BufferGeometry.js";
 import { Object3D, Object3DEventMap } from "../core/Object3D.js";
 import { SpriteMaterial } from "../materials/Materials.js";
 import { Vector2 } from "../math/Vector2.js";
+import SpriteNodeMaterial from '../materials/nodes/SpriteNodeMaterial.js';
 
 /**
  * A {@link Sprite} is a plane that always faces towards the camera, generally with a partially transparent texture applied.
@@ -23,7 +24,7 @@ export class Sprite<TEventMap extends Object3DEventMap = Object3DEventMap> exten
      * Creates a new Sprite.
      * @param material An instance of {@link THREE.SpriteMaterial | SpriteMaterial}. Default {@link THREE.SpriteMaterial | `new SpriteMaterial()`}, _with white color_.
      */
-    constructor(material?: SpriteMaterial);
+    constructor(material?: SpriteMaterial | SpriteNodeMaterial);
 
     /**
      * Read-only flag to check if a given object is of type {@link Sprite}.

--- a/types/three/src/objects/Sprite.d.ts
+++ b/types/three/src/objects/Sprite.d.ts
@@ -1,8 +1,8 @@
 import { BufferGeometry } from "../core/BufferGeometry.js";
 import { Object3D, Object3DEventMap } from "../core/Object3D.js";
 import { SpriteMaterial } from "../materials/Materials.js";
+import SpriteNodeMaterial from "../materials/nodes/SpriteNodeMaterial.js";
 import { Vector2 } from "../math/Vector2.js";
-import SpriteNodeMaterial from '../materials/nodes/SpriteNodeMaterial.js';
 
 /**
  * A {@link Sprite} is a plane that always faces towards the camera, generally with a partially transparent texture applied.


### PR DESCRIPTION
In the WebGPURenderer, Sprites can also take any class that extends SpriteNodeMaterial, as demonstrated by this example.

https://threejs.org/examples/?q=webgpu%20points#webgpu_instance_points

```ts
material = new THREE.PointsNodeMaterial( {

     colorNode: pointColors,
     opacityNode: shapeCircle(),
     positionNode: instancedBufferAttribute( positionAttribute ),
     // rotationNode: time,
     sizeNode: instancedBufferAttribute( instanceSizeBufferAttribute ),
     // size: 40, // in pixels units
     vertexColors: true,
     sizeAttenuation: false,
     alphaToCoverage: true

} );

const instancedPoints = new THREE.Sprite( material );
```
