### PR TITLE
fix(MarchingCubes): triTable and edgeTable should be simple `Int32Array`s

### DIFF
--- a/types/three/examples/jsm/objects/MarchingCubes.d.ts
+++ b/types/three/examples/jsm/objects/MarchingCubes.d.ts
@@ -72,5 +72,5 @@ export class MarchingCubes extends Mesh {
     generateBufferGeometry(): BufferGeometry;
 }
 
-export const edgeTable: Int32Array[];
-export const triTable: Int32Array[];
+export const edgeTable: Int32Array;
+export const triTable: Int32Array;


### PR DESCRIPTION
In `examples/jsm/objects/MarchingCubes.d.ts`, `edgeTable` and `triTable` are defined as `Int32Array[]` (array of `Int32Array`). 

As the original source, it seems that should be just a `Int32Array`.

https://github.com/mrdoob/three.js/blob/d3bb12e3227826ecad0f272ad6fd321754a226b7/examples/jsm/objects/MarchingCubes.js#L969

https://github.com/mrdoob/three.js/blob/d3bb12e3227826ecad0f272ad6fd321754a226b7/examples/jsm/objects/MarchingCubes.js#L1003