### PR TITLE
LDrawLoader: Fix materialLibrary property spelling

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 3.8.1
       three:
         specifier: file:../three.js
-        version: file:three.js
+        version: three.js@file:three.js
       typescript:
         specifier: latest
         version: 6.0.2
@@ -2296,11 +2296,11 @@ packages:
       postprocessing: ^6.33.4
       three: '>= 0.125.0 <= 0.182.0'
 
+  three.js@file:three.js:
+    resolution: {directory: three.js, type: directory}
+
   three@0.183.1:
     resolution: {integrity: sha512-Psv6bbd3d/M/01MT2zZ+VmD0Vj2dbWTNhfe4CuSg7w5TuW96M3NOyCVuh9SZQ05CpGmD7NEcJhZw4GVjhCYxfQ==}
-
-  three@file:three.js:
-    resolution: {directory: three.js, type: directory}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -4991,9 +4991,9 @@ snapshots:
       postprocessing: 6.38.3(three@0.183.1)
       three: 0.183.1
 
-  three@0.183.1: {}
+  three.js@file:three.js: {}
 
-  three@file:three.js: {}
+  three@0.183.1: {}
 
   tinybench@2.9.0: {}
 

--- a/types/three/examples/jsm/loaders/LDrawLoader.d.ts
+++ b/types/three/examples/jsm/loaders/LDrawLoader.d.ts
@@ -4,7 +4,7 @@ import { LDrawConditionalLineMaterial as LDrawConditionalLineNodeMaterial } from
 
 export class LDrawLoader extends Loader<Group> {
     materials: Material[];
-    materialsLibrary: Record<string, Material>;
+    materialLibrary: Record<string, Material>;
 
     fileMap: Record<string, string>;
 

--- a/types/three/test/integration/three-examples/webgl_loader_ldraw.ts
+++ b/types/three/test/integration/three-examples/webgl_loader_ldraw.ts
@@ -95,6 +95,12 @@ function reloadObject(resetCamera: boolean) {
 
     // only smooth when not rendering with flat colors to improve processing time
     const lDrawLoader = new LDrawLoader();
+    const materialLibrary = lDrawLoader.materialLibrary[0];
+    void materialLibrary;
+
+    // @ts-expect-error -- runtime property is singular "materialLibrary"
+    lDrawLoader.materialsLibrary;
+
     lDrawLoader.setPath(ldrawPath).load(
         "",
         group2 => {


### PR DESCRIPTION
Just stumbled across this type mismatch.
https://github.com/mrdoob/three.js/blob/master/examples/jsm/loaders/LDrawLoader.js#L1794

Wasn't really sure on how to properly reflect this change in the tests, so i am very much open for feedback.