### PR TITLE
Renderers: Use internal log, warn and error functions instead of the system ones

### DIFF
--- a/types/three/src/Three.Core.d.ts
+++ b/types/three/src/Three.Core.d.ts
@@ -160,4 +160,4 @@ export * from "./textures/Source.js";
 export * from "./textures/Texture.js";
 export * from "./textures/VideoFrameTexture.js";
 export * from "./textures/VideoTexture.js";
-export { createCanvasElement } from "./utils.js";
+export { createCanvasElement, setConsoleFunction, getConsoleFunction, log, warn, error, warnOnce } from './utils.js';

--- a/types/three/src/Three.Core.d.ts
+++ b/types/three/src/Three.Core.d.ts
@@ -160,4 +160,4 @@ export * from "./textures/Source.js";
 export * from "./textures/Texture.js";
 export * from "./textures/VideoFrameTexture.js";
 export * from "./textures/VideoTexture.js";
-export { createCanvasElement, setConsoleFunction, getConsoleFunction, log, warn, error, warnOnce } from './utils.js';
+export { createCanvasElement, error, getConsoleFunction, log, setConsoleFunction, warn, warnOnce } from "./utils.js";

--- a/types/three/src/utils.d.ts
+++ b/types/three/src/utils.d.ts
@@ -1,3 +1,19 @@
-export function createCanvasElement(): HTMLCanvasElement;
+declare function createCanvasElement(): HTMLCanvasElement;
 
-export function probeAsync(gl: WebGLRenderingContext, sync: WebGLSync, interval: number): Promise<void>;
+declare function setConsoleFunction(
+    fn: (type: "log" | "warn" | "error", message: string, ...params: unknown[]) => void,
+): void;
+
+declare function getConsoleFunction(): (type: "log" | "warn" | "error", message: string, ...params: unknown[]) => void;
+
+declare function log(...params: unknown[]): void;
+
+declare function warn(...params: unknown[]): void;
+
+declare function error(...params: unknown[]): void;
+
+declare function warnOnce(...params: unknown[]): void;
+
+declare function probeAsync(gl: WebGLRenderingContext, sync: WebGLSync, interval: number): Promise<void>;
+
+export { createCanvasElement, error, getConsoleFunction, log, probeAsync, setConsoleFunction, warn, warnOnce };


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/31790