### PR TITLE
WebGLRenderer: Use native depth texture for VSM shadow maps

### DIFF
--- a/types/three/src/constants.d.ts
+++ b/types/three/src/constants.d.ts
@@ -677,13 +677,11 @@ export const BasicDepthPacking: 3200;
 export const RGBADepthPacking: 3201;
 export const RGBDepthPacking: 3202;
 export const RGDepthPacking: 3203;
-export const IdentityDepthPacking: 3204;
 export type DepthPackingStrategies =
     | typeof BasicDepthPacking
     | typeof RGBADepthPacking
     | typeof RGBDepthPacking
-    | typeof RGDepthPacking
-    | typeof IdentityDepthPacking;
+    | typeof RGDepthPacking;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Normal Map types


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/32443