### PR TITLE
DirectionalLight: Remove the second @remarks tag.

### DIFF
--- a/types/three/src/lights/DirectionalLight.d.ts
+++ b/types/three/src/lights/DirectionalLight.d.ts
@@ -5,10 +5,11 @@ import { DirectionalLightShadow } from "./DirectionalLightShadow.js";
 import { Light } from "./Light.js";
 
 /**
- * A light that gets emitted in a specific direction.
+ * A light that gets emitted in a specific direction
+ * @remarks
  * This light will behave as though it is infinitely far away and the rays produced from it are all parallel
  * The common use case for this is to simulate daylight; the sun is far enough away that its position can be considered to be infinite, and all light rays coming from it are parallel.
- * @remarks
+ * 
  * A common point of confusion for directional lights is that setting the rotation has no effect.
  * This is because three.js's {@link DirectionalLight} is the equivalent to what is often called a 'Target Direct Light' in other applications.
  * This means that its direction is calculated as pointing from the light's {@link THREE.Object3D.position | position} to the {@link THREE.DirectionalLight.target | target}'s

--- a/types/three/src/lights/DirectionalLight.d.ts
+++ b/types/three/src/lights/DirectionalLight.d.ts
@@ -5,12 +5,11 @@ import { DirectionalLightShadow } from "./DirectionalLightShadow.js";
 import { Light } from "./Light.js";
 
 /**
- * A light that gets emitted in a specific direction
- * @remarks
+ * A light that gets emitted in a specific direction.
  * This light will behave as though it is infinitely far away and the rays produced from it are all parallel
  * The common use case for this is to simulate daylight; the sun is far enough away that its position can be considered to be infinite, and all light rays coming from it are parallel.
- * A common point of confusion for directional lights is that setting the rotation has no effect
  * @remarks
+ * A common point of confusion for directional lights is that setting the rotation has no effect.
  * This is because three.js's {@link DirectionalLight} is the equivalent to what is often called a 'Target Direct Light' in other applications.
  * This means that its direction is calculated as pointing from the light's {@link THREE.Object3D.position | position} to the {@link THREE.DirectionalLight.target | target}'s
  * position (as opposed to a 'Free Direct Light' that just has a rotation component).


### PR DESCRIPTION
TypeDoc produces a warning when there are two remarks tags.

```
[warning] At most one @remarks tag is expected in a comment, ignoring all but the first in comment at /Users/davili/Documents/xrlabs/arlabs/sdk/node_modules/@types/three/src/lights/DirectionalLight.d.ts:8
[warning] At most one @returns tag is expected in a comment, ignoring all but the first in comment at /Users/davili/Documents/xrlabs/arlabs/sdk/node_modules/@types/three/src/lights/DirectionalLight.d.ts:8
```