### PR TITLE
Vector3: Fix reflect parameter name

### DIFF
--- a/types/three/src/math/Vector3.d.ts
+++ b/types/three/src/math/Vector3.d.ts
@@ -216,7 +216,7 @@ export class Vector3 {
     crossVectors(a: Vector3Like, b: Vector3Like): this;
     projectOnVector(v: Vector3): this;
     projectOnPlane(planeNormal: Vector3): this;
-    reflect(vector: Vector3Like): this;
+    reflect(normal: Vector3Like): this;
     angleTo(v: Vector3): number;
 
     /**


### PR DESCRIPTION
## Summary

Fix declaration for `Vector3.reflect()`.

## Evidence

JS implementation:

- `three.js/src/math/Vector3.js:922`

Declaration:

- `types/three/src/math/Vector3.d.ts:219`

Observed mismatch:

- Parameter name does not match the JS implementation and JSDoc.

## Local Check

- Checked the declaration diff manually.
- `pnpm test` failed: unrelated ESLint plugin error.

## Scope

- Declaration file only
- No runtime change
- Single API only