### PR TITLE
fix: Add `assign`, `toVarIntent`, & `get` methods to `Node`

### DIFF
--- a/types/three/src/nodes/core/Node.d.ts
+++ b/types/three/src/nodes/core/Node.d.ts
@@ -358,7 +358,7 @@ declare class Node extends EventDispatcher<{
      * @return {Object} The serialized node.
      */
     toJSON(meta?: NodeJSONMeta | string): NodeJSONOutputData;
-    assign(...params: Parameters<typeof assign>): this;
+    assign(sourceNode: Node | number): this;
     toVarIntent(): this;
     get(value: string): MemberNode;
 }

--- a/types/three/src/nodes/core/Node.d.ts
+++ b/types/three/src/nodes/core/Node.d.ts
@@ -1,4 +1,6 @@
 import { EventDispatcher } from "../../core/EventDispatcher.js";
+import { MemberNode } from "../Nodes.js";
+import { assign } from "./AssignNode.js";
 import { NodeUpdateType } from "./constants.js";
 import NodeBuilder from "./NodeBuilder.js";
 import NodeFrame from "./NodeFrame.js";
@@ -356,5 +358,8 @@ declare class Node extends EventDispatcher<{
      * @return {Object} The serialized node.
      */
     toJSON(meta?: NodeJSONMeta | string): NodeJSONOutputData;
+    assign(...params: Parameters<typeof assign>): this;
+    toVarIntent(): this;
+    get(value: string): MemberNode;
 }
 export default Node;


### PR DESCRIPTION
fixes: https://github.com/three-types/three-ts-types/issues/1804

going forwards it seems like upstream is ditching the proxy way of adding dynamic properties & tacking them on the prototype instead. this means the types should probably reflect that & apply the swizzling & 0-31 index accesses onto `Node` itself instead of `ShaderNodeObject`