### PR TITLE
TSL: fix `string` and `arrayBuffer`

### DIFF
--- a/types/three/src/nodes/tsl/TSLCore.d.ts
+++ b/types/three/src/nodes/tsl/TSLCore.d.ts
@@ -2354,8 +2354,8 @@ interface Mat4Function {
 
 export const mat4: Mat4Function;
 
-export const string: unknown;
-export const arrayBuffer: unknown;
+export const string: (value?: string) => Node<"string">;
+export const arrayBuffer: (value: ArrayBuffer) => Node<"ArrayBuffer">;
 
 declare module "../core/Node.js" {
     interface ColorExtensions {


### PR DESCRIPTION
`string` and `arrayBuffer` can work in `r183`

https://github.com/three-types/three-ts-types/blob/f149dddf6764bfdbce0be9e0f65d965c889b91a7/types/three/src/nodes/tsl/TSLCore.d.ts#L1965-L1966

`string` and `arrayBuffer` can not work in `r184`

https://github.com/three-types/three-ts-types/blob/cc0b6e96f5a1ef78ba911fc8bda7229ec5811ec4/types/three/src/nodes/tsl/TSLCore.d.ts#L2357-L2358

Change PR: #2058