### PR TITLE
Remove duplicate remark tags

### DIFF
--- a/types/three/src/objects/InstancedMesh.d.ts
+++ b/types/three/src/objects/InstancedMesh.d.ts
@@ -28,7 +28,6 @@ export interface InstancedMeshEventMap extends Object3DEventMap {
  * A special version of {@link THREE.Mesh | Mesh} with instanced rendering support
  * @remarks
  * Use {@link InstancedMesh} if you have to render a large number of objects with the same geometry and material(s) but with different world transformations
- * @remarks
  * The usage of {@link InstancedMesh} will help you to reduce the number of draw calls and thus improve the overall rendering performance in your application.
  * @see Example: {@link https://threejs.org/examples/#webgl_instancing_dynamic | WebGL / instancing / dynamic}
  * @see Example: {@link https://threejs.org/examples/#webgl_instancing_performance | WebGL / instancing / performance}
@@ -76,8 +75,8 @@ export class InstancedMesh<
      * @remarks
      * The `count` value passed into the {@link InstancedMesh | constructor} represents the **maximum** number of instances of this mesh.
      * You can change the number of instances at runtime to an integer value in the range `[0, count]`.
-     * @remarks If you need more instances than the original `count` value, you have to create a new InstancedMesh.
-     * @remarks Expects a `Integer`
+     * If you need more instances than the original `count` value, you have to create a new InstancedMesh.
+     * Expects a `Integer`
      */
     count: number;
 


### PR DESCRIPTION
Same as #749, but for `InstancedMesh`.

Fixes the following TypeDoc warning when `InstancedMesh` somehow ends up in the generated docs:

> At most one remarks tag is expected in a comment, ignoring all but the first in comment