### PR TITLE
WebGLState: Add getParameter and pixelStorei

### DIFF
--- a/types/three/src/renderers/webgl/WebGLState.d.ts
+++ b/types/three/src/renderers/webgl/WebGLState.d.ts
@@ -77,7 +77,7 @@ declare class WebGLState {
     bindTexture(webglType: number, webglTexture: WebGLTexture, webglSlot?: number): void;
     unbindTexture(): void;
     pixelStorei(name: GLenum, value: GLint | GLboolean): void;
-    getParameter(name: GLenum): any;
+    getParameter(name: GLenum): unknown;
 
     // Same interface as https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compressedTexImage2D
     compressedTexImage2D(

--- a/types/three/src/renderers/webgl/WebGLState.d.ts
+++ b/types/three/src/renderers/webgl/WebGLState.d.ts
@@ -76,6 +76,8 @@ declare class WebGLState {
     activeTexture(webglSlot: number): void;
     bindTexture(webglType: number, webglTexture: WebGLTexture, webglSlot?: number): void;
     unbindTexture(): void;
+    pixelStorei(name: GLenum, value: GLint | GLboolean): void;
+    getParameter(name: GLenum): any;
 
     // Same interface as https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/compressedTexImage2D
     compressedTexImage2D(


### PR DESCRIPTION
With r184 the `WebGLState` class gained two new methods as part of https://github.com/mrdoob/three.js/pull/33227. These are accessible through the renderer (`renderer.state`) and are thus part of the public API. This PR adds both `pixelStorei` and `getParameter` to the `WebGLState.d.ts` file.

Both methods are effectively wrappers for the corresponding ones in `WebGLRenderingContext`. I've based the parameter and return types on the ones used in `lib.dom.d.ts` but kept the names as they appear in the Three.js source code.

