### PR TITLE
ViewportDepthNode: Support reversed depth in viewZ functions.

### DIFF
--- a/types/three/src/Three.TSL.d.ts
+++ b/types/three/src/Three.TSL.d.ts
@@ -603,6 +603,8 @@ export const vibrance: typeof TSL.vibrance;
 export const viewZToLogarithmicDepth: typeof TSL.viewZToLogarithmicDepth;
 export const viewZToOrthographicDepth: typeof TSL.viewZToOrthographicDepth;
 export const viewZToPerspectiveDepth: typeof TSL.viewZToPerspectiveDepth;
+export const viewZToReversedOrthographicDepth: typeof TSL.viewZToReversedOrthographicDepth;
+export const viewZToReversedPerspectiveDepth: typeof TSL.viewZToReversedPerspectiveDepth;
 export const viewport: typeof TSL.viewport;
 export const viewportCoordinate: typeof TSL.viewportCoordinate;
 export const viewportDepthTexture: typeof TSL.viewportDepthTexture;

--- a/types/three/src/nodes/display/ViewportDepthNode.d.ts
+++ b/types/three/src/nodes/display/ViewportDepthNode.d.ts
@@ -22,6 +22,8 @@ export default ViewportDepthNode;
 
 export const viewZToOrthographicDepth: (viewZ: Node, near: Node, far: Node) => Node<"float">;
 
+export const viewZToReversedOrthographicDepth: (viewZ: Node, near: Node, far: Node) => Node<"float">;
+
 export const orthographicDepthToViewZ: (depth: Node, near: Node, far: Node) => Node<"float">;
 
 export const viewZToPerspectiveDepth: (viewZ: Node, near: Node, far: Node) => Node<"float">;


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/33001