### PR TITLE
Matrix3: deprecate .scale(), .rotate(), and .translate()

### DIFF
--- a/types/three/src/math/Matrix3.d.ts
+++ b/types/three/src/math/Matrix3.d.ts
@@ -99,10 +99,19 @@ export class Matrix3 {
 
     setUvTransform(tx: number, ty: number, sx: number, sy: number, rotation: number, cx: number, cy: number): this;
 
+    /**
+     * @deprecated Use .makeScale() instead.
+     */
     scale(sx: number, sy: number): this;
 
+    /**
+     * @deprecated Use .makeRotation() instead.
+     */
     rotate(theta: number): this;
 
+    /**
+     * @deprecated Use .makeTranslation() instead.
+     */
     translate(tx: number, ty: number): this;
 
     /**


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/33757