### PR TITLE
AtomicFunctionNode: Fix return types

### DIFF
--- a/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
+++ b/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
@@ -30,8 +30,7 @@ declare class AtomicFunctionNodeClass extends Node {
     static ATOMIC_XOR: "atomicXor";
 }
 
-export type AtomicFunctionNode<TNodeType = unknown> =
-    Node<TNodeType> & AtomicFunctionNodeClass;
+export type AtomicFunctionNode<TNodeType = unknown> = Node<TNodeType> & AtomicFunctionNodeClass;
 
 declare const AtomicFunctionNode: {
     new<TNodeType = unknown>(

--- a/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
+++ b/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
@@ -32,52 +32,52 @@ declare class AtomicFunctionNode extends Node {
 
 export default AtomicFunctionNode;
 
-export const atomicFunc: (
+export const atomicFunc: <TNodeType extends string = string>(
     method: AtomicMethod,
-    pointerNode: Node,
+    pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicLoad: (
-    pointerNode: Node,
-) => AtomicFunctionNode;
+export const atomicLoad: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
+) => Node<TNodeType>;
 
-export const atomicStore: (
-    pointerNode: Node,
+export const atomicStore: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node | number,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicAdd: (
-    pointerNode: Node,
+export const atomicAdd: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node | number,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicSub: (
-    pointerNode: Node,
+export const atomicSub: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node | number,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicMax: (
-    pointerNode: Node,
+export const atomicMax: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicMin: (
-    pointerNode: Node,
+export const atomicMin: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicAnd: (
-    pointerNode: Node,
+export const atomicAnd: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicOr: (
-    pointerNode: Node,
+export const atomicOr: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;
 
-export const atomicXor: (
-    pointerNode: Node,
+export const atomicXor: <TNodeType extends string = string>(
+    pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => AtomicFunctionNode;
+) => Node<TNodeType>;

--- a/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
+++ b/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
@@ -11,7 +11,7 @@ export type AtomicMethod =
     | typeof AtomicFunctionNode.ATOMIC_OR
     | typeof AtomicFunctionNode.ATOMIC_XOR;
 
-declare class AtomicFunctionNode extends Node {
+declare class AtomicFunctionNodeClass extends Node {
     method: AtomicMethod;
     pointerNode: Node;
     valueNode: Node;
@@ -30,54 +30,65 @@ declare class AtomicFunctionNode extends Node {
     static ATOMIC_XOR: "atomicXor";
 }
 
+export type AtomicFunctionNode<TNodeType = unknown> =
+    Node<TNodeType> & AtomicFunctionNodeClass;
+
+declare const AtomicFunctionNode: {
+    new<TNodeType = unknown>(
+        method: AtomicMethod,
+        pointerNode: Node,
+        valueNode: Node,
+    ): AtomicFunctionNode<TNodeType>;
+} & typeof AtomicFunctionNodeClass;
+
 export default AtomicFunctionNode;
 
-export const atomicFunc: <TNodeType extends string = string>(
+export const atomicFunc: <TNodeType = unknown>(
     method: AtomicMethod,
     pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicLoad: <TNodeType extends string = string>(
+export const atomicLoad: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicStore: <TNodeType extends string = string>(
-    pointerNode: Node<TNodeType>,
-    valueNode: Node | number,
-) => Node<TNodeType>;
-
-export const atomicAdd: <TNodeType extends string = string>(
+export const atomicStore: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node | number,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicSub: <TNodeType extends string = string>(
+export const atomicAdd: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node | number,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicMax: <TNodeType extends string = string>(
+export const atomicSub: <TNodeType = unknown>(
+    pointerNode: Node<TNodeType>,
+    valueNode: Node | number,
+) => AtomicFunctionNode<TNodeType>;
+
+export const atomicMax: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicMin: <TNodeType extends string = string>(
+export const atomicMin: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicAnd: <TNodeType extends string = string>(
+export const atomicAnd: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicOr: <TNodeType extends string = string>(
+export const atomicOr: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;
 
-export const atomicXor: <TNodeType extends string = string>(
+export const atomicXor: <TNodeType = unknown>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
-) => Node<TNodeType>;
+) => AtomicFunctionNode<TNodeType>;

--- a/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
+++ b/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
@@ -12,13 +12,6 @@ export type AtomicMethod =
     | typeof AtomicFunctionNode.ATOMIC_XOR;
 
 declare class AtomicFunctionNodeClass extends Node {
-    method: AtomicMethod;
-    pointerNode: Node;
-    valueNode: Node;
-    parents: boolean;
-
-    constructor(method: AtomicMethod, pointerNode: Node, valueNode: Node);
-
     static ATOMIC_LOAD: "atomicLoad";
     static ATOMIC_STORE: "atomicStore";
     static ATOMIC_ADD: "atomicAdd";
@@ -30,13 +23,20 @@ declare class AtomicFunctionNodeClass extends Node {
     static ATOMIC_XOR: "atomicXor";
 }
 
-export type AtomicFunctionNode<TNodeType = unknown> = Node<TNodeType> & AtomicFunctionNodeClass;
+interface AtomicFunctionNodeInterface {
+    method: AtomicMethod;
+    pointerNode: Node;
+    valueNode: Node | null;
+    parents: boolean;
+}
+
+export type AtomicFunctionNode<TNodeType = unknown> = Node<TNodeType> & AtomicFunctionNodeInterface;
 
 declare const AtomicFunctionNode: {
     new<TNodeType = unknown>(
         method: AtomicMethod,
         pointerNode: Node,
-        valueNode: Node,
+        valueNode: Node | null,
     ): AtomicFunctionNode<TNodeType>;
 } & typeof AtomicFunctionNodeClass;
 
@@ -45,7 +45,7 @@ export default AtomicFunctionNode;
 export const atomicFunc: <TNodeType = unknown>(
     method: AtomicMethod,
     pointerNode: Node<TNodeType>,
-    valueNode: Node,
+    valueNode: Node | null,
 ) => AtomicFunctionNode<TNodeType>;
 
 export const atomicLoad: <TNodeType = unknown>(

--- a/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
+++ b/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
@@ -19,7 +19,7 @@ interface AtomicFunctionNodeInterface {
 }
 
 declare const AtomicFunctionNode: {
-    new<TNodeType = unknown>(
+    new<TNodeType>(
         method: AtomicMethod,
         pointerNode: Node,
         valueNode: Node | null,

--- a/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
+++ b/types/three/src/nodes/gpgpu/AtomicFunctionNode.d.ts
@@ -11,18 +11,6 @@ export type AtomicMethod =
     | typeof AtomicFunctionNode.ATOMIC_OR
     | typeof AtomicFunctionNode.ATOMIC_XOR;
 
-declare class AtomicFunctionNodeClass extends Node {
-    static ATOMIC_LOAD: "atomicLoad";
-    static ATOMIC_STORE: "atomicStore";
-    static ATOMIC_ADD: "atomicAdd";
-    static ATOMIC_SUB: "atomicSub";
-    static ATOMIC_MAX: "atomicMax";
-    static ATOMIC_MIN: "atomicMin";
-    static ATOMIC_AND: "atomicAnd";
-    static ATOMIC_OR: "atomicOr";
-    static ATOMIC_XOR: "atomicXor";
-}
-
 interface AtomicFunctionNodeInterface {
     method: AtomicMethod;
     pointerNode: Node;
@@ -30,64 +18,74 @@ interface AtomicFunctionNodeInterface {
     parents: boolean;
 }
 
-export type AtomicFunctionNode<TNodeType = unknown> = Node<TNodeType> & AtomicFunctionNodeInterface;
-
 declare const AtomicFunctionNode: {
     new<TNodeType = unknown>(
         method: AtomicMethod,
         pointerNode: Node,
         valueNode: Node | null,
     ): AtomicFunctionNode<TNodeType>;
-} & typeof AtomicFunctionNodeClass;
+
+    ATOMIC_LOAD: "atomicLoad";
+    ATOMIC_STORE: "atomicStore";
+    ATOMIC_ADD: "atomicAdd";
+    ATOMIC_SUB: "atomicSub";
+    ATOMIC_MAX: "atomicMax";
+    ATOMIC_MIN: "atomicMin";
+    ATOMIC_AND: "atomicAnd";
+    ATOMIC_OR: "atomicOr";
+    ATOMIC_XOR: "atomicXor";
+};
+
+export type AtomicFunctionNode<TNodeType> = Node<TNodeType> & AtomicFunctionNodeInterface;
 
 export default AtomicFunctionNode;
 
-export const atomicFunc: <TNodeType = unknown>(
+export const atomicFunc: <TNodeType>(
     method: AtomicMethod,
     pointerNode: Node<TNodeType>,
     valueNode: Node | null,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicLoad: <TNodeType = unknown>(
+export const atomicLoad: <TNodeType>(
     pointerNode: Node<TNodeType>,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicStore: <TNodeType = unknown>(
-    pointerNode: Node<TNodeType>,
-    valueNode: Node | number,
-) => AtomicFunctionNode<TNodeType>;
-
-export const atomicAdd: <TNodeType = unknown>(
+export const atomicStore: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node | number,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicSub: <TNodeType = unknown>(
+export const atomicAdd: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node | number,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicMax: <TNodeType = unknown>(
+export const atomicSub: <TNodeType>(
+    pointerNode: Node<TNodeType>,
+    valueNode: Node | number,
+) => AtomicFunctionNode<TNodeType>;
+
+export const atomicMax: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicMin: <TNodeType = unknown>(
+export const atomicMin: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicAnd: <TNodeType = unknown>(
+export const atomicAnd: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicOr: <TNodeType = unknown>(
+export const atomicOr: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
 ) => AtomicFunctionNode<TNodeType>;
 
-export const atomicXor: <TNodeType = unknown>(
+export const atomicXor: <TNodeType>(
     pointerNode: Node<TNodeType>,
     valueNode: Node,
 ) => AtomicFunctionNode<TNodeType>;


### PR DESCRIPTION
When working with atomic nodes such as 
```js
const count = float(atomicLoad(trailCounts.element(idx)))
```
typescript would complain because `AtomicFunctionNode` wasn't typed `<'uint'>` properly

```
No overload matches this call.
Overload 1 of 2, '(value?: number | undefined): VarNode<"float", ConstNode<"float", number>>', gave the following error. Argument of type 'AtomicFunctionNode' is not assignable to parameter of type 'number'.
```
this PR fixes the issue having it return
```js
atomicLoad<"uint">(pointerNode: Node<"uint">): AtomicFunctionNode<"uint">
```
instead of 
```js
atomicLoad(pointerNode: Node): AtomicFunctionNode
```