### PR TITLE
Fix ComputeBuiltinNode typings for vector builtins (uvec3 swizzles)

### DIFF
--- a/types/three/src/nodes/gpgpu/ComputeBuiltinNode.d.ts
+++ b/types/three/src/nodes/gpgpu/ComputeBuiltinNode.d.ts
@@ -6,8 +6,8 @@ declare class ComputeBuiltinNode extends Node {
 
 export default ComputeBuiltinNode;
 
-export const numWorkgroups: ComputeBuiltinNode;
-export const workgroupId: ComputeBuiltinNode;
-export const globalId: ComputeBuiltinNode;
-export const localId: ComputeBuiltinNode;
-export const subgroupSize: ComputeBuiltinNode;
+export const numWorkgroups: ComputeBuiltinNode & Node<"uvec3">;
+export const workgroupId: ComputeBuiltinNode & Node<"uvec3">;
+export const globalId: ComputeBuiltinNode & Node<"uvec3">;
+export const localId: ComputeBuiltinNode & Node<"uvec3">;
+export const subgroupSize: ComputeBuiltinNode & Node<"uint">;

--- a/types/three/src/nodes/gpgpu/ComputeBuiltinNode.d.ts
+++ b/types/three/src/nodes/gpgpu/ComputeBuiltinNode.d.ts
@@ -1,13 +1,22 @@
 import Node from "../core/Node.js";
+import { NodeBuilder } from "../Nodes.js";
 
-declare class ComputeBuiltinNode extends Node {
-    constructor(builtinName: string, nodeType: string);
+interface ComputeBuiltinNodeInterface {
+    setBuiltinName(builtinName: string): this;
+    getBuiltinName(builder: NodeBuilder): string;
+    hasBuiltin(builder: NodeBuilder): boolean;
 }
+
+declare const ComputeBuiltinNode: {
+    new<TNodeType>(builtinName: string, nodeType: TNodeType): ComputeBuiltinNode<TNodeType>;
+};
+
+type ComputeBuiltinNode<TNodeType = unknown> = Node<TNodeType> & ComputeBuiltinNodeInterface;
 
 export default ComputeBuiltinNode;
 
-export const numWorkgroups: ComputeBuiltinNode & Node<"uvec3">;
-export const workgroupId: ComputeBuiltinNode & Node<"uvec3">;
-export const globalId: ComputeBuiltinNode & Node<"uvec3">;
-export const localId: ComputeBuiltinNode & Node<"uvec3">;
-export const subgroupSize: ComputeBuiltinNode & Node<"uint">;
+export const numWorkgroups: ComputeBuiltinNode<"uvec3">;
+export const workgroupId: ComputeBuiltinNode<"uvec3">;
+export const globalId: ComputeBuiltinNode<"uvec3">;
+export const localId: ComputeBuiltinNode<"uvec3">;
+export const subgroupSize: ComputeBuiltinNode<"uint">;


### PR DESCRIPTION
Gives proper typing for globalId, localId, etc, allowing the use of builtin `.x/.y/.z`