### PR TITLE
[three] Revert static is(Vector|Matrix*) changes.

### DIFF
--- a/types/three/src/math/Matrix2.d.ts
+++ b/types/three/src/math/Matrix2.d.ts
@@ -12,7 +12,7 @@ export type Matrix2Tuple = [
  * const m = new Matrix2();
  */
 export class Matrix2 {
-    static readonly isMatrix2: boolean;
+    readonly isMatrix2: true;
 
     /**
      * A {@link https://en.wikipedia.org/wiki/Row-_and_column-major_order column-major} list of matrix values.

--- a/types/three/src/math/Matrix3.d.ts
+++ b/types/three/src/math/Matrix3.d.ts
@@ -17,7 +17,7 @@ export type Matrix3Tuple = [
 ];
 
 export class Matrix3 {
-    static readonly isMatrix3: boolean;
+    readonly isMatrix3: true;
 
     /**
      * Array with matrix values.

--- a/types/three/src/math/Matrix4.d.ts
+++ b/types/three/src/math/Matrix4.d.ts
@@ -42,7 +42,7 @@ export type Matrix4Tuple = [
  * m.multiply( m3 );
  */
 export class Matrix4 {
-    static readonly isMatrix4: boolean;
+    readonly isMatrix4: true;
 
     /**
      * Array with matrix values.

--- a/types/three/src/math/Vector2.d.ts
+++ b/types/three/src/math/Vector2.d.ts
@@ -12,8 +12,6 @@ export interface Vector2Like {
  * 2D vector.
  */
 export class Vector2 {
-    static readonly isVector2: boolean;
-
     constructor(x?: number, y?: number);
 
     /**
@@ -27,6 +25,7 @@ export class Vector2 {
     y: number;
     width: number;
     height: number;
+    readonly isVector2: true;
 
     /**
      * Sets value of this vector.

--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -29,8 +29,6 @@ export interface Vector3Like {
  * c.crossVectors( a, b );
  */
 export class Vector3 {
-    static readonly isVector3: boolean;
-
     constructor(x?: number, y?: number, z?: number);
 
     /**
@@ -47,6 +45,7 @@ export class Vector3 {
      * @default 0
      */
     z: number;
+    readonly isVector3: true;
 
     /**
      * Sets value of this vector.

--- a/types/three/src/math/Vector4.d.ts
+++ b/types/three/src/math/Vector4.d.ts
@@ -15,8 +15,6 @@ export interface Vector4Like {
  * 4D vector.
  */
 export class Vector4 {
-    static readonly isVector4: boolean;
-
     constructor(x?: number, y?: number, z?: number, w?: number);
 
     /**
@@ -41,6 +39,7 @@ export class Vector4 {
 
     width: number;
     height: number;
+    readonly isVector4: true;
 
     /**
      * Sets value of this vector.

--- a/types/three/test/unit/src/math/Vector3.ts
+++ b/types/three/test/unit/src/math/Vector3.ts
@@ -1,0 +1,4 @@
+import * as THREE from "three";
+
+const texture = new THREE.Vector3();
+texture.isVector3; // $ExpectType true

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -38,6 +38,7 @@
         "test/unit/src/audio/AudioContext.ts",
         "test/unit/src/core/EventDispatcher.ts",
         "test/unit/src/core/Uniform.ts",
+        "test/unit/src/math/Vector3.ts",
         "test/unit/src/nodes/display/ColorAdjustment.ts",
         "test/unit/src/nodes/materialx/lib/mx_hsv.ts",
         "test/unit/src/nodes/materialx/lib/mx_noise.ts",


### PR DESCRIPTION
Most ThreeJS classes have a is* property on the prototype.  This allows for typechecks without using instanceof.  Recently the vector and matrix classes change to initialize this property using static initialization block. (PR here: https://github.com/mrdoob/three.js/pull/33140)

The types were updated to be 'static readonly isVector3: boolean' which means one can only access isVector3 like this: Vector3.isVector3 which is not useful. While the initialization of the property changed, the shape of the class did not.

This commit reverts the type update and restores the previous functionality.

Thanks!