### PR TITLE
Fix WebXRController export

### DIFF
--- a/types/three/src/Three.Core.d.ts
+++ b/types/three/src/Three.Core.d.ts
@@ -141,7 +141,17 @@ export * from "./objects/Sprite.js";
 export * from "./renderers/WebGL3DRenderTarget.js";
 export * from "./renderers/WebGLArrayRenderTarget.js";
 export * from "./renderers/WebGLRenderTarget.js";
-export * from "./renderers/webxr/WebXRController.js";
+export {
+    WebXRController,
+    type WebXRSpaceEventMap,
+    type XRControllerEventType,
+    type XRGripSpace,
+    type XRHandInputState,
+    type XRHandJoints,
+    type XRHandSpace,
+    type XRJointSpace,
+    type XRTargetRaySpace,
+} from "./renderers/webxr/WebXRController.js";
 export * from "./scenes/Fog.js";
 export * from "./scenes/FogExp2.js";
 export * from "./scenes/Scene.js";

--- a/types/three/src/Three.d.ts
+++ b/types/three/src/Three.d.ts
@@ -38,17 +38,6 @@ export type { WebGLUniforms } from "./renderers/webgl/WebGLUniforms.js";
 export * from "./renderers/webgl/WebGLUtils.js";
 export * from "./renderers/WebGLCubeRenderTarget.js";
 export * from "./renderers/WebGLRenderer.js";
-export type {
-    WebXRController,
-    WebXRSpaceEventMap,
-    XRControllerEventType,
-    XRGripSpace,
-    XRHandInputState,
-    XRHandJoints,
-    XRHandSpace,
-    XRJointSpace,
-    XRTargetRaySpace,
-} from "./renderers/webxr/WebXRController.js";
 export type { WebXRDepthSensing } from "./renderers/webxr/WebXRDepthSensing.js";
 export type {
     WebXRArrayCamera,


### PR DESCRIPTION
`WebXRController` exports in Three.d.ts are incorrect (type-only) and are overshadowing exports in Three.Core.d.ts.

Fix: Remove the `WebXRController` exports from Three.d.ts.