### PR TITLE
fix (GLTFLoader): add `primitives` to `GLTFReference`

### DIFF
--- a/types/three/examples/jsm/loaders/GLTFLoader.d.ts
+++ b/types/three/examples/jsm/loaders/GLTFLoader.d.ts
@@ -64,13 +64,14 @@ export class GLTFLoader extends Loader<GLTF> {
     parseAsync(data: ArrayBuffer | string, path: string): Promise<GLTF>;
 }
 
-export type GLTFReferenceType = "materials" | "nodes" | "textures" | "meshes";
+export type GLTFReferenceType = "materials" | "nodes" | "textures" | "meshes" | "primitives";
 
 export interface GLTFReference {
     materials?: number;
     nodes?: number;
     textures?: number;
     meshes?: number;
+    primitives?: number;
 }
 
 export class GLTFParser {


### PR DESCRIPTION
GLTFLoader can put `primitives` to `parser.associations` to mesh primitives

See: https://github.com/mrdoob/three.js/blob/r184/examples/jsm/loaders/GLTFLoader.js#L3909-L3912