### PR TITLE
Vector3: Fix set z optionality and reflect parameter name

### DIFF
--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -216,7 +216,7 @@ export class Vector3 {
     crossVectors(a: Vector3Like, b: Vector3Like): this;
     projectOnVector(v: Vector3): this;
     projectOnPlane(planeNormal: Vector3): this;
-    reflect(vector: Vector3Like): this;
+    reflect(normal: Vector3Like): this;
     angleTo(v: Vector3): number;
 
     /**

--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -50,7 +50,7 @@ export class Vector3 {
     /**
      * Sets value of this vector.
      */
-    set(x: number, y: number, z: number): this;
+    set(x: number, y: number, z?: number): this;
 
     /**
      * Sets all values of this vector.


### PR DESCRIPTION
## Summary

Fix declarations for `Vector3.set()` and `Vector3.reflect()`.

## Evidence

JS implementation:

- `three.js/src/math/Vector3.js:84` (`set`)
- `three.js/src/math/Vector3.js:922` (`reflect`)

Declaration:

- `types/three/src/math/Vector3.d.ts:53` (`set`)
- `types/three/src/math/Vector3.d.ts:219` (`reflect`)

Observed mismatch:

- `set()`: `z` has a default fallback in JS but is declared as required in the type declaration.
- `reflect()`: Parameter name does not match the JS implementation and JSDoc.

## Local Check

```bash
pnpm test  # failed: unrelated ESLint plugin error
```

## Scope

- Declaration file only
- No runtime change
- Both fixes are isolated to `Vector3.d.ts`