### PR TITLE
WebGPUTextureUtils: Fix rgb9e5ufloat usage and rg11b10ufloat constant value.

### DIFF
--- a/types/three/src/renderers/webgpu/utils/WebGPUConstants.d.ts
+++ b/types/three/src/renderers/webgpu/utils/WebGPUConstants.d.ts
@@ -112,7 +112,7 @@ export enum GPUTextureFormat {
     // Packed 32-bit formats
     RGB9E5UFloat = "rgb9e5ufloat",
     RGB10A2Unorm = "rgb10a2unorm",
-    RG11B10UFloat = "rgb10a2unorm",
+    RG11B10UFloat = "rg11b10ufloat",
 
     // 64-bit formats
 


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/31698