### PR TITLE
Change levels property to readonly in LOD type

### DIFF
--- a/types/three/src/objects/LOD.d.ts
+++ b/types/three/src/objects/LOD.d.ts
@@ -57,7 +57,7 @@ export class LOD<TEventMap extends Object3DEventMap = Object3DEventMap> extends 
     /**
      * An array of level objects
      */
-    levels: Array<{
+    readonly levels: Array<{
         /** The Object3D to display at this level. */
         object: Object3D;
         /** The distance at which to display this level of detail. Expects a `Float`. */


### PR DESCRIPTION
make the levels member readonly ( because it is: https://github.com/mrdoob/three.js/blob/8173be8f500b1a8369c6d6aa25a0a0b700b4cafb/src/objects/LOD.js#L69 )