### PR TITLE
DRACOExporter: Removed bundled encoders in favor of CDN.

### DIFF
--- a/types/three/examples/jsm/exporters/DRACOExporter.d.ts
+++ b/types/three/examples/jsm/exporters/DRACOExporter.d.ts
@@ -13,5 +13,5 @@ export interface DRACOExporterOptions {
 export class DRACOExporter {
     constructor();
 
-    parse(object: Mesh | Points, options?: DRACOExporterOptions): Int8Array<ArrayBuffer>;
+    parseAsync(object: Mesh | Points, options?: DRACOExporterOptions): Promise<Int8Array<ArrayBuffer>>;
 }


### PR DESCRIPTION
https://github.com/mrdoob/three.js/pull/33789