### PR TITLE
fix: correct BatchedMesh.dispose declaration

### DIFF
--- a/types/three/src/objects/BatchedMesh.d.ts
+++ b/types/three/src/objects/BatchedMesh.d.ts
@@ -127,7 +127,7 @@ declare class BatchedMesh extends Mesh<BufferGeometry, Material> {
      * Frees the GPU-related resources allocated by this instance. Call this method whenever this instance is no longer
      * used in your app.
      */
-    dispose(): this;
+    dispose(): void;
 
     /**
      * Takes a sort a function that is run before render. The function takes a list of instances to sort and a camera.


### PR DESCRIPTION
## Summary

- Aligns `BatchedMesh.dispose()` with the JavaScript implementation.
- Keeps the change limited to the declaration file.

## Evidence

- JS implementation: `three.js/src/objects/BatchedMesh.js:1498`
- Declaration: `types/three/src/objects/BatchedMesh.d.ts:130`
- Mismatch: the declaration exposed a chainable return value that the implementation does not return.

## Check

- Confirmed dispose() returns undefined at runtime.
- pnpm test failed due to an unrelated ESLint plugin error.