### PR TITLE
fix: correct KTX2Loader.dispose declaration

### DIFF
--- a/types/three/examples/jsm/loaders/KTX2Loader.d.ts
+++ b/types/three/examples/jsm/loaders/KTX2Loader.d.ts
@@ -54,5 +54,5 @@ export class KTX2Loader extends Loader<CompressedTexture> {
     /**
      * Disposes the loader object, de-allocating any Web Workers created.
      */
-    dispose(): this;
+    dispose(): void;
 }


### PR DESCRIPTION
## Summary

Fix declaration for `KTX2Loader.dispose()`.

## Evidence

JS implementation:

- `three.js/examples/jsm/loaders/KTX2Loader.js:496`

Declaration:

- `types/three/examples/jsm/loaders/KTX2Loader.d.ts:57`

Observed mismatch:

- The declaration returned `this` but the implementation does not return a value.

## Local Check

- Checked the declaration diff manually.
- `pnpm test` failed: unrelated ESLint plugin error.

## Scope

- Declaration file only
- No runtime change
- Single API only