### PR TITLE
WebGLRenderer: add vertexNormals to WebGLProgramParameters

### DIFF
--- a/types/three/src/renderers/webgl/WebGLPrograms.d.ts
+++ b/types/three/src/renderers/webgl/WebGLPrograms.d.ts
@@ -131,6 +131,7 @@ export interface WebGLProgramParameters {
     //
 
     vertexTangents: boolean;
+    vertexNormals: boolean;
     vertexColors: boolean;
     vertexAlphas: boolean;
     vertexUv1s: boolean;


### PR DESCRIPTION
Adds `vertexNormals: boolean` to `WebGLProgramParameters` to reflect the change in [mrdoob/three.js#33391](https://github.com/mrdoob/three.js/pull/33391).

## Test plan
- [ ] Verify `vertexNormals` appears between `vertexTangents` and `vertexColors` in `WebGLPrograms.d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)