### PR TITLE
CubeTexture: make image type generic

### DIFF
--- a/types/three/src/textures/CubeTexture.d.ts
+++ b/types/three/src/textures/CubeTexture.d.ts
@@ -27,7 +27,7 @@ import { Texture } from "./Texture.js";
  * @see {@link https://threejs.org/docs/index.html#api/en/textures/CubeTexture | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/CubeTexture.js | Source}
  */
-export class CubeTexture extends Texture<HTMLImageElement[]> {
+export class CubeTexture<TImage = unknown> extends Texture<TImage[]> {
     /**
      * This creates a new {@link THREE.CubeTexture | CubeTexture} object.
      * @param images
@@ -42,7 +42,7 @@ export class CubeTexture extends Texture<HTMLImageElement[]> {
      * @param colorSpace See {@link Texture.colorSpace | .colorSpace}. Default {@link NoColorSpace}
      */
     constructor(
-        images?: HTMLImageElement[],
+        images?: TImage[],
         mapping?: CubeTextureMapping,
         wrapS?: Wrapping,
         wrapT?: Wrapping,
@@ -65,8 +65,8 @@ export class CubeTexture extends Texture<HTMLImageElement[]> {
      * An image object, typically created using the {@link THREE.CubeTextureLoader.load | CubeTextureLoader.load()} method.
      * @see {@link Texture.image}
      */
-    get images(): HTMLImageElement[];
-    set images(value: HTMLImageElement[]);
+    get images(): TImage[];
+    set images(value: TImage[]);
 
     /**
      * @inheritDoc


### PR DESCRIPTION
CubeTexture.images can hold a `DataTexture[]`, for example when [loading a HDR with HDRCubeTextureLoader](https://github.com/mrdoob/three.js/blob/65bfbd8e51db937ecd5d4be7f2d93319f6e5ee97/examples/jsm/loaders/HDRCubeTextureLoader.js#L113-L122) or an array of `{width, height, depth}` objects when used as part of a [WebGLCubeRenderTarget](https://github.com/mrdoob/three.js/blob/7703433fca8aa2af2ffefe1c83dd17139298f2ce/src/renderers/WebGLCubeRenderTarget.js#L36-L37)

Untested at the time of creating this PR as I couldn't get `npm run test` to run locally.
Let me know if there is anything I should change.