### PR TITLE
fix: Make element from uniformArray accept both a number and Node

### DIFF
--- a/types/three/src/nodes/accessors/UniformArrayNode.d.ts
+++ b/types/three/src/nodes/accessors/UniformArrayNode.d.ts
@@ -1,5 +1,4 @@
 import Node from "../core/Node.js";
-import { NodeRepresentation } from "../tsl/TSLCore.js";
 import ArrayElementNode from "../utils/ArrayElementNode.js";
 import BufferNode from "./BufferNode.js";
 
@@ -18,7 +17,7 @@ declare class UniformArrayNode extends BufferNode<unknown[]> {
 
     getPaddedType(): string;
 
-    element: (indexNode: NodeRepresentation) => UniformArrayElementNode;
+    element: (indexNode: Node | number) => UniformArrayElementNode;
 }
 
 export default UniformArrayNode;

--- a/types/three/src/nodes/accessors/UniformArrayNode.d.ts
+++ b/types/three/src/nodes/accessors/UniformArrayNode.d.ts
@@ -1,4 +1,5 @@
 import Node from "../core/Node.js";
+import { NodeRepresentation } from "../tsl/TSLCore.js";
 import ArrayElementNode from "../utils/ArrayElementNode.js";
 import BufferNode from "./BufferNode.js";
 
@@ -17,7 +18,7 @@ declare class UniformArrayNode extends BufferNode<unknown[]> {
 
     getPaddedType(): string;
 
-    element: (indexNode: Node) => UniformArrayElementNode;
+    element: (indexNode: NodeRepresentation) => UniformArrayElementNode;
 }
 
 export default UniformArrayNode;


### PR DESCRIPTION
Reversion back to an old fix https://github.com/three-types/three-ts-types/pull/1286. Forum post from 2024 discussing the issue: https://discourse.threejs.org/t/how-to-access-an-uniformarray-element-using-a-node-object/72803/6