### PR TITLE
Update StructNode.d.ts

### DIFF
--- a/types/three/src/nodes/core/StructNode.d.ts
+++ b/types/three/src/nodes/core/StructNode.d.ts
@@ -6,6 +6,7 @@ declare class StructNode extends Node {
     values: Node[];
 
     constructor(structLayoutNode: StructTypeNode, values: Node[]);
+    get(name:string):ShaderNodeObject<Node>;
 }
 
 export default StructNode;

--- a/types/three/src/nodes/core/StructNode.d.ts
+++ b/types/three/src/nodes/core/StructNode.d.ts
@@ -15,6 +15,7 @@ export interface Struct {
     (): ShaderNodeObject<StructNode>;
     (values: Node[]): ShaderNodeObject<StructNode>;
     (...values: Node[]): ShaderNodeObject<StructNode>;
+    (values: Record<string, Node>): ShaderNodeObject<StructNode>;
     layout: StructTypeNode;
     isStruct: true;
 }

--- a/types/three/src/nodes/core/StructNode.d.ts
+++ b/types/three/src/nodes/core/StructNode.d.ts
@@ -6,7 +6,6 @@ declare class StructNode extends Node {
     values: Node[];
 
     constructor(structLayoutNode: StructTypeNode, values: Node[]);
-    get(name:string):ShaderNodeObject<Node>;
 }
 
 export default StructNode;

--- a/types/three/src/nodes/core/StructNode.d.ts
+++ b/types/three/src/nodes/core/StructNode.d.ts
@@ -12,7 +12,6 @@ export default StructNode;
 
 export interface Struct {
     (): ShaderNodeObject<StructNode>;
-    (values: Node[]): ShaderNodeObject<StructNode>;
     (...values: Node[]): ShaderNodeObject<StructNode>;
     (values: Record<string, Node>): ShaderNodeObject<StructNode>;
     layout: StructTypeNode;

--- a/types/three/src/nodes/tsl/TSLCore.d.ts
+++ b/types/three/src/nodes/tsl/TSLCore.d.ts
@@ -77,6 +77,9 @@ export type Swizzable<T extends Node = Node> =
     }
     & {
         [Key in SwizzleOption as `flip${Uppercase<Key>}`]: () => ShaderNodeObject<Node>;
+    }
+    &{
+        get: (value:string) => ShaderNodeObject<Node>;
     };
 
 export type ShaderNodeObject<T extends Node> =

--- a/types/three/test/unit/src/nodes/core/StructNode.ts
+++ b/types/three/test/unit/src/nodes/core/StructNode.ts
@@ -1,0 +1,69 @@
+
+import { Fn, vec3, struct, float } from "three/tsl";
+
+
+const Complex = struct({
+    real:'float',
+    imaginary:'float',
+});
+
+const multiply = Fn(([a,b]:[a:ReturnType<typeof Complex>,b:ReturnType<typeof Complex>])=>{
+    const ar=a.get("real");
+    const ai=a.get("imaginary");
+    const br=b.get("real");
+    const bi=b.get("imaginary");
+    return Complex({
+        real: ar.mul(br).sub(ai.mul(bi)),
+        imaginary: ar.mul(bi).add(ai.mul(br))
+    });
+})
+
+const complexA = Complex(float(2),float(1));
+const complexB = Complex({
+    real:float(2),
+    imaginary:float(-1),
+});
+const complexC = multiply(complexA,complexB);
+complexC.get("real");
+complexC.get("imaginary");
+
+
+// https://github.com/mrdoob/three.js/pull/30394
+const BoundingBox = struct( {
+	min: 'vec3',
+	max: 'vec3'
+} );
+
+// style 1
+const bb1 = BoundingBox( vec3( 0 ), vec3( 1 ) );
+
+// style 1 - default value
+const bb2 = BoundingBox();
+
+// style 2
+const bb3 = BoundingBox( {
+	min: vec3( 0 ), 
+	max: vec3( 1 ) 
+} );
+
+// style 2 - optional values
+const bb4 = BoundingBox( {
+	// min: vec3( 0 ),  // use optional value
+	max: vec3( 1 ) 
+} );
+
+// assigns in TSL Fn
+const bbFn = Fn( () => {
+
+	const bb = BoundingBox();
+
+	const bbMax = bb.get( 'max' );
+	bbMax.assign( vec3( 1 ) );
+	// or -> bb.get( 'max' ).assign( vec3( 1 ) );
+
+	return bb;
+
+} );
+
+// debug
+/* material.colorNode = */bbFn().get( 'max' );


### PR DESCRIPTION
## Summary

- **Add** `get()` method to `Swizzable`  
- **Add** support for `Record<string, Node>` overload in `Struct`  
- **Remove** invalid `(values: Node[])` overload from `Struct`  
- **Add** unit tests for `StructNode.d.ts`

## Related Issue

Closes https://github.com/three-types/three-ts-types/issues/1632

## See Also

https://github.com/mrdoob/three.js/pull/30394
