### PR TITLE
TSL: Make Switch Case return void

### DIFF
--- a/types/three/src/nodes/core/StackNode.d.ts
+++ b/types/three/src/nodes/core/StackNode.d.ts
@@ -15,7 +15,7 @@ declare class StackNode extends Node {
 
     Switch(expression: Node): this;
 
-    Case(...params: Node[]): this;
+    Case(...params: [...Node[], () => void]): this;
 
     Default(method: () => void): this;
 }


### PR DESCRIPTION
Currently when doing a Switch statement in TSL such as

```ts
Switch( 0 ).Case( 0, () => {
    col.assign( color( 1, 0, 0 ) );
})
```

typescript complains

```error
Argument of type '() => void' is not assignable to parameter of type 'Node'. Type '() => void' is not assignable to type 'NodeClass'.
```
Simple fix is to change Case type in StackNode.d.ts from
```ts
Case(...params: Node[]): this;
```
to
```ts
Case(...params: [...Node[], () => void]): this;
```