### PR TITLE
fix: correct InterleavedBuffer.set offset parameter optionality

### DIFF
--- a/types/three/src/core/InterleavedBuffer.d.ts
+++ b/types/three/src/core/InterleavedBuffer.d.ts
@@ -104,7 +104,7 @@ export class InterleavedBuffer {
      * @param offset index of the {@link BufferAttribute.array | array} at which to start copying. Expects a `Integer`. Default `0`.
      * @throws `RangeError` When {@link offset} is negative or is too large.
      */
-    set(value: ArrayLike<number>, offset: number): this;
+    set(value: ArrayLike<number>, offset?: number): this;
 
     /**
      * Set {@link BufferAttribute.usage | usage}


### PR DESCRIPTION
## Summary

- Aligns `InterleavedBuffer.set()` offset parameter with the JavaScript implementation.
- Keeps the change limited to the declaration file.

## Evidence

- JS implementation: `three.js/src/core/InterleavedBuffer.js:191`
- Declaration: `types/three/src/core/InterleavedBuffer.d.ts:107`
- Mismatch: `offset` has a default value of `0` in JS but is declared as required in the type declaration.

## Check

- Checked the declaration diff manually.
- `pnpm test` failed: unrelated ESLint plugin error.