### PR TITLE
Color: Fix setRGB return type

### DIFF
--- a/types/three/src/math/Color.d.ts
+++ b/types/three/src/math/Color.d.ts
@@ -239,7 +239,7 @@ export class Color {
      * @param g Green channel value between 0 and 1.
      * @param b Blue channel value between 0 and 1.
      */
-    setRGB(r: number, g: number, b: number, colorSpace?: string): Color;
+    setRGB(r: number, g: number, b: number, colorSpace?: string): this;
 
     /**
      * Sets this color from HSL values.


### PR DESCRIPTION
## Summary

Fix declaration for `Color.setRGB()`.

## Evidence

JS implementation:

- `three.js/src/math/Color.js:227`

Declaration:

- `types/three/src/math/Color.d.ts:242`

Observed mismatch:

- `setRGB()` returns `this` in JS but is declared as returning `Color` in the type declaration.

## Local Check

- Checked the declaration diff manually.
- `pnpm test` failed: unrelated ESLint plugin error.

## Scope

- Declaration file only
- No runtime change
- Single API only