### PR TITLE
WebGLRenderer: Add support for packed normal maps.

### DIFF
--- a/types/three/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/types/three/src/renderers/webgl/WebGLPrograms.d.ts
@@ -53,6 +53,7 @@ export interface WebGLProgramParameters {
 
     normalMapObjectSpace: boolean;
     normalMapTangentSpace: boolean;
+    packedNormalMap: boolean;
 
     metalnessMap: boolean;
     roughnessMap: boolean;


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/33055