### PR TITLE
feat(OrbitControls): add generic camera type parameter

### DIFF
--- a/types/three/examples/jsm/controls/OrbitControls.d.ts
+++ b/types/three/examples/jsm/controls/OrbitControls.d.ts
@@ -20,7 +20,7 @@ export interface OrbitControlsEventMap {
 /**
  * Orbit controls allow the camera to orbit around a target.
  */
-declare class OrbitControls extends Controls<OrbitControlsEventMap> {
+declare class OrbitControls<TCamera extends Camera = Camera> extends Controls<OrbitControlsEventMap, TCamera> {
     /**
      * The focus point of the controls, the {@link .object} orbits around this. It can be updated manually at any point
      * to change the focus of the controls.
@@ -206,7 +206,7 @@ declare class OrbitControls extends Controls<OrbitControlsEventMap> {
      * is the scene itself.
      * @param domElement The HTML element used for event listeners. (optional)
      */
-    constructor(object: Camera, domElement?: HTMLElement | SVGElement | null);
+    constructor(object: TCamera, domElement?: HTMLElement | SVGElement | null);
 
     set cursorStyle(type: "auto" | "grab");
     get cursorStyle(): "auto" | "grab";

--- a/types/three/src/extras/Controls.d.ts
+++ b/types/three/src/extras/Controls.d.ts
@@ -6,13 +6,14 @@ export interface ControlsEventMap {}
 /**
  * Abstract base class for controls.
  */
-declare abstract class Controls<TEventMap extends ControlsEventMap = ControlsEventMap>
-    extends EventDispatcher<TEventMap>
-{
+declare abstract class Controls<
+    TEventMap extends ControlsEventMap = ControlsEventMap,
+    TObject extends Object3D = Object3D,
+> extends EventDispatcher<TEventMap> {
     /**
      * The 3D object that is managed by the controls.
      */
-    object: Object3D;
+    object: TObject;
 
     /**
      * The HTML element used for event listeners. If not provided via the constructor, {@link .connect} must be called
@@ -30,7 +31,7 @@ declare abstract class Controls<TEventMap extends ControlsEventMap = ControlsEve
      * @param object The object the controls should manage (usually the camera).
      * @param domElement The HTML element used for event listeners. (optional)
      */
-    constructor(object: Object3D, domElement?: HTMLElement | SVGElement | null);
+    constructor(object: TObject, domElement?: HTMLElement | SVGElement | null);
 
     /**
      * Connects the controls to the DOM. This method has so called "side effects" since it adds the module's event

--- a/types/three/test/unit/examples/jsm/controls/OrbitControls.ts
+++ b/types/three/test/unit/examples/jsm/controls/OrbitControls.ts
@@ -1,0 +1,27 @@
+import * as THREE from "three";
+
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+
+/**
+ * Generic camera type inference
+ */
+
+// PerspectiveCamera is inferred as TCamera
+const c0 = new OrbitControls(new THREE.PerspectiveCamera());
+c0.object; // $ExpectType PerspectiveCamera
+
+// OrthographicCamera is inferred as TCamera
+const c2 = new OrbitControls(new THREE.OrthographicCamera());
+c2.object; // $ExpectType OrthographicCamera
+
+/**
+ * Explicit type argument
+ */
+const c1 = new OrbitControls<THREE.PerspectiveCamera>(new THREE.PerspectiveCamera());
+c1.object; // $ExpectType PerspectiveCamera
+
+/**
+ * Default type (backward compatibility): Camera
+ */
+const c3: OrbitControls = new OrbitControls(new THREE.PerspectiveCamera());
+c3.object; // $ExpectType Camera

--- a/types/three/tsconfig.json
+++ b/types/three/tsconfig.json
@@ -28,6 +28,7 @@
         "test/integration/webxr-cube.ts",
         "test/unit/examples/jsm/exporters/PLYExporter.ts",
         "test/unit/examples/jsm/exporters/STLExporter.ts",
+        "test/unit/examples/jsm/controls/OrbitControls.ts",
         "test/unit/examples/jsm/helpers/ViewHelper.ts",
         "test/unit/examples/jsm/libs/lil-gui.ts",
         "test/unit/examples/jsm/libs/tween.ts",


### PR DESCRIPTION
Make `OrbitControls` generic over its camera type so that `controls.object` retains the concrete camera type passed to the constructor instead of widening to `Camera`.

## What changed

- `Controls` base class: added a `TObject extends Object3D = Object3D` type parameter; `object` is now typed `TObject` and the constructor accepts `TObject`.
- `OrbitControls`: added a `TCamera extends Camera = Camera` type parameter and forwards it to `Controls<OrbitControlsEventMap, TCamera>`; the constructor accepts `TCamera`.
- Added `test/unit/examples/jsm/controls/OrbitControls.ts` with `$ExpectType` tests.

```ts
const c0 = new OrbitControls(new THREE.PerspectiveCamera());
c0.object; // PerspectiveCamera (was: Camera)

const c3: OrbitControls = new OrbitControls(new THREE.PerspectiveCamera());
c3.object; // Camera (default type argument — backward compatible)
```

All type parameters have defaults, so existing usages (including `MapControls extends OrbitControls` and `const c: OrbitControls`) remain source-compatible.

---

Ported from DefinitelyTyped PR [DefinitelyTyped/DefinitelyTyped#75077](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/75077).
