### PR TITLE
Line2NodeMaterial: Avoid performance degradation with viewportSharedTexture().

### DIFF
--- a/types/three/src/Three.TSL.d.ts
+++ b/types/three/src/Three.TSL.d.ts
@@ -610,6 +610,7 @@ export const viewportCoordinate: typeof TSL.viewportCoordinate;
 export const viewportDepthTexture: typeof TSL.viewportDepthTexture;
 export const viewportLinearDepth: typeof TSL.viewportLinearDepth;
 export const viewportMipTexture: typeof TSL.viewportMipTexture;
+export const viewportOpaqueMipTexture: typeof TSL.viewportOpaqueMipTexture;
 export const viewportResolution: typeof TSL.viewportResolution;
 export const viewportSafeUV: typeof TSL.viewportSafeUV;
 export const viewportSharedTexture: typeof TSL.viewportSharedTexture;

--- a/types/three/src/nodes/display/ViewportTextureNode.d.ts
+++ b/types/three/src/nodes/display/ViewportTextureNode.d.ts
@@ -29,3 +29,5 @@ export const viewportMipTexture: (
     levelNode?: Node | null,
     framebufferTexture?: FramebufferTexture | null,
 ) => Node;
+
+export const viewportOpaqueMipTexture: (uv?: Node, level?: Node | null) => Node;


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/32639