### PR TITLE
TSL: Allow TextureNode to accept Texture or TextureNode

### DIFF
--- a/types/three/src/nodes/accessors/TextureNode.d.ts
+++ b/types/three/src/nodes/accessors/TextureNode.d.ts
@@ -60,7 +60,7 @@ export default class TextureNode extends UniformNode<Texture> {
 }
 
 export const texture: (
-    value?: Texture,
+    value?: Texture | TextureNode,
     uvNode?: Node | null,
     levelNode?: Node | number | null,
     biasNode?: Node | null,
@@ -71,7 +71,7 @@ export const uniformTexture: (
 ) => ShaderNodeObject<TextureNode>;
 
 export const textureLoad: (
-    value?: Texture,
+    value?: Texture | TextureNode,
     uvNode?: Node,
     levelNode?: Node | number,
     biasNode?: Node,


### PR DESCRIPTION
The `texture()` and `textureLoad()` functions in Three.js TSL accept TextureNode as well as Texture. The inline type for this can be seen [here](https://github.com/mrdoob/three.js/blob/3c32743c1e5355f43d9e8319086caf92a0b19955/src/nodes/accessors/TextureNode.js#L822). This has been the case since r177 and the change can be found in [this PR](https://github.com/mrdoob/three.js/pull/31190).
