### PR TITLE
fix: correct UniformGroup.dispose declaration

### DIFF
--- a/types/three/src/core/UniformsGroup.d.ts
+++ b/types/three/src/core/UniformsGroup.d.ts
@@ -31,7 +31,7 @@ export class UniformsGroup<TEventMap extends UniformsGroupEventMap = UniformsGro
 
     setUsage(value: Usage): this;
 
-    dispose(): this;
+    dispose(): void;
 
     copy(source: UniformsGroup): this;
 


### PR DESCRIPTION
## Summary

- Aligns `UniformsGroup.dispose()` with the JavaScript implementation.
- Keeps the change limited to the declaration file.

## Evidence

- JS implementation: `three.js/src/core/UniformsGroup.js:130`
- Declaration: `types/three/src/core/UniformsGroup.d.ts:34`
- Mismatch: the declaration exposed a chainable return value that the implementation does not return.

## Check

- Confirmed dispose() returns undefined at runtime.
- pnpm test failed due to an unrelated ESLint plugin error.