### PR TITLE
WebGLRenderer: Modernized shadow mapping: native cube depth textures, Vogel disk sampling, and VSM improvements

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -677,11 +677,13 @@ export const BasicDepthPacking: 3200;
 export const RGBADepthPacking: 3201;
 export const RGBDepthPacking: 3202;
 export const RGDepthPacking: 3203;
+export const IdentityDepthPacking: 3204;
 export type DepthPackingStrategies =
     | typeof BasicDepthPacking
     | typeof RGBADepthPacking
     | typeof RGBDepthPacking
-    | typeof RGDepthPacking;
+    | typeof RGDepthPacking
+    | typeof IdentityDepthPacking;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Normal Map types

--- a/types/three/src/lights/PointLightShadow.d.ts
+++ b/types/three/src/lights/PointLightShadow.d.ts
@@ -17,6 +17,7 @@ export class PointLightShadow extends LightShadow<PerspectiveCamera> {
     /**
      * Update the matrices for the camera and shadow, used internally by the renderer.
      * @param light The light for which the shadow is being rendered.
+     * @param [faceIndex=0] - The cube face index (0-5).
      */
-    override updateMatrices(light: Light, viewportIndex?: number): void;
+    override updateMatrices(light: Light, faceIndex?: number): void;
 }

--- a/types/three/src/renderers/shaders/ShaderLib.d.ts
+++ b/types/three/src/renderers/shaders/ShaderLib.d.ts
@@ -21,7 +21,7 @@ declare const ShaderLib: {
     background: ShaderLibShader;
     cube: ShaderLibShader;
     equirect: ShaderLibShader;
-    distanceRGBA: ShaderLibShader;
+    distance: ShaderLibShader;
     shadow: ShaderLibShader;
     physical: ShaderLibShader;
 };

--- a/types/three/src/textures/CubeDepthTexture.d.ts
+++ b/types/three/src/textures/CubeDepthTexture.d.ts
@@ -6,7 +6,7 @@ import {
     TextureDataType,
     Wrapping,
 } from "../constants.js";
-import { DepthTextureImageData } from "./DepthTexture";
+import { DepthTextureImageData } from "./DepthTexture.js";
 import { Texture } from "./Texture.js";
 
 declare class CubeDepthTexture extends Texture<CubeDepthTextureImageData> {

--- a/types/three/src/textures/CubeDepthTexture.d.ts
+++ b/types/three/src/textures/CubeDepthTexture.d.ts
@@ -1,0 +1,41 @@
+import {
+    DepthTexturePixelFormat,
+    MagnificationTextureFilter,
+    Mapping,
+    MinificationTextureFilter,
+    TextureDataType,
+    Wrapping,
+} from "../constants.js";
+import { DepthTextureImageData } from "./DepthTexture";
+import { Texture } from "./Texture.js";
+
+declare class CubeDepthTexture extends Texture<CubeDepthTextureImageData> {
+    readonly isCubeDepthTexture: true;
+    readonly isCubeTexture: true;
+
+    constructor(
+        size: number,
+        type?: TextureDataType,
+        mapping?: Mapping,
+        wrapS?: Wrapping,
+        wrapT?: Wrapping,
+        magFilter?: MagnificationTextureFilter,
+        minFilter?: MinificationTextureFilter,
+        anisotropy?: number,
+        format?: DepthTexturePixelFormat,
+    );
+
+    get images(): CubeDepthTextureImageData;
+    set images(value: CubeDepthTextureImageData);
+}
+
+export { CubeDepthTexture };
+
+export type CubeDepthTextureImageData = [
+    DepthTextureImageData,
+    DepthTextureImageData,
+    DepthTextureImageData,
+    DepthTextureImageData,
+    DepthTextureImageData,
+    DepthTextureImageData,
+];


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/32303