### PR TITLE
DFGLUT: Mention direct lighting use in headers, fix generator output path.

### DIFF
--- a/types/three/src/nodes/functions/BSDF/DFGLUT.d.ts
+++ b/types/three/src/nodes/functions/BSDF/DFGLUT.d.ts
@@ -2,7 +2,8 @@ import Node from "../../core/Node.js";
 import OperatorNode from "../../math/OperatorNode.js";
 
 /**
- * Precomputed DFG LUT for Image-Based Lighting
+ * Precomputed DFG LUT for physically based specular lighting, used by both
+ * image-based lighting and direct-light multi-scattering energy compensation
  * Resolution: 16x16
  * Samples: 4096 per texel
  * Format: RG16F (2 half floats per texel: scale, bias)


### PR DESCRIPTION
https://github.com/mrdoob/three.js/commit/d60e5bd8688dbef0c0efab901cb2ddae2ecd447b