### PR TITLE
fix: Add branches for `JoinNode` in `mat*` node functions

### DIFF
--- a/types/three/src/nodes/tsl/TSLCore.d.ts
+++ b/types/three/src/nodes/tsl/TSLCore.d.ts
@@ -410,6 +410,17 @@ interface Matrix3Function {
     ): ShaderNodeObject<ConstNode<Matrix3>>;
     (): ShaderNodeObject<ConstNode<Matrix3>>;
     (node: Node): ShaderNodeObject<Node>;
+    (
+        n11: Node | number,
+        n12: Node | number,
+        n13: Node | number,
+        n21: Node | number,
+        n22: Node | number,
+        n23: Node | number,
+        n31: Node | number,
+        n32: Node | number,
+        n33: Node | number,
+    ): ShaderNodeObject<JoinNode>;
 }
 
 export const mat3: Matrix3Function;
@@ -436,6 +447,24 @@ interface Matrix4Function {
     ): ShaderNodeObject<ConstNode<Matrix4>>;
     (): ShaderNodeObject<ConstNode<Matrix4>>;
     (node: Node): ShaderNodeObject<Node>;
+    (
+        n11: Node | number,
+        n12: Node | number,
+        n13: Node | number,
+        n14: Node | number,
+        n21: Node | number,
+        n22: Node | number,
+        n23: Node | number,
+        n24: Node | number,
+        n31: Node | number,
+        n32: Node | number,
+        n33: Node | number,
+        n34: Node | number,
+        n41: Node | number,
+        n42: Node | number,
+        n43: Node | number,
+        n44: Node | number,
+    ): ShaderNodeObject<JoinNode>;
 }
 
 export const mat4: Matrix4Function;


### PR DESCRIPTION
`mat*` functions currently only accept numbers in the constructor to create `ConstNode`s of matrices. however, since they use the same code path as `vec*`, & [core source](https://github.com/mrdoob/three.js/blob/27151c8325d1dba520d4abfb5a2e1077dd59de22/src/nodes/functions/BSDF/LTC.js#L92) shows that they can accept nodes, this PR adds the same signature as `vec*`s to align them.