### PR TITLE
[three] Fix CubeDepthTexture inheritance.

### DIFF
--- a/types/three/src/textures/CubeDepthTexture.d.ts
+++ b/types/three/src/textures/CubeDepthTexture.d.ts
@@ -6,10 +6,9 @@ import {
     TextureDataType,
     Wrapping,
 } from "../constants.js";
-import { DepthTextureImageData } from "./DepthTexture.js";
-import { Texture } from "./Texture.js";
+import { DepthTexture, DepthTextureImageData } from "./DepthTexture.js";
 
-declare class CubeDepthTexture extends Texture<CubeDepthTextureImageData> {
+declare class CubeDepthTexture extends DepthTexture<CubeDepthTextureImageData> {
     readonly isCubeDepthTexture: true;
     readonly isCubeTexture: true;
 

--- a/types/three/src/textures/DepthTexture.d.ts
+++ b/types/three/src/textures/DepthTexture.d.ts
@@ -15,7 +15,7 @@ import { Texture } from "./Texture.js";
  * @see {@link https://threejs.org/docs/index.html#api/en/textures/DepthTexture | Official Documentation}
  * @see {@link https://github.com/mrdoob/three.js/blob/master/src/textures/DepthTexture.js | Source}
  */
-export class DepthTexture extends Texture<DepthTextureImageData> {
+export class DepthTexture<TImage = DepthTextureImageData> extends Texture<TImage> {
     /**
      * Create a new instance of {@link DepthTexture}
      * @param width Width of the texture.

--- a/types/three/test/unit/src/textures/CubeDepthTexture.ts
+++ b/types/three/test/unit/src/textures/CubeDepthTexture.ts
@@ -3,4 +3,5 @@ import * as THREE from "three";
 const texture = new THREE.CubeDepthTexture(512);
 texture.isCubeDepthTexture; // $ExpectType true
 texture.isCubeTexture; // $ExpectType true
+texture.isDepthTexture; // $ExpectType true
 texture.images; // $ExpectType CubeDepthTextureImageData


### PR DESCRIPTION
Make DepthTexture generic and have CubeDepthTexture extend it so that isDepthTexture and other DepthTexture members are properly inherited.